### PR TITLE
Feature/cli client

### DIFF
--- a/install-cli.sh
+++ b/install-cli.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+#
+# Apple Mail CLI Installer
+# Installs the apple-mail command-line tool
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOLD="\033[1m"
+GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
+RED="\033[0;31m"
+NC="\033[0m" # No Color
+
+echo -e "${BOLD}Apple Mail CLI Installer${NC}"
+echo "========================="
+echo ""
+
+# Check if running on macOS
+if [[ "$(uname)" != "Darwin" ]]; then
+    echo -e "${RED}Error: This tool only works on macOS${NC}"
+    exit 1
+fi
+
+# Check Python version
+check_python() {
+    if command -v python3 &> /dev/null; then
+        PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        MAJOR_VERSION=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+        MINOR_VERSION=$(echo "$PYTHON_VERSION" | cut -d. -f2)
+        
+        if [[ "$MAJOR_VERSION" -ge 3 ]] && [[ "$MINOR_VERSION" -ge 10 ]]; then
+            echo -e "${GREEN}✓${NC} Python $PYTHON_VERSION found"
+            return 0
+        fi
+    fi
+    
+    echo -e "${RED}✗${NC} Python 3.10+ is required"
+    echo "  Install Python 3.10+ from https://python.org or via Homebrew:"
+    echo "  brew install python@3.12"
+    exit 1
+}
+
+# Check if pip is available
+check_pip() {
+    if python3 -m pip --version &> /dev/null; then
+        echo -e "${GREEN}✓${NC} pip is available"
+        return 0
+    fi
+    
+    echo -e "${RED}✗${NC} pip is not available"
+    echo "  Install pip: python3 -m ensurepip --upgrade"
+    exit 1
+}
+
+# Install options
+install_options() {
+    echo ""
+    echo "Installation Options:"
+    echo "  1) Install in user space (recommended)"
+    echo "  2) Install in virtual environment"
+    echo "  3) Install for development (editable)"
+    echo ""
+    read -p "Choose an option [1]: " choice
+    choice=${choice:-1}
+    
+    case $choice in
+        1)
+            install_user
+            ;;
+        2)
+            install_venv
+            ;;
+        3)
+            install_dev
+            ;;
+        *)
+            echo -e "${RED}Invalid option${NC}"
+            exit 1
+            ;;
+    esac
+}
+
+# Install in user space
+install_user() {
+    echo ""
+    echo -e "${BOLD}Installing in user space...${NC}"
+    cd "$SCRIPT_DIR"
+    
+    python3 -m pip install --user . --quiet
+    
+    # Check if user bin is in PATH
+    USER_BIN="$HOME/.local/bin"
+    if [[ ":$PATH:" != *":$USER_BIN:"* ]]; then
+        echo ""
+        echo -e "${YELLOW}⚠${NC}  Add the following to your shell profile (.zshrc or .bashrc):"
+        echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+        echo ""
+        echo "Then restart your terminal or run: source ~/.zshrc"
+    fi
+    
+    install_complete
+}
+
+# Install in virtual environment
+install_venv() {
+    echo ""
+    read -p "Virtual environment path [./venv]: " VENV_PATH
+    VENV_PATH=${VENV_PATH:-"$SCRIPT_DIR/venv"}
+    
+    echo -e "${BOLD}Creating virtual environment at $VENV_PATH...${NC}"
+    python3 -m venv "$VENV_PATH"
+    
+    echo -e "${BOLD}Installing apple-mail CLI...${NC}"
+    "$VENV_PATH/bin/pip" install "$SCRIPT_DIR" --quiet
+    
+    echo ""
+    echo -e "${GREEN}✓${NC} Installed in virtual environment"
+    echo ""
+    echo "To use the CLI, either:"
+    echo "  1. Activate the venv: source $VENV_PATH/bin/activate"
+    echo "  2. Use the full path: $VENV_PATH/bin/apple-mail"
+    echo ""
+    echo "To create a symlink in /usr/local/bin:"
+    echo "  sudo ln -sf $VENV_PATH/bin/apple-mail /usr/local/bin/apple-mail"
+    
+    install_complete_venv "$VENV_PATH"
+}
+
+# Install for development (editable)
+install_dev() {
+    echo ""
+    echo -e "${BOLD}Installing in development mode...${NC}"
+    cd "$SCRIPT_DIR"
+    
+    # Check if in a virtual environment
+    if [[ -z "$VIRTUAL_ENV" ]]; then
+        echo -e "${YELLOW}⚠${NC}  Not in a virtual environment. Creating one..."
+        python3 -m venv "$SCRIPT_DIR/.venv"
+        source "$SCRIPT_DIR/.venv/bin/activate"
+        echo -e "${GREEN}✓${NC} Virtual environment created and activated at .venv"
+    fi
+    
+    pip install -e ".[dev]" --quiet
+    
+    echo ""
+    echo -e "${GREEN}✓${NC} Installed in development mode"
+    echo ""
+    echo "The CLI is now available as 'apple-mail' when the venv is active."
+    echo "Changes to the source code will be reflected immediately."
+    
+    install_complete_dev
+}
+
+install_complete() {
+    echo ""
+    echo -e "${GREEN}✓ Installation complete!${NC}"
+    echo ""
+    echo -e "${BOLD}Usage:${NC}"
+    echo "  apple-mail --help                    Show all commands"
+    echo "  apple-mail list-mailboxes Gmail      List mailboxes"
+    echo "  apple-mail search Gmail --limit 10   Search messages"
+    echo "  apple-mail get <message_id>          Get message details"
+    echo ""
+    echo "For more information, see the documentation at:"
+    echo "  https://github.com/morgancoopercom/apple-mail-mcp"
+}
+
+install_complete_venv() {
+    local venv_path=$1
+    echo ""
+    echo -e "${GREEN}✓ Installation complete!${NC}"
+    echo ""
+    echo -e "${BOLD}Quick start:${NC}"
+    echo "  source $venv_path/bin/activate"
+    echo "  apple-mail --help"
+}
+
+install_complete_dev() {
+    echo ""
+    echo -e "${GREEN}✓ Development installation complete!${NC}"
+    echo ""
+    echo -e "${BOLD}Quick start:${NC}"
+    echo "  apple-mail --help"
+    echo ""
+    echo "Run tests with:"
+    echo "  pytest"
+}
+
+# Main
+echo "Checking requirements..."
+echo ""
+check_python
+check_pip
+
+install_options
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 
 dependencies = [
     "fastmcp>=0.2.0",
+    "click>=8.0.0",
 ]
 
 [project.optional-dependencies]
