### PR TITLE
fix: iterative limit in search_messages for IMAP compatibility

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -205,16 +205,19 @@ class AppleMailConnector:
             conditions.append(f"read status is {status}")
 
         whose_clause = " and ".join(conditions) if conditions else "true"
-        limit_clause = f"items 1 thru {limit} of" if limit else ""
+        limit_val = int(limit) if limit else 0
 
         script = f"""
         tell application "Mail"
             set accountRef to account "{account_safe}"
             set mailboxRef to mailbox "{mailbox_safe}" of accountRef
-            set matchedMessages to {limit_clause} (messages of mailboxRef whose {whose_clause})
+            set matchedMessages to (messages of mailboxRef whose {whose_clause})
 
             set resultList to {{}}
+            set maxCount to {limit_val}
+            set countSoFar to 0
             repeat with msg in matchedMessages
+                if maxCount > 0 and countSoFar >= maxCount then exit repeat
                 set msgId to id of msg as text
                 set msgSubject to subject of msg
                 set msgSender to sender of msg
@@ -223,6 +226,7 @@ class AppleMailConnector:
 
                 set msgData to msgId & "|" & msgSubject & "|" & msgSender & "|" & msgDate & "|" & msgRead
                 set end of resultList to msgData
+                set countSoFar to countSoFar + 1
             end repeat
 
             -- Join with newlines


### PR DESCRIPTION
Closes #46.

## Problem

`items 1 thru N of (messages of mailboxRef whose X)` throws AppleScript `-1728` on IMAP accounts (iCloud confirmed). Mail.app doesn't fully materialize remote message references, so the lazy list can't be sliced.

## Fix

Replace the slice with an in-loop counter:

```applescript
set matchedMessages to (messages of mailboxRef whose X)
set countSoFar to 0
repeat with msg in matchedMessages
  if maxCount > 0 and countSoFar >= maxCount then exit repeat
  …
  set countSoFar to countSoFar + 1
end repeat
```

`limit=0` (or unset) means no cap. Behavior for local mailboxes is unchanged since the `whose` filter still runs server-side.

## Test

Verified against an iCloud INBOX (~10k messages, 985 unread):

```python
search_messages(account="iCloud", sender_contains="apple.com", subject_contains="receipt", limit=10)
# → 10 results, no error
```

Existing unit tests still pass.

## Notes

- No API change.
- No new dependencies.