### PR TITLE
Fix search_messages AppleScript errors (-1726 and -1728)

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -205,17 +205,16 @@ class AppleMailConnector:
             status = "true" if read_status else "false"
             conditions.append(f"read status is {status}")
 
-        whose_clause = " and ".join(conditions) if conditions else "true"
-        limit_clause = f"items 1 thru {limit} of" if limit else ""
+        whose_filter = f" whose {' and '.join(conditions)}" if conditions else ""
 
         script = f"""
         tell application "Mail"
             set accountRef to account "{account_safe}"
             set mailboxRef to mailbox "{mailbox_safe}" of accountRef
-            set matchedMessages to {limit_clause} (messages of mailboxRef whose {whose_clause})
 
             set resultList to {{}}
-            repeat with msg in matchedMessages
+            set msgCount to 0
+            repeat with msg in (messages of mailboxRef{whose_filter})
                 set msgId to id of msg as text
                 set msgSubject to subject of msg
                 set msgSender to sender of msg
@@ -224,6 +223,8 @@ class AppleMailConnector:
 
                 set msgData to msgId & "|" & msgSubject & "|" & msgSender & "|" & msgDate & "|" & msgRead
                 set end of resultList to msgData
+                set msgCount to msgCount + 1
+                if {limit or 0} > 0 and msgCount >= {limit or 0} then exit repeat
             end repeat
 
             -- Join with newlines


### PR DESCRIPTION
## Summary

Fixes #1 - `search_messages` fails with AppleScript error "Illegal comparison or logical" (-1726)

Two issues were causing `search_messages` to fail:

1. **Invalid `whose true` clause**: When no filter conditions were provided, the code generated `whose true` which is invalid AppleScript syntax. Now we only include the `whose` clause when there are actual conditions.

2. **Invalid `items 1 thru N of` syntax**: The `items 1 thru N of (messages of mailbox)` syntax doesn't work in AppleScript for this context. Now we iterate through messages with a counter and exit the loop when the limit is reached.

## Test plan

- [x] Tested with Gmail account via IMAP in Apple Mail
- [x] Verified `search_messages` works with no filters
- [x] Verified `search_messages` works with limit parameter
- [x] Verified `search_messages` works with filter conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)