### PR TITLE
Fix search_messages AppleScript errors (-1726 and -1728)

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -205,14 +205,34 @@ class AppleMailConnector:
             status = "true" if read_status else "false"
             conditions.append(f"read status is {status}")
 
-        whose_clause = " and ".join(conditions) if conditions else "true"
-        limit_clause = f"items 1 thru {limit} of" if limit else ""
+        whose_clause = " and ".join(conditions) if conditions else ""
+
+        # Build the message query - only include 'whose' if we have conditions
+        if whose_clause:
+            message_query = f"messages of mailboxRef whose {whose_clause}"
+        else:
+            message_query = "messages of mailboxRef"
+
+        # Build the limit clause for AppleScript - handles empty/small mailbox gracefully
+        if limit:
+            limit_handling = f"""
+            set allMsgs to {message_query}
+            set msgCount to count of allMsgs
+            if msgCount is 0 then
+                return ""
+            else if msgCount < {limit} then
+                set matchedMessages to allMsgs
+            else
+                set matchedMessages to items 1 thru {limit} of allMsgs
+            end if"""
+        else:
+            limit_handling = f"set matchedMessages to {message_query}"
 
         script = f"""
         tell application "Mail"
             set accountRef to account "{account_safe}"
             set mailboxRef to mailbox "{mailbox_safe}" of accountRef
-            set matchedMessages to {limit_clause} (messages of mailboxRef whose {whose_clause})
+            {limit_handling}
 
             set resultList to {{}}
             repeat with msg in matchedMessages


### PR DESCRIPTION
> [!NOTE]
> This fix was developed using [Claude Code](https://github.com/anthropics/claude-code) and tested locally.

## Summary

This PR fixes issue #1 where `search_messages` fails with AppleScript errors.

Two bugs were identified and fixed:

- **Error -1726 (Illegal comparison or logical)**: When no filter conditions were provided, the code generated `whose true` which is invalid AppleScript syntax. Fixed by only including the `whose` clause when there are actual conditions to filter on.

- **Error -1728 (Can't get items)**: When requesting `items 1 thru N` from a mailbox with fewer than N messages, AppleScript throws an error. Fixed by counting messages first and only slicing if there are enough messages.

## Test plan

- [x] Tested locally with Claude Code MCP integration
- [x] Verified `search_messages` works without filters (just account/mailbox)
- [x] Verified `search_messages` works with limit parameter when mailbox has fewer messages than the limit
- [x] Verified `search_messages` works on large mailboxes (tested with ~5000 messages)
- [x] Verified `get_message` still works to read full message content

Fixes #1