### PR TITLE
Sanitize message IDs before AppleScript interpolation

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -1159,8 +1159,11 @@ class AppleMailConnector:
 
         status = "true" if read else "false"
 
-        # Build list of IDs
-        id_list = ", ".join(message_ids)
+        # Build list of IDs (sanitize and escape each)
+        id_list = ", ".join(
+            f'"{escape_applescript_string(sanitize_input(mid))}"'
+            for mid in message_ids
+        )
 
         script = f"""
         tell application "Mail"
@@ -1699,7 +1702,10 @@ class AppleMailConnector:
 
         account_clause = applescript_account_clause(account)
         mailbox_safe = escape_applescript_string(sanitize_input(destination_mailbox))
-        id_list = ", ".join(message_ids)
+        id_list = ", ".join(
+            f'"{escape_applescript_string(sanitize_input(mid))}"'
+            for mid in message_ids
+        )
 
         if gmail_mode:
             # Gmail requires copy + delete approach to properly handle labels
@@ -1782,7 +1788,10 @@ class AppleMailConnector:
 
         flag_index = get_flag_index(flag_color)
         flagged_status = "true" if flag_color != "none" else "false"
-        id_list = ", ".join(message_ids)
+        id_list = ", ".join(
+            f'"{escape_applescript_string(sanitize_input(mid))}"'
+            for mid in message_ids
+        )
 
         script = f"""
         tell application "Mail"
@@ -1893,7 +1902,10 @@ class AppleMailConnector:
                 "Maximum is 100 without skip_bulk_check=True"
             )
 
-        id_list = ", ".join(message_ids)
+        id_list = ", ".join(
+            f'"{escape_applescript_string(sanitize_input(mid))}"'
+            for mid in message_ids
+        )
 
         if permanent:
             # Permanent delete (not recommended, requires extra caution)
@@ -1967,6 +1979,7 @@ class AppleMailConnector:
         """
         from .utils import sanitize_input
 
+        message_id_safe = escape_applescript_string(sanitize_input(message_id))
         body_safe = escape_applescript_string(sanitize_input(body))
         reply_type = "reply to all" if reply_all else "reply"
 
@@ -1974,12 +1987,12 @@ class AppleMailConnector:
         # We'll create a reply and set its content
         script = f"""
         tell application "Mail"
-            set idList to {{"{message_id}"}}
+            set idList to {{"{message_id_safe}"}}
 
             repeat with acc in accounts
                 repeat with mb in mailboxes of acc
                     try
-                        set origMsg to first message of mb whose id is "{message_id}"
+                        set origMsg to first message of mb whose id is "{message_id_safe}"
 
                         -- Create reply message
                         set replyMsg to {reply_type} origMsg
@@ -2052,6 +2065,7 @@ class AppleMailConnector:
                 if not validate_email(email):
                     raise ValueError(f"Invalid BCC email address: {email}")
 
+        message_id_safe = escape_applescript_string(sanitize_input(message_id))
         body_safe = escape_applescript_string(sanitize_input(body))
         to_list = format_applescript_list(to)
         cc_list = format_applescript_list(cc) if cc else '""'
@@ -2062,7 +2076,7 @@ class AppleMailConnector:
             repeat with acc in accounts
                 repeat with mb in mailboxes of acc
                     try
-                        set origMsg to first message of mb whose id is "{message_id}"
+                        set origMsg to first message of mb whose id is "{message_id_safe}"
 
                         -- Create forward message
                         set fwdMsg to forward origMsg

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -1036,7 +1036,7 @@ class AppleMailConnector:
             repeat with acc in accounts
                 repeat with mb in mailboxes of acc
                     try
-                        set msg to first message of mb whose id is {message_id_safe}
+                        set msg to first message of mb whose id is "{message_id_safe}"
                         {content_clause}
 
                         set resultData to {{|id|:(id of msg as text), |subject|:(subject of msg), |sender|:(sender of msg), |date_received|:(date received of msg as text), |read_status|:(read status of msg), |flagged|:(flagged status of msg), |content|:msgContent}}
