### PR TITLE
Fix search_messages for Gmail labels/folders

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -211,7 +211,20 @@ class AppleMailConnector:
         script = f"""
         tell application "Mail"
             set accountRef to account "{account_safe}"
-            set mailboxRef to mailbox "{mailbox_safe}" of accountRef
+
+            -- Find mailbox by name (handles Gmail labels)
+            set mailboxRef to missing value
+            repeat with mb in mailboxes of accountRef
+                if name of mb is "{mailbox_safe}" then
+                    set mailboxRef to mb
+                    exit repeat
+                end if
+            end repeat
+
+            if mailboxRef is missing value then
+                error "Can't get mailbox \\"{mailbox_safe}\\"" number -1728
+            end if
+
             set matchedMessages to {limit_clause} (messages of mailboxRef whose {whose_clause})
 
             set resultList to {{}}


### PR DESCRIPTION
## Summary

Fixes `search_messages` to work with Gmail labels and custom folders in Apple Mail.

**Problem:** The direct mailbox reference `mailbox "Name" of accountRef` fails for Gmail labels with AppleScript error -1728 ("can't get mailbox").

**Solution:** Iterate through `mailboxes of accountRef` and match by name, which correctly handles Gmail's label-based folder structure.

## Changes

- Modified `search_messages` in `mail_connector.py` to use iteration-based mailbox lookup
- Maintains backward compatibility with standard IMAP folders (INBOX, etc.)

## Testing

- Tested with Gmail IMAP account in Apple Mail
- Successfully accessed custom Gmail labels (e.g., "Weekly Emails")
- Standard INBOX access still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)