### PR TITLE
Raise coverage threshold to 90% and refresh stale docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Mail via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.3.0 | **Tests:** 99 unit | **Coverage:** 52%
+**Version:** v0.3.0 | **Tests:** 221 unit | **Coverage:** 94%
 
 ## Commands
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         continue-on-error: true
 
       - name: Unit tests
-        run: uv run pytest tests/ -m "not integration and not e2e and not benchmark" -v --cov=apple_mail_mcp --cov-report=term-missing --cov-fail-under=60
+        run: uv run pytest tests/ -m "not integration and not e2e and not benchmark" -v --cov=apple_mail_mcp --cov-report=term-missing --cov-fail-under=90
         timeout-minutes: 5
 
       - name: Complexity check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ make test-integration  # Real Mail.app tests
 
 - Unit tests mock at `_run_applescript()` boundary
 - Integration tests run against real Mail.app (opt-in via `--run-integration`)
-- Coverage enforced: `fail_under = 60` (target: 90%)
+- Coverage enforced: `fail_under = 90`
 
 ## Release Process
 

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -72,7 +72,6 @@ Each test file follows:
 
 ## Coverage
 
-- Current: ~52%
 - Target: 90%
-- Enforced: `fail_under = 60` in pyproject.toml
-- Primary gap: `server.py` (0% — needs tool-level tests)
+- Enforced: `fail_under = 90` in pyproject.toml
+- Run `make coverage` for the current report.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ markers = [
 source = ["apple_mail_mcp"]
 
 [tool.coverage.report]
-fail_under = 60
+fail_under = 90
 show_missing = true
 exclude_lines = [
     "if __name__ == .__main__.:",


### PR DESCRIPTION
## Summary
- Overall coverage is already 94% (up from 52% when #20 was filed); PR #43 closed the primary gap by covering `server.py`.
- Bumps `fail_under` from 60 to 90 in both `pyproject.toml` and the CI workflow so the enforced floor matches reality and leaves a ~4-point buffer above the current 94%.
- Refreshes stale 52% / "99 unit tests" / "server.py 0%" references in `CLAUDE.md`, `TESTING.md`, and `CONTRIBUTING.md`.

Closes #20.

## Test plan
- [x] `make coverage` — TOTAL 94.07%, passes new 90% floor
- [x] `make check-all` — all checks passed (lint, typecheck, 221 unit tests, complexity, version sync, parity)
- [ ] GitHub Actions `Tests` workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)