@@ -1311,7 +1311,7 @@ class AppleMailConnector:
             repeat with acc in accounts
                 repeat with mb in mailboxes of acc
                     try
-                        set msg to first message of mb whose id is {message_id_safe}
+                        set msg to first message of mb whose id is "{message_id_safe}"
                         set attList to mail attachments of msg
 
                         set resultData to {{}}
@@ -1439,7 +1439,7 @@ class AppleMailConnector:
             repeat with acc in accounts
                 repeat with mb in mailboxes of acc
                     try
-                        set msg to first message of mb whose id is {message_id_safe}
+                        set msg to first message of mb whose id is "{message_id_safe}"
                         set anchorInReplyTo to ""
                         set anchorRefs to ""
                         try
@@ -1648,7 +1648,7 @@ class AppleMailConnector:
             repeat with acc in accounts
                 repeat with mb in mailboxes of acc
                     try
-                        set msg to first message of mb whose id is {message_id_safe}
+                        set msg to first message of mb whose id is "{message_id_safe}"
                         set attList to {index_filter} mail attachments of msg
                         set saveCount to 0
 

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1847,8 +1847,10 @@ class TestAppleMailConnector:
         # All record keys must be |quoted| per the v0.4.1 selector-collision rule.
         assert "|rfc_message_id|:(message id of msg)" in anchor_script
         assert "|subject|:(subject of msg)" in anchor_script
-        # Anchor lookup iterates by internal id.
-        assert "whose id is 12345" in anchor_script
+        # Anchor lookup iterates by internal id; id must be wrapped in
+        # AppleScript string quotes (otherwise UUID-style ids tokenize
+        # as invalid syntax — see TestWhoseIdQuoting).
+        assert 'whose id is "12345"' in anchor_script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_get_thread_anchor_not_found_raises(
@@ -2027,6 +2029,58 @@ class TestMessageIdAppleScriptInjection:
         )
         script = mock_run.call_args[0][0]
         assert 'whose id is "craft\\"ed-id"' in script
