### PR TITLE
Add support for getting selected mails

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ An MCP server that provides programmatic access to Apple Mail, enabling AI assis
 
 > ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.5.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading. The aim is to reach 1.0 once the v0.6.0 polish work lands.
 
-## Tools (26)
+## Tools (27)
 
-**Core:** list_mailboxes, search_messages, get_message, send_email, mark_as_read
+**Core:** list_mailboxes, search_messages, get_message, get_selected_messages, send_email, mark_as_read
 **Attachments & Management:** send_email_with_attachments, get_attachments, save_attachments, move_messages, flag_message, create_mailbox, delete_messages
 **Reply/Forward:** reply_to_message, forward_message
 **Discovery & Rules:** list_accounts, list_rules, get_thread, set_rule_enabled, create_rule, update_rule, delete_rule

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -2135,37 +2135,34 @@ class AppleMailConnector:
             include_content: Include message body (default: True)
 
         Returns:
-            List of message dicts (same structure as get_message), empty if nothing selected
+            List of message dicts (same structure as get_message). Empty list if
+            no messages are selected.
 
         Raises:
             MailAppleScriptError: If AppleScript execution fails
         """
-        id_script = """
+        # Single AppleScript pass: enumerate `selection`, build a list of records,
+        # and let _wrap_as_json_script emit the NSJSONSerialization epilogue.
+        # This is one osascript call regardless of how many messages are
+        # selected — N round-trips would cost 100-300ms each.
+        content_clause = (
+            "set msgContent to content of msg"
+            if include_content
+            else 'set msgContent to ""'
+        )
+
+        tell_body = f"""
         tell application "Mail"
+            set resultData to {{}}
             set sel to selection
-            if (count of sel) is 0 then return ""
-            set idList to {}
             repeat with msg in sel
-                set end of idList to (id of msg as rich text)
+                {content_clause}
+                set msgRecord to {{|id|:(id of msg as text), |subject|:(subject of msg), |sender|:(sender of msg), |date_received|:(date received of msg as text), |read_status|:(read status of msg), |flagged|:(flagged status of msg), |content|:msgContent}}
+                set end of resultData to msgRecord
             end repeat
-            set AppleScript's text item delimiters to ","
-            set result to idList as rich text
-            return result
         end tell
         """
 
-        raw_ids = self._run_applescript(id_script).strip()
-        if not raw_ids:
-            return []
-
-        message_ids = [mid.strip() for mid in raw_ids.split(",") if mid.strip()]
-
-        messages = []
-        for message_id in message_ids:
-            try:
-                msg = self.get_message(message_id, include_content=include_content)
-                messages.append(msg)
-            except MailMessageNotFoundError:
-                logger.warning(f"Selected message {message_id} could not be retrieved")
-
-        return messages
+        script = _wrap_as_json_script(tell_body)
+        result = self._run_applescript(script)
+        return cast(list[dict[str, Any]], parse_applescript_json(result))

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -2126,3 +2126,46 @@ class AppleMailConnector:
 
         result = self._run_applescript(script)
         return result
+
+    def get_selected_messages(self, include_content: bool = True) -> list[dict[str, Any]]:
+        """
+        Get messages currently selected in Apple Mail.
+
+        Args:
+            include_content: Include message body (default: True)
+
+        Returns:
+            List of message dicts (same structure as get_message), empty if nothing selected
+
+        Raises:
+            MailAppleScriptError: If AppleScript execution fails
+        """
+        id_script = """
+        tell application "Mail"
+            set sel to selection
+            if (count of sel) is 0 then return ""
+            set idList to {}
+            repeat with msg in sel
+                set end of idList to (id of msg as rich text)
+            end repeat
+            set AppleScript's text item delimiters to ","
+            set result to idList as rich text
+            return result
+        end tell
+        """
+
+        raw_ids = self._run_applescript(id_script).strip()
+        if not raw_ids:
+            return []
+
+        message_ids = [mid.strip() for mid in raw_ids.split(",") if mid.strip()]
+
+        messages = []
+        for message_id in message_ids:
+            try:
+                msg = self.get_message(message_id, include_content=include_content)
+                messages.append(msg)
+            except MailMessageNotFoundError:
+                logger.warning(f"Selected message {message_id} could not be retrieved")
+
+        return messages

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -772,6 +772,48 @@ def get_message(message_id: str, include_content: bool = True) -> dict[str, Any]
 
 
 @mcp.tool()
