### PR TITLE
Fix search_messages for Exchange accounts

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -205,16 +205,18 @@ class AppleMailConnector:
             status = "true" if read_status else "false"
             conditions.append(f"read status is {status}")
 
-        whose_clause = " and ".join(conditions) if conditions else "true"
-        limit_clause = f"items 1 thru {limit} of" if limit else ""
+        whose_clause = " whose " + " and ".join(conditions) if conditions else ""
+        limit_counter_init = "\n            set msgCount to 0" if limit else ""
+        limit_counter_incr = (f"\n                set msgCount to msgCount + 1"
+                              f"\n                if msgCount >= {limit} then exit repeat") if limit else ""
 
         script = f"""
         tell application "Mail"
             set accountRef to account "{account_safe}"
             set mailboxRef to mailbox "{mailbox_safe}" of accountRef
-            set matchedMessages to {limit_clause} (messages of mailboxRef whose {whose_clause})
+            set matchedMessages to (every message of mailboxRef{whose_clause})
 
-            set resultList to {{}}
+            set resultList to {{}}{limit_counter_init}
             repeat with msg in matchedMessages
                 set msgId to id of msg as text
                 set msgSubject to subject of msg
@@ -223,7 +225,7 @@ class AppleMailConnector:
                 set msgRead to read status of msg
 
                 set msgData to msgId & "|" & msgSubject & "|" & msgSender & "|" & msgDate & "|" & msgRead
-                set end of resultList to msgData
+                set end of resultList to msgData{limit_counter_incr}
             end repeat
 
             -- Join with newlines

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -124,7 +124,7 @@ class TestAppleMailConnector:
         assert 'sender contains "john@example.com"' in call_args
         assert 'subject contains "meeting"' in call_args
         assert "read status is false" in call_args
-        assert "items 1 thru 10" in call_args
+        assert "if msgCount >= 10 then exit repeat" in call_args
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_get_message(


### PR DESCRIPTION
## Summary

- No-filter searches generated invalid AppleScript (`whose true`) causing "Illegal comparison or logical" errors
- `items 1 thru N of` syntax failed on Exchange accounts with "Can't get items" errors
- Replaced with `every message of mailboxRef` (no `whose` when unfiltered) and counter-based `exit repeat` for limiting results

## Details

Two bugs in `search_messages` made it unusable with Exchange accounts:

1. When no filters (sender, subject, read_status) were provided, `whose_clause` defaulted to the string `"true"`, producing `messages of mailboxRef whose true` which is invalid AppleScript. Fix: omit the `whose` clause entirely when no conditions exist.

2. The `items 1 thru N of (messages of mailboxRef whose ...)` syntax for limiting results is not supported by Exchange mailboxes. Fix: fetch all matching messages and use a counter with `exit repeat` inside the `repeat with` loop, which works across all account types (Exchange, iCloud, Gmail/IMAP).

Updated the unit test assertion to match the new limit mechanism.

## Test plan

- [x] All 99 unit tests pass (including updated limit assertion)
- [x] No new lint errors
- [x] Manually tested against real Exchange account via MCP
- [ ] Test against iCloud/IMAP accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)