@@ -41,6 +42,7 @@ dev = [
 
 [project.scripts]
 apple-mail-mcp = "apple_mail_mcp.server:main"
+apple-mail = "apple_mail_mcp.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/morgancoopercom/apple-mail-mcp"

--- a/src/apple_mail_mcp/cli.py
+++ b/src/apple_mail_mcp/cli.py
@@ -1,0 +1,1003 @@
+"""
+CLI interface for Apple Mail MCP functions.
+
+This module provides command-line access to all Apple Mail MCP operations.
+"""
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from .exceptions import (
+    MailAccountNotFoundError,
+    MailAppleScriptError,
+    MailMailboxNotFoundError,
+    MailMessageNotFoundError,
+)
+from .mail_connector import AppleMailConnector
+
+# Configure logging
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def output_result(result: dict, format_type: str = "json") -> None:
+    """Output result in the specified format."""
+    if format_type == "json":
+        click.echo(json.dumps(result, indent=2, default=str))
+    elif format_type == "pretty":
+        for key, value in result.items():
+            if isinstance(value, list):
+                click.echo(f"{key}:")
+                for item in value:
+                    if isinstance(item, dict):
+                        for k, v in item.items():
+                            click.echo(f"  {k}: {v}")
+                        click.echo("  ---")
+                    else:
+                        click.echo(f"  - {item}")
+            else:
+                click.echo(f"{key}: {value}")
+
+
+def handle_error(error: Exception, error_type: str = "unknown") -> dict:
+    """Create a standardized error response."""
+    return {
+        "success": False,
+        "error": str(error),
+        "error_type": error_type,
+    }
+
+
+@click.group()
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["json", "pretty"]),
+    default="json",
+    help="Output format (default: json)",
+)
+@click.pass_context
+def cli(ctx: click.Context, verbose: bool, output_format: str) -> None:
+    """Apple Mail CLI - Command line interface for Apple Mail operations.
+
+    This tool provides direct access to Apple Mail functionality through
+    the command line, mirroring all MCP server capabilities.
+    """
+    ctx.ensure_object(dict)
+    ctx.obj["verbose"] = verbose
+    ctx.obj["format"] = output_format
+    ctx.obj["mail"] = AppleMailConnector()
+
+    if verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+
+@cli.command("list-accounts")
+@click.pass_context
+def list_accounts(ctx: click.Context) -> None:
+    """List all configured mail accounts.
+
+    Example:
+        apple-mail list-accounts
+    """
+    mail = ctx.obj["mail"]
+    try:
+        accounts = mail.list_accounts()
+        result = {
+            "success": True,
+            "accounts": accounts,
+            "count": len(accounts),
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("list-mailboxes")
+@click.argument("account")
+@click.pass_context
+def list_mailboxes(ctx: click.Context, account: str) -> None:
+    """List all mailboxes for an account.
+
+    ACCOUNT: Account name (e.g., "Gmail", "iCloud")
+
+    Example:
+        apple-mail list-mailboxes Gmail
+    """
+    mail = ctx.obj["mail"]
+    try:
+        mailboxes = mail.list_mailboxes(account)
+        result = {
+            "success": True,
+            "account": account,
+            "mailboxes": mailboxes,
+        }
+    except MailAccountNotFoundError as e:
+        result = {
+            "success": False,
+            "error": f"Account '{account}' not found",
+            "error_type": "account_not_found",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("search")
+@click.argument("account")
+@click.option("-m", "--mailbox", default="INBOX", help="Mailbox name (default: INBOX)")
+@click.option("-s", "--sender", help="Filter by sender email/domain")
+@click.option("-j", "--subject", help="Filter by subject keywords")
+@click.option(
+    "-r",
+    "--read-status",
+    type=click.Choice(["read", "unread", "any"]),
+    default="any",
+    help="Filter by read status",
+)
+@click.option("-l", "--limit", type=int, default=50, help="Maximum results (default: 50)")
+@click.pass_context
+def search_messages(
+    ctx: click.Context,
+    account: str,
+    mailbox: str,
+    sender: Optional[str],
+    subject: Optional[str],
+    read_status: str,
+    limit: int,
+) -> None:
+    """Search for messages matching criteria.
+
+    ACCOUNT: Account name (e.g., "Gmail", "iCloud")
+
+    Examples:
+        apple-mail search Gmail --sender "john@example.com"
+        apple-mail search Gmail -m INBOX --read-status unread --limit 10
+        apple-mail search iCloud --subject "Meeting"
+    """
+    mail = ctx.obj["mail"]
+
+    read_bool: Optional[bool] = None
+    if read_status == "read":
+        read_bool = True
+    elif read_status == "unread":
+        read_bool = False
+
+    try:
+        messages = mail.search_messages(
+            account=account,
+            mailbox=mailbox,
+            sender_contains=sender,
+            subject_contains=subject,
+            read_status=read_bool,
+            limit=limit,
+        )
+        result = {
+            "success": True,
+            "account": account,
+            "mailbox": mailbox,
+            "messages": messages,
+            "count": len(messages),
+        }
+    except (MailAccountNotFoundError, MailMailboxNotFoundError) as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "error_type": "not_found",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("unread")
+@click.argument("account")
+@click.option("-m", "--mailbox", default="INBOX", help="Mailbox name (default: INBOX)")
+@click.option("-l", "--limit", type=int, default=20, help="Maximum results (default: 20)")
+@click.pass_context
+def get_unread(ctx: click.Context, account: str, mailbox: str, limit: int) -> None:
+    """Get the most recent unread messages from a mailbox.
+
+    ACCOUNT: Account name (e.g., "Gmail", "iCloud")
+
+    This is a convenience command equivalent to:
+        apple-mail search ACCOUNT -m MAILBOX --read-status unread --limit LIMIT
+
+    Examples:
+        apple-mail unread Gmail
+        apple-mail unread iCloud -m "All Mail" --limit 50
+    """
+    mail = ctx.obj["mail"]
+    try:
+        messages = mail.search_messages(
+            account=account,
+            mailbox=mailbox,
+            read_status=False,
+            limit=limit,
+        )
+        result = {
+            "success": True,
+            "account": account,
+            "mailbox": mailbox,
+            "messages": messages,
+            "count": len(messages),
+        }
+    except (MailAccountNotFoundError, MailMailboxNotFoundError) as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "error_type": "not_found",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("get")
+@click.argument("message_id")
+@click.option("--no-content", is_flag=True, help="Exclude message body")
+@click.pass_context
+def get_message(ctx: click.Context, message_id: str, no_content: bool) -> None:
+    """Get full details of a specific message.
+
+    MESSAGE_ID: Message ID from search results
+
+    Example:
+        apple-mail get 12345
+        apple-mail get 12345 --no-content
+    """
+    mail = ctx.obj["mail"]
+    try:
+        message = mail.get_message(message_id, include_content=not no_content)
+        result = {
+            "success": True,
+            "message": message,
+        }
+    except MailMessageNotFoundError:
+        result = {
+            "success": False,
+            "error": f"Message '{message_id}' not found",
+            "error_type": "message_not_found",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("send")
+@click.option("-s", "--subject", required=True, help="Email subject")
+@click.option("-b", "--body", required=True, help="Email body")
+@click.option("-t", "--to", "recipients", required=True, multiple=True, help="Recipient email(s)")
+@click.option("-c", "--cc", multiple=True, help="CC recipient(s)")
+@click.option("--bcc", multiple=True, help="BCC recipient(s)")
+@click.option("-y", "--yes", is_flag=True, help="Skip confirmation prompt")
+@click.pass_context
+def send_email(
+    ctx: click.Context,
+    subject: str,
+    body: str,
+    recipients: tuple,
+    cc: tuple,
+    bcc: tuple,
+    yes: bool,
+) -> None:
+    """Send an email via Apple Mail.
+
+    Examples:
+        apple-mail send -s "Hello" -b "Hi there!" -t alice@example.com
+        apple-mail send -s "Meeting" -b "Let's meet" -t bob@example.com -c carol@example.com
+    """
+    mail = ctx.obj["mail"]
+    to_list = list(recipients)
+    cc_list = list(cc) if cc else None
+    bcc_list = list(bcc) if bcc else None
+
+    # Show confirmation unless --yes flag is set
+    if not yes:
+        click.echo("Email Details:")
+        click.echo(f"  Subject: {subject}")
+        click.echo(f"  To: {', '.join(to_list)}")
+        if cc_list:
+            click.echo(f"  CC: {', '.join(cc_list)}")
+        if bcc_list:
+            click.echo(f"  BCC: {', '.join(bcc_list)}")
+        click.echo(f"  Body: {body[:100]}{'...' if len(body) > 100 else ''}")
+        click.echo()
+
+        if not click.confirm("Send this email?"):
+            result = {
+                "success": False,
+                "error": "User cancelled operation",
+                "error_type": "cancelled",
+            }
+            output_result(result, ctx.obj["format"])
+            sys.exit(1)
+
+    try:
+        mail.send_email(
+            subject=subject,
+            body=body,
+            to=to_list,
+            cc=cc_list,
+            bcc=bcc_list,
+        )
+        result = {
+            "success": True,
+            "message": "Email sent successfully",
+            "details": {
+                "subject": subject,
+                "recipients": len(to_list) + len(cc_list or []) + len(bcc_list or []),
+            },
+        }
+    except MailAppleScriptError as e:
+        result = {
+            "success": False,
+            "error": f"Failed to send email: {str(e)}",
+            "error_type": "send_error",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("mark-read")
+@click.argument("message_ids", nargs=-1, required=True)
+@click.option("--unread", is_flag=True, help="Mark as unread instead")
+@click.pass_context
+def mark_as_read(ctx: click.Context, message_ids: tuple, unread: bool) -> None:
+    """Mark messages as read or unread.
+
+    MESSAGE_IDS: One or more message IDs
+
+    Examples:
+        apple-mail mark-read 12345 12346
+        apple-mail mark-read 12345 --unread
+    """
+    mail = ctx.obj["mail"]
+    ids = list(message_ids)
+
+    if len(ids) > 100:
+        result = {
+            "success": False,
+            "error": f"Cannot process {len(ids)} messages at once (max: 100)",
+            "error_type": "validation_error",
+        }
+        output_result(result, ctx.obj["format"])
+        sys.exit(1)
+
+    try:
+        count = mail.mark_as_read(ids, read=not unread)
+        result = {
+            "success": True,
+            "updated": count,
+            "requested": len(ids),
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("send-with-attachments")
+@click.option("-s", "--subject", required=True, help="Email subject")
+@click.option("-b", "--body", required=True, help="Email body")
+@click.option("-t", "--to", "recipients", required=True, multiple=True, help="Recipient email(s)")
+@click.option("-a", "--attachment", "attachments", required=True, multiple=True, help="File path(s) to attach")
+@click.option("-c", "--cc", multiple=True, help="CC recipient(s)")
+@click.option("--bcc", multiple=True, help="BCC recipient(s)")
+@click.option("-y", "--yes", is_flag=True, help="Skip confirmation prompt")
+@click.pass_context
+def send_email_with_attachments(
+    ctx: click.Context,
+    subject: str,
+    body: str,
+    recipients: tuple,
+    attachments: tuple,
+    cc: tuple,
+    bcc: tuple,
+    yes: bool,
+) -> None:
+    """Send an email with file attachments.
+
+    Examples:
+        apple-mail send-with-attachments -s "Report" -b "See attached" -t bob@example.com -a report.pdf
+        apple-mail send-with-attachments -s "Files" -b "Here are the files" -t alice@example.com -a file1.pdf -a file2.docx
+    """
+    mail = ctx.obj["mail"]
+    to_list = list(recipients)
+    attachment_paths = [Path(p) for p in attachments]
+    cc_list = list(cc) if cc else None
+    bcc_list = list(bcc) if bcc else None
+
+    # Validate attachments exist
+    missing_files = [str(p) for p in attachment_paths if not p.exists()]
+    if missing_files:
+        result = {
+            "success": False,
+            "error": f"Attachment files not found: {', '.join(missing_files)}",
+            "error_type": "file_not_found",
+        }
+        output_result(result, ctx.obj["format"])
+        sys.exit(1)
+
+    # Show confirmation unless --yes flag is set
+    if not yes:
+        click.echo("Email Details:")
+        click.echo(f"  Subject: {subject}")
+        click.echo(f"  To: {', '.join(to_list)}")
+        if cc_list:
+            click.echo(f"  CC: {', '.join(cc_list)}")
+        if bcc_list:
+            click.echo(f"  BCC: {', '.join(bcc_list)}")
+        click.echo(f"  Attachments: {', '.join(p.name for p in attachment_paths)}")
+        click.echo(f"  Body: {body[:100]}{'...' if len(body) > 100 else ''}")
+        click.echo()
+
+        if not click.confirm("Send this email?"):
+            result = {
+                "success": False,
+                "error": "User cancelled operation",
+                "error_type": "cancelled",
+            }
+            output_result(result, ctx.obj["format"])
+            sys.exit(1)
+
+    try:
+        mail.send_email_with_attachments(
+            subject=subject,
+            body=body,
+            to=to_list,
+            attachments=attachment_paths,
+            cc=cc_list,
+            bcc=bcc_list,
+        )
+        result = {
+            "success": True,
+            "message": f"Email sent with {len(attachments)} attachment(s)",
+            "details": {
+                "subject": subject,
+                "recipients": len(to_list) + len(cc_list or []) + len(bcc_list or []),
+                "attachments": len(attachments),
+            },
+        }
+    except (FileNotFoundError, ValueError) as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "error_type": "validation_error",
+        }
+    except MailAppleScriptError as e:
+        result = {
+            "success": False,
+            "error": f"Failed to send email: {str(e)}",
+            "error_type": "send_error",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("get-attachments")
+@click.argument("message_id")
+@click.pass_context
+def get_attachments(ctx: click.Context, message_id: str) -> None:
+    """Get list of attachments from a message.
+
+    MESSAGE_ID: Message ID from search results
+
+    Example:
+        apple-mail get-attachments 12345
+    """
+    mail = ctx.obj["mail"]
+    try:
+        attachments = mail.get_attachments(message_id)
+        result = {
+            "success": True,
+            "attachments": attachments,
+            "count": len(attachments),
+        }
+    except MailMessageNotFoundError:
+        result = {
+            "success": False,
+            "error": f"Message '{message_id}' not found",
+            "error_type": "message_not_found",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("save-attachments")
+@click.argument("message_id")
+@click.argument("save_directory")
+@click.option("-i", "--index", "indices", multiple=True, type=int, help="Specific attachment indices (0-based)")
+@click.pass_context
+def save_attachments(
+    ctx: click.Context,
+    message_id: str,
+    save_directory: str,
+    indices: tuple,
+) -> None:
+    """Save attachments from a message to a directory.
+
+    MESSAGE_ID: Message ID from search results
+    SAVE_DIRECTORY: Directory path to save attachments to
+
+    Examples:
+        apple-mail save-attachments 12345 ~/Downloads
+        apple-mail save-attachments 12345 ~/Downloads -i 0 -i 2
+    """
+    mail = ctx.obj["mail"]
+    save_path = Path(save_directory)
+
+    if not save_path.exists():
+        result = {
+            "success": False,
+            "error": f"Directory does not exist: {save_directory}",
+            "error_type": "directory_not_found",
+        }
+        output_result(result, ctx.obj["format"])
+        sys.exit(1)
+
+    if not save_path.is_dir():
+        result = {
+            "success": False,
+            "error": f"Path is not a directory: {save_directory}",
+            "error_type": "invalid_directory",
+        }
+        output_result(result, ctx.obj["format"])
+        sys.exit(1)
+
+    attachment_indices = list(indices) if indices else None
+
+    try:
+        count = mail.save_attachments(
+            message_id=message_id,
+            save_directory=save_path,
+            attachment_indices=attachment_indices,
+        )
+        result = {
+            "success": True,
+            "saved": count,
+            "directory": save_directory,
+        }
+    except (FileNotFoundError, ValueError) as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "error_type": "validation_error",
+        }
+    except MailMessageNotFoundError:
+        result = {
+            "success": False,
+            "error": f"Message '{message_id}' not found",
+            "error_type": "message_not_found",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("move")
+@click.argument("message_ids", nargs=-1, required=True)
+@click.option("-d", "--destination", required=True, help="Destination mailbox name")
+@click.option("-a", "--account", required=True, help="Account name")
+@click.option("--gmail", is_flag=True, help="Use Gmail-specific move handling")
+@click.pass_context
+def move_messages(
+    ctx: click.Context,
+    message_ids: tuple,
+    destination: str,
+    account: str,
+    gmail: bool,
+) -> None:
+    """Move messages to a different mailbox/folder.
+
+    MESSAGE_IDS: One or more message IDs
+
+    Examples:
+        apple-mail move 12345 12346 -d Archive -a Gmail
+        apple-mail move 12345 -d "Projects/Client Work" -a iCloud
+    """
+    mail = ctx.obj["mail"]
+    ids = list(message_ids)
+
+    try:
+        count = mail.move_messages(
+            message_ids=ids,
+            destination_mailbox=destination,
+            account=account,
+            gmail_mode=gmail,
+        )
+        result = {
+            "success": True,
+            "count": count,
+            "destination": destination,
+            "account": account,
+        }
+    except MailMailboxNotFoundError:
+        result = {
+            "success": False,
+            "error": f"Mailbox '{destination}' not found in account '{account}'",
+            "error_type": "mailbox_not_found",
+        }
+    except MailAccountNotFoundError:
+        result = {
+            "success": False,
+            "error": f"Account '{account}' not found",
+            "error_type": "account_not_found",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("flag")
+@click.argument("message_ids", nargs=-1, required=True)
+@click.option(
+    "-c",
+    "--color",
+    required=True,
+    type=click.Choice(["none", "orange", "red", "yellow", "blue", "green", "purple", "gray"]),
+    help="Flag color",
+)
+@click.pass_context
+def flag_message(ctx: click.Context, message_ids: tuple, color: str) -> None:
+    """Set flag color on messages.
+
+    MESSAGE_IDS: One or more message IDs
+
+    Examples:
+        apple-mail flag 12345 -c red
+        apple-mail flag 12345 12346 -c none
+    """
+    mail = ctx.obj["mail"]
+    ids = list(message_ids)
+
+    try:
+        count = mail.flag_message(message_ids=ids, flag_color=color)
+        result = {
+            "success": True,
+            "count": count,
+            "flag_color": color,
+        }
+    except ValueError as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "error_type": "validation_error",
+        }
+    except MailMessageNotFoundError as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "error_type": "message_not_found",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("create-mailbox")
+@click.argument("account")
+@click.argument("name")
+@click.option("-p", "--parent", help="Parent mailbox for nesting")
+@click.pass_context
+def create_mailbox(ctx: click.Context, account: str, name: str, parent: Optional[str]) -> None:
+    """Create a new mailbox/folder.
+
+    ACCOUNT: Account name
+    NAME: Name of the new mailbox
+
+    Examples:
+        apple-mail create-mailbox Gmail "Client Work"
+        apple-mail create-mailbox iCloud "Work Projects" -p Projects
+    """
+    mail = ctx.obj["mail"]
+
+    if not name or not name.strip():
+        result = {
+            "success": False,
+            "error": "Mailbox name cannot be empty",
+            "error_type": "validation_error",
+        }
+        output_result(result, ctx.obj["format"])
+        sys.exit(1)
+
+    try:
+        success = mail.create_mailbox(account=account, name=name, parent_mailbox=parent)
+        result = {
+            "success": success,
+            "account": account,
+            "mailbox": name,
+            "parent": parent,
+        }
+    except ValueError as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "error_type": "validation_error",
+        }
+    except MailAccountNotFoundError:
+        result = {
+            "success": False,
+            "error": f"Account '{account}' not found",
+            "error_type": "account_not_found",
+        }
+    except MailAppleScriptError as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "error_type": "applescript_error",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("delete")
+@click.argument("message_ids", nargs=-1, required=True)
+@click.option("--permanent", is_flag=True, help="Permanently delete (bypass trash)")
+@click.option("-y", "--yes", is_flag=True, help="Skip confirmation prompt")
+@click.pass_context
+def delete_messages(
+    ctx: click.Context,
+    message_ids: tuple,
+    permanent: bool,
+    yes: bool,
+) -> None:
+    """Delete messages (move to trash or permanently delete).
+
+    MESSAGE_IDS: One or more message IDs
+
+    Examples:
+        apple-mail delete 12345
+        apple-mail delete 12345 12346 --permanent -y
+    """
+    mail = ctx.obj["mail"]
+    ids = list(message_ids)
+
+    if len(ids) > 100:
+        result = {
+            "success": False,
+            "error": f"Cannot delete {len(ids)} messages at once (max: 100)",
+            "error_type": "validation_error",
+        }
+        output_result(result, ctx.obj["format"])
+        sys.exit(1)
+
+    # Confirm permanent deletion
+    if permanent and not yes:
+        click.echo(f"WARNING: This will permanently delete {len(ids)} message(s)!")
+        click.echo("This action cannot be undone.")
+        if not click.confirm("Are you sure?"):
+            result = {
+                "success": False,
+                "error": "User cancelled operation",
+                "error_type": "cancelled",
+            }
+            output_result(result, ctx.obj["format"])
+            sys.exit(1)
+
+    try:
+        count = mail.delete_messages(
+            message_ids=ids,
+            permanent=permanent,
+            skip_bulk_check=False,
+        )
+        result = {
+            "success": True,
+            "count": count,
+            "permanent": permanent,
+        }
+    except ValueError as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "error_type": "validation_error",
+        }
+    except MailMessageNotFoundError as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "error_type": "message_not_found",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("reply")
+@click.argument("message_id")
+@click.option("-b", "--body", required=True, help="Reply body text")
+@click.option("--all", "reply_all", is_flag=True, help="Reply to all recipients")
+@click.option("-y", "--yes", is_flag=True, help="Skip confirmation prompt")
+@click.pass_context
+def reply_to_message(
+    ctx: click.Context,
+    message_id: str,
+    body: str,
+    reply_all: bool,
+    yes: bool,
+) -> None:
+    """Reply to a message.
+
+    MESSAGE_ID: ID of the message to reply to
+
+    Examples:
+        apple-mail reply 12345 -b "Thanks for your email!"
+        apple-mail reply 12345 -b "Great point, team!" --all
+    """
+    mail = ctx.obj["mail"]
+
+    if not yes:
+        click.echo("Reply Details:")
+        click.echo(f"  Original Message ID: {message_id}")
+        click.echo(f"  Reply All: {reply_all}")
+        click.echo(f"  Body: {body[:100]}{'...' if len(body) > 100 else ''}")
+        click.echo()
+
+        if not click.confirm("Send this reply?"):
+            result = {
+                "success": False,
+                "error": "User cancelled operation",
+                "error_type": "cancelled",
+            }
+            output_result(result, ctx.obj["format"])
+            sys.exit(1)
+
+    try:
+        reply_id = mail.reply_to_message(
+            message_id=message_id,
+            body=body,
+            reply_all=reply_all,
+        )
+        result = {
+            "success": True,
+            "reply_id": reply_id,
+            "original_message_id": message_id,
+            "reply_all": reply_all,
+        }
+    except MailMessageNotFoundError:
+        result = {
+            "success": False,
+            "error": f"Message '{message_id}' not found",
+            "error_type": "message_not_found",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+@cli.command("forward")
+@click.argument("message_id")
+@click.option("-t", "--to", "recipients", required=True, multiple=True, help="Recipient email(s)")
+@click.option("-b", "--body", default="", help="Body text to add before forwarded content")
+@click.option("-c", "--cc", multiple=True, help="CC recipient(s)")
+@click.option("--bcc", multiple=True, help="BCC recipient(s)")
+@click.option("-y", "--yes", is_flag=True, help="Skip confirmation prompt")
+@click.pass_context
+def forward_message(
+    ctx: click.Context,
+    message_id: str,
+    recipients: tuple,
+    body: str,
+    cc: tuple,
+    bcc: tuple,
+    yes: bool,
+) -> None:
+    """Forward a message to recipients.
+
+    MESSAGE_ID: ID of the message to forward
+
+    Examples:
+        apple-mail forward 12345 -t colleague@example.com
+        apple-mail forward 12345 -t bob@example.com -b "FYI - see below"
+    """
+    mail = ctx.obj["mail"]
+    to_list = list(recipients)
+    cc_list = list(cc) if cc else None
+    bcc_list = list(bcc) if bcc else None
+
+    if not yes:
+        click.echo("Forward Details:")
+        click.echo(f"  Original Message ID: {message_id}")
+        click.echo(f"  To: {', '.join(to_list)}")
+        if cc_list:
+            click.echo(f"  CC: {', '.join(cc_list)}")
+        if bcc_list:
+            click.echo(f"  BCC: {', '.join(bcc_list)}")
+        if body:
+            click.echo(f"  Body: {body[:100]}{'...' if len(body) > 100 else ''}")
+        click.echo()
+
+        if not click.confirm("Send this forward?"):
+            result = {
+                "success": False,
+                "error": "User cancelled operation",
+                "error_type": "cancelled",
+            }
+            output_result(result, ctx.obj["format"])
+            sys.exit(1)
+
+    try:
+        forward_id = mail.forward_message(
+            message_id=message_id,
+            to=to_list,
+            body=body,
+            cc=cc_list,
+            bcc=bcc_list,
+        )
+        result = {
+            "success": True,
+            "forward_id": forward_id,
+            "original_message_id": message_id,
+            "recipients": to_list,
+            "cc": cc_list,
+            "bcc": bcc_list,
+        }
+    except ValueError as e:
+        result = {
+            "success": False,
+            "error": str(e),
+            "error_type": "validation_error",
+        }
+    except MailMessageNotFoundError:
+        result = {
+            "success": False,
+            "error": f"Message '{message_id}' not found",
+            "error_type": "message_not_found",
+        }
+    except Exception as e:
+        result = handle_error(e)
+
+    output_result(result, ctx.obj["format"])
+    sys.exit(0 if result.get("success") else 1)
+
+
+def main() -> None:
+    """Entry point for the CLI."""
+    cli(obj={})
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -206,16 +206,21 @@ class AppleMailConnector:
             conditions.append(f"read status is {status}")
 
         whose_clause = " and ".join(conditions) if conditions else "true"
-        limit_clause = f"items 1 thru {limit} of" if limit else ""
+        limit_value = limit if limit else 1000  # Default max if no limit
 
         script = f"""
         tell application "Mail"
             set accountRef to account "{account_safe}"
             set mailboxRef to mailbox "{mailbox_safe}" of accountRef
-            set matchedMessages to {limit_clause} (messages of mailboxRef whose {whose_clause})
+            set matchedMessages to (messages of mailboxRef whose {whose_clause})
 
             set resultList to {{}}
+            set msgCount to 0
+            set maxCount to {limit_value}
+
             repeat with msg in matchedMessages
+                if msgCount >= maxCount then exit repeat
+
                 set msgId to id of msg as text
                 set msgSubject to subject of msg
                 set msgSender to sender of msg
@@ -224,6 +229,7 @@ class AppleMailConnector:
 
                 set msgData to msgId & "|" & msgSubject & "|" & msgSender & "|" & msgDate & "|" & msgRead
                 set end of resultList to msgData
+                set msgCount to msgCount + 1
             end repeat
 
             -- Join with newlines

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -36,6 +36,107 @@ mail = AppleMailConnector()
 
 
 @mcp.tool()
+def list_accounts() -> dict[str, Any]:
+    """
+    List all configured mail accounts.
+
+    Returns:
+        Dictionary containing list of accounts with names and email addresses
+
+    Example:
+        >>> list_accounts()
+        {"success": True, "accounts": [{"name": "Gmail", "emails": ["user@gmail.com"]}], "count": 2}
+    """
+    try:
+        logger.info("Listing mail accounts")
+
+        accounts = mail.list_accounts()
+
+        operation_logger.log_operation(
+            "list_accounts",
+            {},
+            "success"
+        )
+
+        return {
+            "success": True,
+            "accounts": accounts,
+            "count": len(accounts),
+        }
+
+    except Exception as e:
+        logger.error(f"Error listing accounts: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "unknown",
+        }
+
+
+@mcp.tool()
+def get_unread_messages(
+    account: str,
+    mailbox: str = "INBOX",
+    limit: int = 20,
+) -> dict[str, Any]:
+    """
+    Get the most recent unread messages from a mailbox.
+
+    This is a convenience function that searches for unread messages.
+
+    Args:
+        account: Account name (e.g., "Gmail", "iCloud")
+        mailbox: Mailbox name (default: "INBOX")
+        limit: Maximum results to return (default: 20)
+
+    Returns:
+        Dictionary containing unread messages
+
+    Example:
+        >>> get_unread_messages("Gmail", limit=10)
+        {"success": True, "messages": [...], "count": 5}
+    """
+    try:
+        logger.info(f"Getting unread messages from {account}/{mailbox}")
+
+        messages = mail.search_messages(
+            account=account,
+            mailbox=mailbox,
+            read_status=False,
+            limit=limit,
+        )
+
+        operation_logger.log_operation(
+            "get_unread_messages",
+            {"account": account, "mailbox": mailbox, "limit": limit},
+            "success"
+        )
+
+        return {
+            "success": True,
+            "account": account,
+            "mailbox": mailbox,
+            "messages": messages,
+            "count": len(messages),
+        }
+
+    except (MailAccountNotFoundError, MailMailboxNotFoundError) as e:
+        logger.error(f"Not found error: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "not_found",
+        }
+    except Exception as e:
+        logger.error(f"Error getting unread messages: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "unknown",
+        }
+
+
+@mcp.tool()
 def list_mailboxes(account: str) -> dict[str, Any]:
     """
     List all mailboxes for an account.


### PR DESCRIPTION
# Pull Request

## Description

Adds a CLI alternative to the MCP server, allowing all Apple Mail operations to be performed directly from the command line. Includes an installation script and fixes an AppleScript bug with message limits.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement
- [ ] Performance improvement

## Related Issues

## Changes Made

- Added `src/apple_mail_mcp/cli.py` - Full CLI module using Click that exposes all MCP functions as command-line commands
- Added `install-cli.sh` - Interactive installation script with three options: user space, virtual environment, or development/editable mode
- Updated `pyproject.toml` - Added `click>=8.0.0` dependency and `apple-mail` entry point
- Added `list_accounts()` MCP tool and `list-accounts` CLI command to list all configured mail accounts
- Added `get_unread_messages()` MCP tool and `unread` CLI command as a convenience function to quickly get recent unread messages
- Fixed bug in `mail_connector.py` where `search_messages` failed when the requested limit exceeded available matching messages (AppleScript `items 1 thru N` error)

### New CLI Commands
| Command | Description |
|---------|-------------|
| `list-accounts` | List all configured mail accounts |
| `list-mailboxes` | List mailboxes for an account |
| `search` | Search messages with filters |
| `unread` | Get recent unread messages (convenience) |
| `get` | Get full message details |
| `send` | Send an email |
| `send-with-attachments` | Send email with file attachments |
| `get-attachments` | List attachments from a message |
| `save-attachments` | Save attachments to a directory |
| `mark-read` | Mark messages as read/unread |
| `move` | Move messages to another mailbox |
| `flag` | Set flag color on messages |
| `create-mailbox` | Create a new mailbox/folder |
| `delete` | Delete messages |
| `reply` | Reply to a message |
| `forward` | Forward a message |

## Testing

## Code Quality Checklist

- [x] Code follows project style guidelines
- [x] Added docstrings for new functions
- [ ] Updated documentation (README, TOOLS.md, etc.)
- [x] No new security vulnerabilities introduced
- [x] Input validation added where needed
- [x] Error handling is comprehensive

## Screenshots (if applicable)

## Additional Notes