+def get_selected_messages(include_content: bool = True) -> dict[str, Any]:
+    """
+    Get messages currently selected in the Apple Mail application.
+
+    Returns the full details of whichever message(s) the user has highlighted
+    in Mail's message list at the time of the call.
+
+    Args:
+        include_content: Include message body text (default: true)
+
+    Returns:
+        Dictionary containing selected messages and count
+
+    Example:
+        >>> get_selected_messages()
+        {"success": True, "messages": [...], "count": 1}
+    """
+    try:
+        messages = mail.get_selected_messages(include_content=include_content)
+
+        operation_logger.log_operation(
+            "get_selected_messages",
+            {"include_content": include_content},
+            "success",
+        )
+
+        return {
+            "success": True,
+            "messages": messages,
+            "count": len(messages),
+        }
+
+    except Exception as e:
+        logger.error(f"Error getting selected messages: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "unknown",
+        }
+
+
+@mcp.tool()
 async def send_email(
     subject: str,
     body: str,

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1830,12 +1830,13 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         """Test getting a single selected message."""
-        mock_run.side_effect = [
-            # First call: get selection IDs
-            "12345",
-            # Second call: get message details
-            "12345|Selected Subject|sender@example.com|Mon Jan 1 2024|true|false|Body text",
-        ]
+        # Modernized: single AppleScript call returns JSON array of records.
+        mock_run.return_value = (
+            '[{"id":"12345","subject":"Selected Subject",'
+            '"sender":"sender@example.com",'
+            '"date_received":"Mon Jan 1 2024",'
+            '"read_status":true,"flagged":false,"content":"Body text"}]'
+        )
 
         result = connector.get_selected_messages(include_content=True)
 
@@ -1850,14 +1851,14 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         """Test getting multiple selected messages."""
-        mock_run.side_effect = [
-            # First call: get selection IDs (comma-separated)
-            "111,222",
-            # Second call: first message details
-            "111|Subject One|a@example.com|Mon Jan 1 2024|true|false|Body one",
-            # Third call: second message details
-            "222|Subject Two|b@example.com|Tue Jan 2 2024|false|true|Body two",
-        ]
+        mock_run.return_value = (
+            '[{"id":"111","subject":"Subject One","sender":"a@example.com",'
+            '"date_received":"Mon Jan 1 2024","read_status":true,'
+            '"flagged":false,"content":"Body one"},'
+            '{"id":"222","subject":"Subject Two","sender":"b@example.com",'
+            '"date_received":"Tue Jan 2 2024","read_status":false,'
+            '"flagged":true,"content":"Body two"}]'
+        )
 
         result = connector.get_selected_messages(include_content=True)
 
@@ -1870,8 +1871,8 @@ class TestAppleMailConnector:
     def test_get_selected_messages_none_selected(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """Test when no message is selected."""
-        mock_run.return_value = ""
+        """Test when no message is selected — script returns empty JSON array."""
+        mock_run.return_value = "[]"
 
         result = connector.get_selected_messages()
 
@@ -1881,13 +1882,22 @@ class TestAppleMailConnector:
     def test_get_selected_messages_no_content(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """Test getting selected message without body content."""
-        mock_run.side_effect = [
-            "12345",
-            "12345|Subject|sender@example.com|Mon Jan 1 2024|false|false|",
-        ]
+        """Test that include_content=False emits the no-content branch in
+        the AppleScript and the returned record has empty content."""
+        mock_run.return_value = (
+            '[{"id":"12345","subject":"Subject",'
+            '"sender":"sender@example.com",'
+            '"date_received":"Mon Jan 1 2024",'
+            '"read_status":false,"flagged":false,"content":""}]'
+        )
 
         result = connector.get_selected_messages(include_content=False)
+
+        # Verify the script took the no-content branch (no `set msgContent
+        # to content of msg`).
+        script = mock_run.call_args[0][0]
+        assert 'set msgContent to ""' in script
+        assert "set msgContent to content of msg" not in script
 
         assert len(result) == 1
         assert result[0]["content"] == ""

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1825,6 +1825,73 @@ class TestAppleMailConnector:
         call_args = mock_run.call_args[0][0]
         assert "set read status of msg to false" in call_args
 
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_selected_messages_single(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Test getting a single selected message."""
+        mock_run.side_effect = [
+            # First call: get selection IDs
+            "12345",
+            # Second call: get message details
+            "12345|Selected Subject|sender@example.com|Mon Jan 1 2024|true|false|Body text",
+        ]
+
+        result = connector.get_selected_messages(include_content=True)
+
+        assert len(result) == 1
+        assert result[0]["id"] == "12345"
+        assert result[0]["subject"] == "Selected Subject"
+        assert result[0]["sender"] == "sender@example.com"
+        assert result[0]["content"] == "Body text"
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_selected_messages_multiple(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Test getting multiple selected messages."""
+        mock_run.side_effect = [
+            # First call: get selection IDs (comma-separated)
+            "111,222",
+            # Second call: first message details
+            "111|Subject One|a@example.com|Mon Jan 1 2024|true|false|Body one",
+            # Third call: second message details
+            "222|Subject Two|b@example.com|Tue Jan 2 2024|false|true|Body two",
+        ]
+
+        result = connector.get_selected_messages(include_content=True)
+
+        assert len(result) == 2
+        assert result[0]["id"] == "111"
+        assert result[1]["id"] == "222"
+        assert result[1]["flagged"] is True
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_selected_messages_none_selected(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Test when no message is selected."""
+        mock_run.return_value = ""
+
+        result = connector.get_selected_messages()
+
+        assert result == []
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_selected_messages_no_content(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Test getting selected message without body content."""
+        mock_run.side_effect = [
+            "12345",
+            "12345|Subject|sender@example.com|Mon Jan 1 2024|false|false|",
+        ]
+
+        result = connector.get_selected_messages(include_content=False)
+
+        assert len(result) == 1
+        assert result[0]["content"] == ""
+
     def test_mark_as_read_empty_list(self, connector: AppleMailConnector) -> None:
         """Test marking with empty list."""
         result = connector.mark_as_read([])

--- a/tests/unit/test_server_selected.py
+++ b/tests/unit/test_server_selected.py
@@ -1,0 +1,76 @@
+"""Tests for get_selected_messages server tool."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apple_mail_mcp.server import get_selected_messages
+
+
+class TestGetSelectedMessagesTool:
+    """Tests for the get_selected_messages MCP tool."""
+
+    @patch("apple_mail_mcp.server.mail")
+    def test_returns_selected_messages(self, mock_mail: MagicMock) -> None:
+        """Test successful retrieval of selected messages."""
+        mock_mail.get_selected_messages.return_value = [
+            {
+                "id": "12345",
+                "subject": "Hello",
+                "sender": "alice@example.com",
+                "date_received": "Mon Jan 1 2024",
+                "read_status": True,
+                "flagged": False,
+                "content": "Hi there",
+            }
+        ]
+
+        result = get_selected_messages()
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["messages"][0]["id"] == "12345"
+        mock_mail.get_selected_messages.assert_called_once_with(include_content=True)
+
+    @patch("apple_mail_mcp.server.mail")
+    def test_returns_empty_when_nothing_selected(self, mock_mail: MagicMock) -> None:
+        """Test response when no message is selected."""
+        mock_mail.get_selected_messages.return_value = []
+
+        result = get_selected_messages()
+
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["messages"] == []
+
+    @patch("apple_mail_mcp.server.mail")
+    def test_without_content(self, mock_mail: MagicMock) -> None:
+        """Test fetching selected messages without body content."""
+        mock_mail.get_selected_messages.return_value = [
+            {
+                "id": "99",
+                "subject": "Test",
+                "sender": "b@example.com",
+                "date_received": "Tue Jan 2 2024",
+                "read_status": False,
+                "flagged": False,
+                "content": "",
+            }
+        ]
+
+        result = get_selected_messages(include_content=False)
+
+        assert result["success"] is True
+        mock_mail.get_selected_messages.assert_called_once_with(include_content=False)
+
+    @patch("apple_mail_mcp.server.mail")
+    def test_handles_applescript_error(self, mock_mail: MagicMock) -> None:
+        """Test error handling when AppleScript fails."""
+        from apple_mail_mcp.exceptions import MailAppleScriptError
+
+        mock_mail.get_selected_messages.side_effect = MailAppleScriptError("timeout")
+
+        result = get_selected_messages()
+
+        assert result["success"] is False
+        assert "error" in result

--- a/tests/unit/test_server_selected.py
+++ b/tests/unit/test_server_selected.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from apple_mail_mcp.server import get_selected_messages
 
 


### PR DESCRIPTION
# Pull Request

## Description
Brief description of what this PR does.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement
- [ ] Performance improvement

## Related Issues

## Changes Made
- Change 1
Added new MCP tool: get_selected_messages
 Retrieves whichever message(s) are currently highlighted in Apple Mail at the time of the call.
 

## Testing
- [x] All existing tests pass (`pytest tests/unit/ -v`)
- [x] Added new tests for new functionality
- [x] Tested manually with Apple Mail
- [x] Code review agent passes (score >= 70)

## Code Quality Checklist
- [x] Code follows project style guidelines
- [x] Added docstrings for new functions
- [x] Updated documentation (README, TOOLS.md, etc.)
- [x] No new security vulnerabilities introduced
- [x] Input validation added where needed
- [x] Error handling is comprehensive

## Screenshots (if applicable)


## Additional Notes
Ran mypy and ruff check src/ tests/ and found no new issues introduced by this change.