+
+
+class TestWhoseIdQuoting:
+    """Regression guards for #86: `whose id is X` must wrap X in quotes
+    even when X is already escape_applescript_string'd.
+
+    Without quotes, AppleScript chokes on UUID-style ids like
+    'CF7C3761-...@icloud.com' because the dashes/dots/@ get parsed as
+    syntax (dash = subtraction, @ = bare identifier, etc.).
+    """
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_message_quotes_id_in_whose(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = '{"id":"x","subject":"s","sender":"","date_received":"","read_status":false,"flagged":false,"content":""}'
+        uuid_id = "CF7C3761-C190-40BA-B94E-3EBC321980ED@icloud.com"
+        connector.get_message(uuid_id, include_content=False)
+        script = mock_run.call_args[0][0]
+        assert f'whose id is "{uuid_id}"' in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_attachments_quotes_id_in_whose(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "[]"
+        uuid_id = "CF7C3761-C190-40BA-B94E-3EBC321980ED@icloud.com"
+        connector.get_attachments(uuid_id)
+        script = mock_run.call_args[0][0]
+        assert f'whose id is "{uuid_id}"' in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_save_attachments_quotes_id_in_whose(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "[]"
+        uuid_id = "CF7C3761-C190-40BA-B94E-3EBC321980ED@icloud.com"
+        # save_attachments takes a Path (uses .exists()).
+        import tempfile
+        from pathlib import Path
+        with tempfile.TemporaryDirectory() as td:
+            connector.save_attachments(uuid_id, Path(td))
+        # Multiple AppleScript calls may happen; check at least one
+        # contained the quoted-id pattern.
+        scripts = [c[0][0] for c in mock_run.call_args_list]
+        assert any(f'whose id is "{uuid_id}"' in s for s in scripts), (
+            f"expected quoted id in one of the scripts: {scripts}"
+        )
 
 
 class TestWrapAsJsonScript:

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1941,6 +1941,94 @@ class TestAppleMailConnector:
         assert 'subject contains "Re:' not in candidate_script
 
 
+class TestMessageIdAppleScriptInjection:
+    """Regression guards for AppleScript-injection via message IDs.
+
+    Two bug families this class protects against:
+
+    1. Multi-id list methods (mark_as_read, move_messages, flag_message,
+       delete_messages) used to do `", ".join(message_ids)` directly into
+       an AppleScript list literal — a crafted id containing a `"` could
+       escape the list and inject arbitrary script.
+
+    2. Single-id `whose id is "..."` clauses used to interpolate the raw
+       message_id without escaping in reply_to_message and forward_message.
+
+    See PR #34 (martparve) for the original report.
+    """
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_mark_as_read_quotes_and_escapes_each_id(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "1"
+        # Crafted id with a quote and backslash: a naive join would
+        # break out of the list literal.
+        connector.mark_as_read(['abc"; do evil; --', "back\\slash"])
+        script = mock_run.call_args[0][0]
+        # Both ids appear inside their own quoted string.
+        assert '"abc\\"; do evil; --"' in script
+        assert '"back\\\\slash"' in script
+        # The injected `do evil` must NOT appear unquoted at the script level
+        # (i.e., outside the list).
+        assert "{\"abc\\\"; do evil; --\", \"back\\\\slash\"}" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_move_messages_quotes_and_escapes_each_id(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "1"
+        connector.move_messages(['evil"; foo', "ok"], "Gmail", "Archive")
+        script = mock_run.call_args[0][0]
+        assert '"evil\\"; foo"' in script
+        assert '"ok"' in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_flag_message_quotes_and_escapes_each_id(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "1"
+        connector.flag_message(['evil"', "ok"], "red")
+        script = mock_run.call_args[0][0]
+        assert '"evil\\""' in script
+        assert '"ok"' in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_delete_messages_quotes_and_escapes_each_id(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "1"
+        connector.delete_messages(['evil"', "ok"])
+        script = mock_run.call_args[0][0]
+        assert '"evil\\""' in script
+        assert '"ok"' in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_reply_to_message_escapes_id(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "msg-id"
+        connector.reply_to_message('craft"ed-id', body="hi")
+        script = mock_run.call_args[0][0]
+        # Quoted and escaped — no raw quote breaks out of the string.
+        assert 'whose id is "craft\\"ed-id"' in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_forward_message_escapes_id(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "msg-id"
+        connector.forward_message(
+            'craft"ed-id', to=["a@example.com"], body="hi"
+        )
+        script = mock_run.call_args[0][0]
+        assert 'whose id is "craft\\"ed-id"' in script
+
+
 class TestWrapAsJsonScript:
     def test_wrapper_contains_framework_directive(self) -> None:
         script = _wrap_as_json_script('tell application "Mail"\n    set resultData to {}\nend tell')


### PR DESCRIPTION
## Summary

- Several connector methods (`mark_as_read`, `move_messages`, `flag_message`, `delete_messages`, `reply_to_message`, `forward_message`) interpolated message IDs directly into AppleScript without sanitization or escaping, enabling potential code injection
- Applied the same `sanitize_input()` + `escape_applescript_string()` pattern already used in `get_message`, `get_attachments`, and `save_attachments`

## Details

The `_run_applescript` method passes scripts to `osascript` via stdin. Methods like `mark_as_read` joined raw message IDs into AppleScript list literals (`set idList to {id1, id2}`), and `reply_to_message`/`forward_message` interpolated the message ID directly into `whose id is "..."` clauses. A crafted message ID could break out of the AppleScript context.

The fix wraps each ID with `escape_applescript_string(sanitize_input(mid))` and quotes them as strings in the AppleScript list, matching the existing safe pattern used elsewhere in the connector.

## Test plan

- [x] All 99 unit tests pass
- [x] No new lint errors
- [ ] Integration test with real Mail.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)