### PR TITLE
Emit JSON from AppleScript instead of pipe-delimited strings (#23)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -83,7 +83,7 @@ CHANGELOG.md is only updated on release branches, never on feature branches.
 Load these skills when working in their domains:
 
 - **release** — Full release workflow: milestone check, version bump, changelog, validation, tagging, PR
-- **applescript-mail** — Apple Mail AppleScript patterns, quirks, workarounds, pipe-delimited parsing
+- **applescript-mail** — Apple Mail AppleScript patterns, quirks, workarounds, JSON emission via ASObjC
 - **api-design** — Tool design philosophy, decision tree for new tools
 - **integration-testing** — Real Mail.app testing, why mocks miss AppleScript bugs
 - **performance-patterns** — Operation timings, `whose` clause optimization, batch patterns, Gmail notes

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,7 +40,7 @@ make coverage              # Coverage report
 
 ## AppleScript Gotchas
 
-**Pipe-delimited output parsing:** AppleScript returns results as `field1|field2|field3` with newline-separated records. Fragile — breaks if any field contains `|`. Known limitation, documented in issue tracker.
+**JSON output from AppleScript:** Scripts emit JSON via ASObjC + `NSJSONSerialization` (wrap with `_wrap_as_json_script`, parse with `parse_applescript_json`). Always quote the `name` record key as `|name|:` — the bare form is silently dropped during NSDictionary conversion. Coerce `missing value` to safe defaults (`{}` / `0`) before serializing. See applescript-mail skill for details.
 
 **Gmail mode:** Gmail's label-based system doesn't support standard IMAP move. The `move_messages` tool has a `gmail_mode` parameter that uses copy+delete instead of move.
 

--- a/.claude/skills/applescript-mail/SKILL.md
+++ b/.claude/skills/applescript-mail/SKILL.md
@@ -1,28 +1,25 @@
 ---
 name: applescript-mail
-description: Use when writing, modifying, or debugging ANY AppleScript that interacts with Apple Mail. Also use when encountering AppleScript errors, unexpected Mail.app behavior, when adding new connector methods, or when debugging pipe-delimited output parsing. Covers string escaping, attachment handling, Gmail compatibility, message ID lookup patterns, and known Mail.app automation limitations.
+description: Use when writing, modifying, or debugging ANY AppleScript that interacts with Apple Mail. Also use when encountering AppleScript errors, unexpected Mail.app behavior, when adding new connector methods, or when debugging JSON output from ASObjC. Covers string escaping, attachment handling, Gmail compatibility, message ID lookup patterns, NSJSONSerialization gotchas, and known Mail.app automation limitations.
 ---
 
 # AppleScript + Apple Mail Patterns
 
-## Critical: Pipe-Delimited Output Parsing
+## Emitting JSON from AppleScript
 
-Apple Mail MCP returns AppleScript results as pipe-delimited strings with newline-separated records:
+Scripts emit JSON via ASObjC + `NSJSONSerialization` (not pipe-delimited text). Use the `_wrap_as_json_script(body)` helper in `mail_connector.py` and parse responses with `parse_applescript_json(result)` from `utils.py`.
 
+**Tell-block contract:** the body passed to `_wrap_as_json_script` must contain a `tell application "Mail" ... end tell` block and assign the final value to a variable named `resultData` (list, record, or scalar).
+
+**Record key gotcha — always quote `name`:** Use `|name|:(name of acc)`, never `name:(name of acc)`. The bare form collides with NSObject's `name` selector and the key is silently dropped during NSDictionary conversion, leaving records without their name field.
+
+**`missing value` gotcha:** `NSJSONSerialization` rejects `missing value`. For optional properties (e.g., `email addresses` of an account with none, `unread count` on some mailboxes), coerce before building the record:
 ```applescript
--- AppleScript returns:
--- "12345|Subject Here|sender@example.com|Mon Jan 1 2024|false"
-
--- Python parses:
-parts = line.split("|")
-# parts[0] = message_id, parts[1] = subject, etc.
+set accEmails to email addresses of acc
+if accEmails is missing value then set accEmails to {}
 ```
 
-**Known fragility:** If ANY field contains a `|` character (common in email subjects), parsing breaks silently. There is no escaping mechanism. This is the project's biggest technical debt.
-
-**Workaround:** Fields are positional. Always check `len(parts) >= expected_count` before accessing. Log warnings on unexpected field counts.
-
-**Future fix:** Migrate to JSON output with inline helpers (duplicated per script — AppleScript has no modules, same pattern as OmniFocus MCP).
+**Error propagation:** Do NOT wrap the tell-body in `try / on error` when you want typed exceptions (`MailAccountNotFoundError`, `MailMessageNotFoundError`, etc.). Let AppleScript errors bubble via stderr — `_run_applescript` maps them to the right exception type.
 
 ## Gmail Label-Based System
 

--- a/.claude/skills/integration-testing/SKILL.md
+++ b/.claude/skills/integration-testing/SKILL.md
@@ -11,7 +11,7 @@ Unit tests mock `_run_applescript()` and test Python logic only. They CANNOT cat
 - AppleScript syntax errors
 - Variable naming conflicts in AppleScript
 - Mail.app API behavior differences between versions
-- Pipe-delimited parsing issues with real email content
+- Silently-dropped record keys from NSJSONSerialization (e.g., `name`, `id`, `size` selector collisions)
 - Gmail-specific behavior differences
 - Timeout issues with real mailbox sizes
 

--- a/.claude/skills/performance-patterns/SKILL.md
+++ b/.claude/skills/performance-patterns/SKILL.md
@@ -65,7 +65,7 @@ Message ID lookup is O(accounts x mailboxes) when searching globally. Always acc
 ## Anti-Patterns
 
 - **Repeated subprocess calls in loops** — Build one script, execute once
-- **Fetching all properties when only some are needed** — The pipe-delimited format fetches a fixed set; future JSON migration should fetch selectively
+- **Fetching all properties when only some are needed** — Scripts currently fetch a fixed set of fields; when adding a new field, consider whether every caller needs it
 - **Not using `whose` clauses** — Manual filtering in Python transfers all data first
 - **Default timeout too low for large operations** — Increase from 60s for bulk operations on large mailboxes
 

--- a/docs/plans/2026-04-18-json-applescript-output-design.md
+++ b/docs/plans/2026-04-18-json-applescript-output-design.md
@@ -1,0 +1,147 @@
+# Replace pipe-delimited AppleScript output with JSON
+
+**Issue:** #23
+**Date:** 2026-04-18
+**Status:** Approved
+
+## Context
+
+Apple Mail MCP's connector communicates with AppleScript by returning pipe-delimited strings and parsing them in Python with `line.split("|")`. Every field is positional. If any field value contains `|` — common in email subjects and bodies — parsing breaks silently with no error. The project documents this as its biggest technical debt (see `.claude/skills/applescript-mail/SKILL.md`).
+
+Five methods in `src/apple_mail_mcp/mail_connector.py` are affected:
+
+| Method | Current state |
+|---|---|
+| `search_messages` | 5 fields, pipe-delimited, working but fragile |
+| `get_message` | 7 fields, pipe-delimited (maxsplit=6), working but fragile |
+| `get_attachments` | 4 fields, pipe-delimited, working but fragile |
+| `list_accounts` | Half-baked pseudo-JSON, parsed as `[{"raw": str}]` — effectively broken |
+| `list_mailboxes` | Returns raw AppleScript record string as `[{"raw": str}]` with a TODO — effectively broken |
+
+## Non-goals
+
+- Changing the MCP tool return shapes exposed via `server.py`. The public API keeps working; only the internal connector → tool handoff changes.
+- Changing error propagation. `ERROR:` prefix strings from AppleScript keep their meaning.
+- Fixing other known AppleScript quirks (Gmail move, date format normalization). Tracked separately.
+
+## Design
+
+### AppleScript pattern
+
+Each refactored script has this shape:
+
+```applescript
+use framework "Foundation"
+use scripting additions
+
+tell application "Mail"
+    try
+        -- build a native AppleScript list or record with descriptive keys
+        set resultData to ...
+    on error errMsg
+        return "ERROR: " & errMsg
+    end try
+end tell
+
+-- NSJSONSerialization lives outside the tell block for stability
+set jsonData to (current application's NSJSONSerialization's ¬
+    dataWithJSONObject:resultData options:0 |error|:(missing value))
+return (current application's NSString's alloc()'s ¬
+    initWithData:jsonData encoding:4) as text
+```
+
+Verified via osascript smoke test: AppleScript records auto-bridge to NSDictionary with property names as JSON keys; NSJSONSerialization handles quote, apostrophe, pipe, backslash, Unicode, integer, and boolean escaping correctly. Test input `{myName:"Alice\"O'Brien", myAge:30, isAdmin:true}` produced `{"myAge":30,"myName":"Alice\"O'Brien","isAdmin":true}`.
+
+### Python-side wrapper
+
+To keep scripts DRY, add a single helper in `mail_connector.py`:
+
+```python
+def _wrap_as_json_script(body: str) -> str:
+    """Wrap a tell-block body with ASObjC imports + NSJSONSerialization epilogue.
+
+    The `body` must assign the result to a variable named `resultData` inside
+    a `tell application "Mail"` block, and return `"ERROR: ..."` on failure
+    via `try/on error`.
+    """
+    return f'''
+    use framework "Foundation"
+    use scripting additions
+
+    {body}
+
+    set jsonData to (current application's NSJSONSerialization's dataWithJSONObject:resultData options:0 |error|:(missing value))
+    return (current application's NSString's alloc()'s initWithData:jsonData encoding:4) as text
+    '''
+```
+
+Each of the 5 methods uses this helper, writing only the Mail-specific middle.
+
+### Python-side parse
+
+New utility in `src/apple_mail_mcp/utils.py`:
+
+```python
+def parse_applescript_json(result: str) -> Any:
+    """Parse JSON emitted by an AppleScript helper, or raise on ERROR: prefix."""
+    result = result.strip()
+    if result.startswith("ERROR:"):
+        raise MailAppleScriptError(result[len("ERROR:"):].strip())
+    return json.loads(result)
+```
+
+Each method's body becomes:
+
+```python
+script = _wrap_as_json_script(tell_body)
+result = self._run_applescript(script)
+return parse_applescript_json(result)  # list or dict
+```
+
+### Field naming
+
+AppleScript property names become JSON keys become Python dict keys. Use `snake_case` throughout: `read_status`, `mime_type`, `unread_count`, `email_addresses`, `date_received`. AppleScript accepts these as record property names.
+
+### Per-method output shapes
+
+| Method | Return type | Keys |
+|---|---|---|
+| `list_accounts` | `list[dict]` | `name`, `email_addresses` (list of str) |
+| `list_mailboxes` | `list[dict]` | `name`, `unread_count` |
+| `search_messages` | `list[dict]` | `id`, `subject`, `sender`, `date_received`, `read_status` |
+| `get_message` | `dict` | `id`, `subject`, `sender`, `date_received`, `read_status`, `flagged`, `content` |
+| `get_attachments` | `list[dict]` | `name`, `mime_type`, `size`, `downloaded` |
+
+### Error handling
+
+Unchanged at the boundary. `tell` blocks have `try/on error errMsg … return "ERROR: " & errMsg`. `parse_applescript_json` detects the prefix. The existing typed-exception mapping in `_run_applescript()` (account-not-found, mailbox-not-found, message-not-found) continues to run on stderr before parsing ever sees the result.
+
+### Testing
+
+- **Unit tests:** Update 3 existing mocks (2 in `tests/unit/test_mail_connector.py`, 1 in `tests/unit/test_attachments.py`) from pipe-delimited strings to JSON. Add tests for `list_accounts` and `list_mailboxes` now that they return structured data.
+- **New unit tests:** `tests/unit/test_utils.py` gains cases for `parse_applescript_json`: valid JSON, `ERROR:` prefix raises `MailAppleScriptError`, malformed JSON raises `json.JSONDecodeError`, whitespace handling.
+- **Integration tests:** Existing `list_mailboxes` and `search_messages` tests already exist. Add 3 more: `list_accounts`, `get_message`, `get_attachments`. These prove the ASObjC pattern produces valid JSON against real Mail.app.
+
+### Migration strategy
+
+Big-bang in one PR. 5 scripts, 5 parse sites, 3 updated mocks, 2 new unit methods, 3 new integration tests. Per-script migration would double the test-fixture churn for no benefit.
+
+### Backwards compatibility
+
+The server layer (`server.py`) wraps connector returns into `{"success": True, "messages": [...]}` etc. The connector's internal return shape changes (from `{"raw": str}` for `list_accounts`/`list_mailboxes`, and from pipe-split tuples for the other three, to proper dicts), which means:
+
+- `server.py` callers that previously did `[{"raw": ...}]` workarounds get deleted.
+- MCP tool public shapes gain real fields for `list_accounts` and `list_mailboxes` (they were unusable before). This is an improvement, not a break — no caller was relying on the `"raw"` field.
+
+## Verification
+
+1. `make test` — all unit tests pass; coverage ≥ 90%.
+2. `make test-e2e` — existing 20 e2e tests still pass (they mock the connector; no AppleScript change affects them).
+3. `make test-integration` — run locally against a real Mail.app account. The 5 refactored methods return well-typed data; no `{"raw": ...}` shapes remain.
+4. `make check-all` — lint, typecheck, complexity, parity all green.
+5. Manual smoke: hit each of the 5 methods via the MCP client and confirm structured output.
+
+## Follow-ups (out of scope)
+
+- Normalize `date_received` to ISO 8601. Currently each script emits the AppleScript default string format ("Friday, January 1, 2024 at 12:00:00 PM"). File a new issue.
+- Review other connector methods' return types for opportunities to tighten now that JSON is available — e.g., `send_email` returning the new message ID as a typed dict instead of a string.

--- a/docs/plans/2026-04-18-json-applescript-output.md
+++ b/docs/plans/2026-04-18-json-applescript-output.md
@@ -1,0 +1,893 @@
+# JSON AppleScript Output Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace pipe-delimited AppleScript output with JSON across all 5 affected connector methods, removing the project's biggest parsing-fragility bug.
+
+**Architecture:** Add a `parse_applescript_json()` helper in `utils.py` and a `_wrap_as_json_script()` helper in `mail_connector.py` that wraps a tell-block body with `use framework "Foundation"` + a trailing `NSJSONSerialization` encoding step. Each of the 5 methods builds a native AppleScript list/record of results, lets the wrapper serialize it, then Python-side calls `parse_applescript_json()`.
+
+**Tech Stack:** Python 3.10+, AppleScript with ASObjC (`use framework "Foundation"`), NSJSONSerialization, pytest.
+
+**Design doc:** [`docs/plans/2026-04-18-json-applescript-output-design.md`](./2026-04-18-json-applescript-output-design.md)
+
+---
+
+## Preflight
+
+**Verified (smoke test in the design doc):** `osascript` with `use framework "Foundation"` + `NSJSONSerialization's dataWithJSONObject:l options:0 |error|:(missing value)` correctly serializes an AppleScript `list of records` to JSON, handling embedded quotes (`\"`), pipes (literal), apostrophes (literal), booleans (`true`/`false`), and integers. No encoding library needed on the Python side beyond the stdlib `json` module.
+
+**Affected methods:**
+
+| Method | Line (approx) | Output shape after refactor |
+|---|---|---|
+| `list_accounts` | 86–126 | `list[dict]` with `name`, `email_addresses` |
+| `list_mailboxes` | 128–161 | `list[dict]` with `name`, `unread_count` |
+| `search_messages` | 163–255 | `list[dict]` with `id`, `subject`, `sender`, `date_received`, `read_status` |
+| `get_message` | 257–319 | `dict` with `id`, `subject`, `sender`, `date_received`, `read_status`, `flagged`, `content` |
+| `get_attachments` | 530–596 | `list[dict]` with `name`, `mime_type`, `size`, `downloaded` |
+
+**Existing mocks to update:**
+
+- `tests/unit/test_mail_connector.py:85` (`test_list_mailboxes` — currently asserts only `len(result) > 0` on nonsense string)
+- `tests/unit/test_mail_connector.py:95` (`test_search_messages_basic`)
+- `tests/unit/test_mail_connector.py:133` (`test_get_message`)
+- `tests/unit/test_attachments.py:120` (`test_get_attachments_list`)
+
+**No changes needed in `server.py`** — it passes connector return values through unchanged. The existing `list_mailboxes` tool docstring already documents the target shape (`{"name": "INBOX", "unread_count": 5}`), so this refactor aligns with the documented contract.
+
+---
+
+## Task 1: `parse_applescript_json` helper + tests
+
+**Files:**
+- Modify: `src/apple_mail_mcp/utils.py` (add function at end, with `import json` at top)
+- Modify: `tests/unit/test_utils.py` (add `TestParseAppleScriptJson` class)
+
+**Step 1: Write failing tests**
+
+At the end of `tests/unit/test_utils.py`, add:
+
+```python
+import json
+import pytest
+
+from apple_mail_mcp.exceptions import MailAppleScriptError
+from apple_mail_mcp.utils import parse_applescript_json
+
+
+class TestParseAppleScriptJson:
+    def test_parses_valid_json_list(self) -> None:
+        result = parse_applescript_json('[{"name": "INBOX", "unread_count": 5}]')
+        assert result == [{"name": "INBOX", "unread_count": 5}]
+
+    def test_parses_valid_json_object(self) -> None:
+        result = parse_applescript_json('{"id": "abc", "read_status": true}')
+        assert result == {"id": "abc", "read_status": True}
+
+    def test_parses_empty_list(self) -> None:
+        assert parse_applescript_json("[]") == []
+
+    def test_strips_whitespace(self) -> None:
+        assert parse_applescript_json("  [1,2,3]  \n") == [1, 2, 3]
+
+    def test_raises_on_error_prefix(self) -> None:
+        with pytest.raises(MailAppleScriptError, match="boom"):
+            parse_applescript_json("ERROR: boom")
+
+    def test_raises_on_error_prefix_with_whitespace(self) -> None:
+        with pytest.raises(MailAppleScriptError, match="something broke"):
+            parse_applescript_json("ERROR:   something broke  ")
+
+    def test_raises_on_malformed_json(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            parse_applescript_json("{not valid")
+```
+
+**Step 2: Run — expect fail**
+
+`uv run pytest tests/unit/test_utils.py::TestParseAppleScriptJson -v`
+
+Expected: all 7 tests fail with `ImportError` or `AttributeError` (function doesn't exist).
+
+**Step 3: Implement**
+
+At the top of `src/apple_mail_mcp/utils.py`, add `import json` next to the existing `import re`. At the bottom of the file, add:
+
+```python
+def parse_applescript_json(result: str) -> Any:
+    """Parse JSON emitted by an AppleScript helper, or raise on ERROR: prefix.
+
+    AppleScript scripts wrapped with _wrap_as_json_script return either:
+    - A JSON-serialized string (list, dict, or scalar), or
+    - "ERROR: <message>" when the tell-block catches an error.
+
+    Args:
+        result: Raw stdout from _run_applescript().
+
+    Returns:
+        Deserialized JSON (list, dict, str, int, bool, or None).
+
+    Raises:
+        MailAppleScriptError: If the result starts with "ERROR:".
+        json.JSONDecodeError: If the result is neither an error nor valid JSON.
+    """
+    from .exceptions import MailAppleScriptError
+
+    stripped = result.strip()
+    if stripped.startswith("ERROR:"):
+        raise MailAppleScriptError(stripped[len("ERROR:"):].strip())
+    return json.loads(stripped)
+```
+
+(The local import of `MailAppleScriptError` avoids a circular import — `utils.py` must not import from the connector layer.)
+
+**Step 4: Run — expect pass**
+
+`uv run pytest tests/unit/test_utils.py::TestParseAppleScriptJson -v`
+
+Expected: 7 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/apple_mail_mcp/utils.py tests/unit/test_utils.py
+git commit -m "Add parse_applescript_json helper for JSON-emitting scripts (#23)"
+```
+
+---
+
+## Task 2: `_wrap_as_json_script` helper on the connector
+
+**Files:**
+- Modify: `src/apple_mail_mcp/mail_connector.py` (add module-level function below the `AppleMailConnector` class, or as a private method — plan uses module-level for easier testing)
+
+**Step 1: Write the failing test**
+
+In `tests/unit/test_mail_connector.py` add a new class at the end:
+
+```python
+from apple_mail_mcp.mail_connector import _wrap_as_json_script
+
+
+class TestWrapAsJsonScript:
+    def test_wrapper_contains_framework_directive(self) -> None:
+        script = _wrap_as_json_script('tell application "Mail"\n    set resultData to {}\nend tell')
+        assert 'use framework "Foundation"' in script
+        assert "use scripting additions" in script
+
+    def test_wrapper_appends_json_serialization(self) -> None:
+        script = _wrap_as_json_script('tell application "Mail"\n    set resultData to {}\nend tell')
+        assert "NSJSONSerialization" in script
+        assert "dataWithJSONObject:resultData" in script
+
+    def test_wrapper_preserves_body(self) -> None:
+        body = 'tell application "Mail"\n    set resultData to {name:"INBOX"}\nend tell'
+        script = _wrap_as_json_script(body)
+        assert body in script
+```
+
+**Step 2: Run — expect fail**
+
+`uv run pytest tests/unit/test_mail_connector.py::TestWrapAsJsonScript -v`
+
+Expected: ImportError — `_wrap_as_json_script` doesn't exist yet.
+
+**Step 3: Implement**
+
+In `src/apple_mail_mcp/mail_connector.py`, after the `import` block and before `class AppleMailConnector`, add:
+
+```python
+def _wrap_as_json_script(body: str) -> str:
+    """Wrap a tell-block body with ASObjC imports and an NSJSONSerialization return.
+
+    The `body` must:
+      - Contain a `tell application "Mail" ... end tell` block.
+      - Assign the final result to an AppleScript variable named `resultData`
+        inside that tell block.
+      - Use `try/on error errMsg / return "ERROR: " & errMsg / end try` for
+        failure cases (the wrapper does not add a try/catch).
+
+    The wrapper:
+      - Prepends `use framework "Foundation"` and `use scripting additions`.
+      - After the tell block, serializes `resultData` via NSJSONSerialization
+        and returns the resulting NSString as text.
+
+    Args:
+        body: AppleScript tell-block source setting `resultData`.
+
+    Returns:
+        Full AppleScript source ready for osascript.
+    """
+    return (
+        'use framework "Foundation"\n'
+        "use scripting additions\n"
+        "\n"
+        f"{body}\n"
+        "\n"
+        "set jsonData to (current application's NSJSONSerialization's "
+        "dataWithJSONObject:resultData options:0 |error|:(missing value))\n"
+        "return (current application's NSString's alloc()'s "
+        "initWithData:jsonData encoding:4) as text\n"
+    )
+```
+
+**Step 4: Run — expect pass**
+
+`uv run pytest tests/unit/test_mail_connector.py::TestWrapAsJsonScript -v`
+
+Expected: 3 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/apple_mail_mcp/mail_connector.py tests/unit/test_mail_connector.py
+git commit -m "Add _wrap_as_json_script connector helper (#23)"
+```
+
+---
+
+## Task 3: Refactor `search_messages` to JSON
+
+**Files:**
+- Modify: `src/apple_mail_mcp/mail_connector.py:163-255`
+- Modify: `tests/unit/test_mail_connector.py:90-103` (`test_search_messages_basic`)
+
+**Step 1: Update the test mock first (RED)**
+
+Replace the mock line at `tests/unit/test_mail_connector.py:95`:
+
+```python
+# Before:
+mock_run.return_value = "12345|Test Subject|sender@example.com|Mon Jan 1 2024|false"
+
+# After:
+mock_run.return_value = (
+    '[{"id":"12345","subject":"Test Subject",'
+    '"sender":"sender@example.com","date_received":"Mon Jan 1 2024",'
+    '"read_status":false}]'
+)
+```
+
+Leave the assertions unchanged — they already check `id`, `subject`, `sender`, `read_status`.
+
+Add a second test that the old code couldn't handle (this is the raison d'être of the refactor):
+
+```python
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_handles_pipe_in_subject(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Subject containing '|' must not break parsing (the bug this refactor fixes)."""
+        mock_run.return_value = (
+            '[{"id":"abc","subject":"Q3 Report | Draft",'
+            '"sender":"boss@example.com","date_received":"Wed Feb 5 2025",'
+            '"read_status":true}]'
+        )
+        result = connector.search_messages("Gmail", "INBOX")
+        assert len(result) == 1
+        assert result[0]["subject"] == "Q3 Report | Draft"
+```
+
+**Step 2: Run — expect fail**
+
+`uv run pytest tests/unit/test_mail_connector.py::TestAppleMailConnector::test_search_messages_basic tests/unit/test_mail_connector.py::TestAppleMailConnector::test_search_messages_handles_pipe_in_subject -v`
+
+Expected: both fail. The existing code does `line.split("\n")` then `line.split("|")` on JSON text — shapes won't match.
+
+**Step 3: Refactor the method**
+
+Replace the body of `search_messages` in `src/apple_mail_mcp/mail_connector.py` (lines 210-255). The new script uses a native AppleScript list of records and `_wrap_as_json_script`:
+
+```python
+        tell_body = f"""
+        tell application "Mail"
+            try
+                set accountRef to account "{account_safe}"
+                set mailboxRef to mailbox "{mailbox_safe}" of accountRef
+                set matchedMessages to {limit_clause} (messages of mailboxRef whose {whose_clause})
+
+                set resultData to {{}}
+                repeat with msg in matchedMessages
+                    set msgRecord to {{id:(id of msg as text), subject:(subject of msg), sender:(sender of msg), date_received:(date received of msg as text), read_status:(read status of msg)}}
+                    set end of resultData to msgRecord
+                end repeat
+            on error errMsg
+                return "ERROR: " & errMsg
+            end try
+        end tell
+        """
+
+        script = _wrap_as_json_script(tell_body)
+        result = self._run_applescript(script)
+        return parse_applescript_json(result)
+```
+
+At the top of the file, add to the existing `from .utils import ...`:
+
+```python
+from .utils import escape_applescript_string, parse_applescript_json, sanitize_input
+```
+
+Remove the old `for line in result.split("\n")` parsing loop entirely.
+
+**Step 4: Run — expect pass**
+
+`uv run pytest tests/unit/test_mail_connector.py::TestAppleMailConnector::test_search_messages_basic tests/unit/test_mail_connector.py::TestAppleMailConnector::test_search_messages_handles_pipe_in_subject -v`
+
+Expected: 2 passed.
+
+Also run the `test_search_messages_with_filters` test — it asserts on the AppleScript string contents and may break because of the refactor:
+
+`uv run pytest tests/unit/test_mail_connector.py::TestAppleMailConnector::test_search_messages_with_filters -v`
+
+If it fails because the test asserts on a substring that's still present in the new script (e.g., `'sender contains "john@example.com"'`), it should pass unchanged. If an assertion was on a substring we removed (e.g., the old pipe-concatenation line), update the test to assert on the equivalent JSON-era substring instead.
+
+**Step 5: Commit**
+
+```bash
+git add src/apple_mail_mcp/mail_connector.py tests/unit/test_mail_connector.py
+git commit -m "Refactor search_messages to emit JSON (#23)"
+```
+
+---
+
+## Task 4: Refactor `get_message` to JSON
+
+**Files:**
+- Modify: `src/apple_mail_mcp/mail_connector.py:257-319`
+- Modify: `tests/unit/test_mail_connector.py:128-141` (`test_get_message`)
+
+**Step 1: Update the mock (RED)**
+
+Replace the mock at `tests/unit/test_mail_connector.py:133`:
+
+```python
+# Before:
+mock_run.return_value = "12345|Subject|sender@example.com|Mon Jan 1 2024|true|false|Message body"
+
+# After:
+mock_run.return_value = (
+    '{"id":"12345","subject":"Subject","sender":"sender@example.com",'
+    '"date_received":"Mon Jan 1 2024","read_status":true,"flagged":false,'
+    '"content":"Message body"}'
+)
+```
+
+Add a new pipe-tolerance test:
+
+```python
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_message_handles_pipe_in_content(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Body containing '|' must not break parsing."""
+        mock_run.return_value = (
+            '{"id":"99","subject":"x","sender":"a@b.com",'
+            '"date_received":"Mon Jan 1 2024","read_status":false,"flagged":false,'
+            '"content":"col1|col2|col3"}'
+        )
+        result = connector.get_message("99", include_content=True)
+        assert result["content"] == "col1|col2|col3"
+```
+
+**Step 2: Run — expect fail**
+
+Both tests fail (old code does `result.split("|", 6)`).
+
+**Step 3: Refactor**
+
+Replace the body of `get_message`:
+
+```python
+        content_clause = (
+            'set msgContent to content of msg'
+            if include_content
+            else 'set msgContent to ""'
+        )
+
+        tell_body = f"""
+        tell application "Mail"
+            try
+                repeat with acc in accounts
+                    repeat with mb in mailboxes of acc
+                        try
+                            set msg to first message of mb whose id is {message_id_safe}
+                            {content_clause}
+
+                            set resultData to {{id:(id of msg as text), subject:(subject of msg), sender:(sender of msg), date_received:(date received of msg as text), read_status:(read status of msg), flagged:(flagged status of msg), content:msgContent}}
+                            exit repeat
+                        end try
+                    end repeat
+                    if resultData is not missing value then exit repeat
+                end repeat
+
+                if resultData is missing value then
+                    return "ERROR: Message not found"
+                end if
+            on error errMsg
+                return "ERROR: " & errMsg
+            end try
+        end tell
+        """
+```
+
+**Important:** The original script relied on an `error "Message not found"` thrown from the outer AppleScript block after the loops — which `_run_applescript` would convert to stderr and raise `MailMessageNotFoundError` via the "Can't get message" string match (this may or may not match; verify). The new version explicitly returns `"ERROR: Message not found"` from the wrapper, which `parse_applescript_json` turns into `MailAppleScriptError`, not `MailMessageNotFoundError`.
+
+**Decision needed before committing:** preserve `MailMessageNotFoundError` semantics by either:
+- (a) Catching the AppleScript error inside the inner `try` as before, then after the loops `error "Message not found"` (keeps stderr path).
+- (b) Keeping `return "ERROR: Message not found"` and updating `parse_applescript_json` OR the method to raise `MailMessageNotFoundError` on that specific message.
+
+**Go with (a)** — minimal change to error surface:
+
+```python
+        tell_body = f"""
+        tell application "Mail"
+            set resultData to missing value
+            repeat with acc in accounts
+                repeat with mb in mailboxes of acc
+                    try
+                        set msg to first message of mb whose id is {message_id_safe}
+                        {content_clause}
+
+                        set resultData to {{id:(id of msg as text), subject:(subject of msg), sender:(sender of msg), date_received:(date received of msg as text), read_status:(read status of msg), flagged:(flagged status of msg), content:msgContent}}
+                        exit repeat
+                    end try
+                end repeat
+                if resultData is not missing value then exit repeat
+            end repeat
+
+            if resultData is missing value then
+                error "Message not found"
+            end if
+        end tell
+        """
+
+        script = _wrap_as_json_script(tell_body)
+        result = self._run_applescript(script)
+        return parse_applescript_json(result)
+```
+
+The `error` call propagates to stderr; `_run_applescript` maps "Can't get message" / "Message not found" to `MailMessageNotFoundError`. Verify by reading `_run_applescript` — if the error-string match is "Can't get message" exactly, change the AppleScript to `error "Can't get message: not found"` to hit the existing mapping. Otherwise update the mapping to also recognize "Message not found".
+
+Remove the old parsing block in Python (`parts = result.split("|", 6)` etc.).
+
+**Step 4: Run — expect pass**
+
+`uv run pytest tests/unit/test_mail_connector.py::TestAppleMailConnector -k "get_message" -v`
+
+Expected: existing `test_get_message_not_found` still raises `MailMessageNotFoundError` (via the stderr path); the refactored basic and pipe-tolerance tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/apple_mail_mcp/mail_connector.py tests/unit/test_mail_connector.py
+git commit -m "Refactor get_message to emit JSON (#23)"
+```
+
+---
+
+## Task 5: Refactor `get_attachments` to JSON
+
+**Files:**
+- Modify: `src/apple_mail_mcp/mail_connector.py:530-596`
+- Modify: `tests/unit/test_attachments.py:115-139` (`test_get_attachments_list`, `test_get_attachments_empty`)
+
+**Step 1: Update mocks (RED)**
+
+`test_get_attachments_list` mock at `tests/unit/test_attachments.py:120`:
+
+```python
+mock_run.return_value = (
+    '[{"name":"document.pdf","mime_type":"application/pdf","size":524288,"downloaded":true},'
+    '{"name":"image.jpg","mime_type":"image/jpeg","size":102400,"downloaded":true}]'
+)
+```
+
+`test_get_attachments_empty` mock at `:135`:
+
+```python
+mock_run.return_value = "[]"
+```
+
+Add a pipe-tolerance case:
+
+```python
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_attachments_handles_pipe_in_name(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = (
+            '[{"name":"q1|q2.pdf","mime_type":"application/pdf","size":1000,"downloaded":true}]'
+        )
+        result = connector.get_attachments("12345")
+        assert result[0]["name"] == "q1|q2.pdf"
+```
+
+**Step 2: Run — expect fail**
+
+Old parsing `line.split("|")` can't handle JSON.
+
+**Step 3: Refactor**
+
+Replace the body of `get_attachments`:
+
+```python
+        tell_body = f"""
+        tell application "Mail"
+            set resultData to missing value
+            repeat with acc in accounts
+                repeat with mb in mailboxes of acc
+                    try
+                        set msg to first message of mb whose id is {message_id_safe}
+                        set attList to mail attachments of msg
+
+                        set resultData to {{}}
+                        repeat with att in attList
+                            set attRecord to {{name:(name of att), mime_type:(MIME type of att), size:(file size of att), downloaded:(downloaded of att)}}
+                            set end of resultData to attRecord
+                        end repeat
+                        exit repeat
+                    end try
+                end repeat
+                if resultData is not missing value then exit repeat
+            end repeat
+
+            if resultData is missing value then
+                error "Message not found"
+            end if
+        end tell
+        """
+
+        script = _wrap_as_json_script(tell_body)
+        result = self._run_applescript(script)
+        return parse_applescript_json(result)
+```
+
+Remove the old pipe-split loop. Keep the existing `test_get_attachments_message_not_found` test as-is — it mocks `_run_applescript` to raise directly.
+
+**Step 4: Run — expect pass**
+
+`uv run pytest tests/unit/test_attachments.py::TestGetAttachments -v`
+
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/apple_mail_mcp/mail_connector.py tests/unit/test_attachments.py
+git commit -m "Refactor get_attachments to emit JSON (#23)"
+```
+
+---
+
+## Task 6: Refactor `list_mailboxes` to JSON (finishes the TODO)
+
+**Files:**
+- Modify: `src/apple_mail_mcp/mail_connector.py:128-161`
+- Modify: `tests/unit/test_mail_connector.py:80-88` (`test_list_mailboxes`)
+
+**Step 1: Update the test (RED)**
+
+Replace `test_list_mailboxes`:
+
+```python
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_mailboxes_returns_structured_data(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = (
+            '[{"name":"INBOX","unread_count":5},'
+            '{"name":"Sent","unread_count":0},'
+            '{"name":"Projects/Client A","unread_count":3}]'
+        )
+        result = connector.list_mailboxes("Gmail")
+        assert result == [
+            {"name": "INBOX", "unread_count": 5},
+            {"name": "Sent", "unread_count": 0},
+            {"name": "Projects/Client A", "unread_count": 3},
+        ]
+```
+
+**Step 2: Run — expect fail**
+
+The existing code returns `[{"raw": result}]` — shape doesn't match.
+
+**Step 3: Refactor**
+
+Replace the body of `list_mailboxes`:
+
+```python
+        account_safe = escape_applescript_string(sanitize_input(account))
+
+        tell_body = f"""
+        tell application "Mail"
+            try
+                set accountRef to account "{account_safe}"
+                set resultData to {{}}
+
+                repeat with mb in mailboxes of accountRef
+                    set mbRecord to {{name:(name of mb), unread_count:(unread count of mb)}}
+                    set end of resultData to mbRecord
+                end repeat
+            on error errMsg
+                return "ERROR: " & errMsg
+            end try
+        end tell
+        """
+
+        script = _wrap_as_json_script(tell_body)
+        result = self._run_applescript(script)
+        return parse_applescript_json(result)
+```
+
+The `{"raw": result}` placeholder code is removed. The TODO comment goes away.
+
+**Step 4: Run — expect pass**
+
+`uv run pytest tests/unit/test_mail_connector.py::TestAppleMailConnector::test_list_mailboxes_returns_structured_data -v`
+
+Also run e2e to confirm the tool's `TestToolInvocation` parametrized case for `list_mailboxes` still works (server layer unchanged):
+
+`uv run pytest tests/e2e/test_mcp_tools.py -v`
+
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/apple_mail_mcp/mail_connector.py tests/unit/test_mail_connector.py
+git commit -m "Refactor list_mailboxes to emit JSON, remove TODO placeholder (#23)"
+```
+
+---
+
+## Task 7: Refactor `list_accounts` to JSON (finishes the half-baked pseudo-JSON)
+
+**Files:**
+- Modify: `src/apple_mail_mcp/mail_connector.py:86-126`
+- Modify: `tests/unit/test_mail_connector.py` (add new test — no existing test for this)
+
+**Step 1: Write the new test (RED)**
+
+In `tests/unit/test_mail_connector.py`, add to `TestAppleMailConnector`:
+
+```python
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_accounts_returns_structured_data(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = (
+            '[{"name":"Gmail","email_addresses":["me@gmail.com"]},'
+            '{"name":"Work","email_addresses":["me@work.com","alt@work.com"]}]'
+        )
+        result = connector.list_accounts()
+        assert result == [
+            {"name": "Gmail", "email_addresses": ["me@gmail.com"]},
+            {"name": "Work", "email_addresses": ["me@work.com", "alt@work.com"]},
+        ]
+```
+
+**Step 2: Run — expect fail**
+
+The existing code returns `[{"raw": str}]` shapes.
+
+**Step 3: Refactor**
+
+Replace the body of `list_accounts`:
+
+```python
+    def list_accounts(self) -> list[dict[str, Any]]:
+        """List all mail accounts.
+
+        Returns:
+            List of account dictionaries with keys:
+              - name: account display name
+              - email_addresses: list of associated email addresses
+        """
+        tell_body = """
+        tell application "Mail"
+            try
+                set resultData to {}
+                repeat with acc in accounts
+                    set accRecord to {name:(name of acc), email_addresses:(email addresses of acc)}
+                    set end of resultData to accRecord
+                end repeat
+            on error errMsg
+                return "ERROR: " & errMsg
+            end try
+        end tell
+        """
+
+        script = _wrap_as_json_script(tell_body)
+        result = self._run_applescript(script)
+        return parse_applescript_json(result)
+```
+
+Important check during implementation: `email addresses of acc` may return `missing value` for accounts with no address set. If so, wrap the property access with a `try` or use a fallback. Verify against a real Mail.app account during integration testing (Task 9).
+
+**Step 4: Run — expect pass**
+
+`uv run pytest tests/unit/test_mail_connector.py::TestAppleMailConnector::test_list_accounts_returns_structured_data -v`
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/apple_mail_mcp/mail_connector.py tests/unit/test_mail_connector.py
+git commit -m "Refactor list_accounts to emit proper JSON (#23)"
+```
+
+---
+
+## Task 8: Full unit + e2e suite green
+
+**Files:** None modified unless issues surface.
+
+**Step 1: Run the whole suite**
+
+```bash
+make test
+make test-e2e
+```
+
+Expected:
+- Unit: all pass. New coverage for `parse_applescript_json`, `_wrap_as_json_script`, `list_accounts`, `list_mailboxes`, plus pipe-tolerance tests.
+- E2E: 20 still pass (connector is mocked at server layer; refactor is internal).
+
+**Step 2: Run `make check-all`**
+
+```bash
+make check-all
+```
+
+Expected: lint, typecheck, tests, complexity, version-sync, parity all green. Coverage ≥ 90%.
+
+**Step 3: If anything fails**
+
+Fix and commit separately with a descriptive message. Do not amend prior per-task commits.
+
+No commit if everything was already green — this is a gate task.
+
+---
+
+## Task 9: Integration sanity check (optional but recommended)
+
+**Files:** `tests/integration/test_mail_integration.py` (if adding tests)
+
+**Goal:** Prove the ASObjC JSON pattern works against a real Mail.app, not just in isolated osascript smoke tests.
+
+**Step 1: Minimal live smoke**
+
+Run a one-shot osascript smoke test against the user's Mail.app:
+
+```bash
+osascript <<'EOF'
+use framework "Foundation"
+use scripting additions
+
+tell application "Mail"
+    set resultData to {}
+    repeat with acc in accounts
+        set accRecord to {name:(name of acc), email_addresses:(email addresses of acc)}
+        set end of resultData to accRecord
+    end repeat
+end tell
+
+set jsonData to (current application's NSJSONSerialization's dataWithJSONObject:resultData options:0 |error|:(missing value))
+return (current application's NSString's alloc()'s initWithData:jsonData encoding:4) as text
+EOF
+```
+
+Expected: valid JSON printed. If `jsonData` returns `missing value`, NSJSONSerialization rejected the record — likely because one property was `missing value` (e.g., an account with no email addresses). If that happens, wrap `email addresses of acc` with:
+
+```applescript
+try
+    set addrs to email addresses of acc
+    if addrs is missing value then set addrs to {}
+on error
+    set addrs to {}
+end try
+```
+
+Adjust Task 7's tell-body accordingly before shipping.
+
+**Step 2: Optional — add 1 integration test**
+
+If the project wants at least one integration test that proves JSON end-to-end, add to `tests/integration/test_mail_integration.py`:
+
+```python
+@pytest.mark.integration
+def test_list_accounts_returns_json(connector: AppleMailConnector) -> None:
+    accounts = connector.list_accounts()
+    assert isinstance(accounts, list)
+    # Every entry is a dict with the documented keys (no {"raw": ...} shapes)
+    for acct in accounts:
+        assert set(acct.keys()) >= {"name", "email_addresses"}
+        assert isinstance(acct["name"], str)
+        assert isinstance(acct["email_addresses"], list)
+```
+
+Run: `make test-integration` — requires real Mail.app and passes `MAIL_TEST_MODE=true`.
+
+**Step 3: Commit if integration tests added**
+
+```bash
+git add tests/integration/test_mail_integration.py
+git commit -m "Add integration test for list_accounts JSON shape (#23)"
+```
+
+If step 1 surfaced edge cases (missing-value handling), include the connector fix in the same commit as the test.
+
+---
+
+## Task 10: Update documentation
+
+**Files:**
+- Modify: `.claude/skills/applescript-mail/SKILL.md` (the "Critical: Pipe-Delimited Output Parsing" section is now outdated)
+- Modify: `.claude/CLAUDE.md` (the "Pipe-delimited output parsing" gotcha entry)
+
+**Step 1: Update the skill**
+
+In `.claude/skills/applescript-mail/SKILL.md`, replace the "Critical: Pipe-Delimited Output Parsing" section with a note that the project now uses JSON + ASObjC, and briefly document the `_wrap_as_json_script` / `parse_applescript_json` pattern so future contributors follow it. Keep the section short (≤ 20 lines).
+
+**Step 2: Update CLAUDE.md**
+
+In `.claude/CLAUDE.md`, find the "AppleScript Gotchas" section and either remove the "Pipe-delimited output parsing" bullet or replace it with a one-line note that output is JSON (via `_wrap_as_json_script`). Do not touch other gotchas.
+
+**Step 3: Run verification**
+
+```bash
+make check-all
+```
+
+Expected: green. No Python code changes in this task.
+
+**Step 4: Commit**
+
+```bash
+git add .claude/skills/applescript-mail/SKILL.md .claude/CLAUDE.md
+git commit -m "Document JSON AppleScript pattern, remove pipe-delimited gotcha (#23)"
+```
+
+---
+
+## Task 11: Push and open PR closing #23
+
+**Step 1: Push**
+
+```bash
+git push -u origin refactor/issue-23-json-applescript-output
+```
+
+**Step 2: Open PR**
+
+```bash
+gh pr create --title "Emit JSON from AppleScript instead of pipe-delimited strings (#23)" --body "..."
+```
+
+PR body should:
+
+- Summarize the refactor: `parse_applescript_json`, `_wrap_as_json_script`, 5 methods converted.
+- Call out the user-visible wins: `list_accounts` and `list_mailboxes` now return real structured data (previously `[{"raw": str}]`).
+- Call out the bug fix: subjects/content containing `|` no longer break parsing.
+- Reference the design doc (`docs/plans/2026-04-18-json-applescript-output-design.md`).
+- Include the test-plan checklist: `make test`, `make test-e2e`, `make check-all`, optional `make test-integration`.
+- Use `Closes #23`.
+
+**Step 3: Wait for CI**
+
+`gh pr checks <pr-number> --watch`
+
+**Step 4: On green, use `/merge-and-status` to merge.**
+
+---
+
+## Verification (end-to-end)
+
+- `make test` — unit tests green; new `parse_applescript_json` and per-method pipe-tolerance tests pass.
+- `make test-e2e` — 20 E2E tests still pass (connector is mocked; dispatch layer unaffected).
+- `make check-all` — all gates green; coverage ≥ 90%.
+- `grep -r 'split("|")' src/apple_mail_mcp/` returns no matches.
+- `grep -r '{"raw":' src/apple_mail_mcp/` returns no matches (both placeholder shapes gone).
+- Manual osascript smoke or `make test-integration` if the user runs it locally confirms real Mail.app produces valid JSON.

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -122,46 +122,26 @@ class AppleMailConnector:
             raise MailAppleScriptError(f"Unexpected error: {str(e)}") from e
 
     def list_accounts(self) -> list[dict[str, Any]]:
-        """
-        List all mail accounts.
+        """List all mail accounts.
 
         Returns:
-            List of account dictionaries with name and email addresses
+            List of account dicts with keys:
+              - name: account display name
+              - email_addresses: list of associated email addresses
         """
-        script = """
+        tell_body = """
         tell application "Mail"
-            set accountList to {}
+            set resultData to {}
             repeat with acc in accounts
-                set accountInfo to {accountName:(name of acc), emailAddresses:(email addresses of acc)}
-                set end of accountList to accountInfo
+                set accRecord to {name:(name of acc), email_addresses:(email addresses of acc)}
+                set end of resultData to accRecord
             end repeat
-
-            -- Convert to JSON-like format
-            set output to ""
-            repeat with acc in accountList
-                set output to output & "{name:'" & accountName of acc & "',emails:["
-                repeat with addr in emailAddresses of acc
-                    set output to output & "'" & addr & "',"
-                end repeat
-                set output to output & "]}|"
-            end repeat
-
-            return output
         end tell
         """
 
+        script = _wrap_as_json_script(tell_body)
         result = self._run_applescript(script)
-
-        # Parse the result
-        accounts = []
-        for account_str in result.split("|"):
-            if not account_str:
-                continue
-            # Simple parsing - in production, use more robust parsing
-            # For now, we'll return raw result and handle in tools
-            accounts.append({"raw": account_str})
-
-        return accounts
+        return parse_applescript_json(result)
 
     def list_mailboxes(self, account: str) -> list[dict[str, Any]]:
         """List all mailboxes for an account.

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -283,49 +283,37 @@ class AppleMailConnector:
         # We need to search through mailboxes
         # For now, we'll use a simplified approach
 
-        content_clause = 'set msgContent to content of msg' if include_content else 'set msgContent to ""'
+        content_clause = (
+            'set msgContent to content of msg'
+            if include_content
+            else 'set msgContent to ""'
+        )
 
-        script = f"""
+        tell_body = f'''
         tell application "Mail"
-            -- Search all accounts for message
+            set resultData to missing value
             repeat with acc in accounts
                 repeat with mb in mailboxes of acc
                     try
                         set msg to first message of mb whose id is {message_id_safe}
-
-                        set msgId to id of msg as text
-                        set msgSubject to subject of msg
-                        set msgSender to sender of msg
-                        set msgDate to date received of msg as text
-                        set msgRead to read status of msg
-                        set msgFlagged to flagged status of msg
                         {content_clause}
 
-                        return msgId & "|" & msgSubject & "|" & msgSender & "|" & msgDate & "|" & msgRead & "|" & msgFlagged & "|" & msgContent
+                        set resultData to {{id:(id of msg as text), subject:(subject of msg), sender:(sender of msg), date_received:(date received of msg as text), read_status:(read status of msg), flagged:(flagged status of msg), content:msgContent}}
+                        exit repeat
                     end try
                 end repeat
+                if resultData is not missing value then exit repeat
             end repeat
 
-            error "Message not found"
+            if resultData is missing value then
+                error "Can't get message: not found"
+            end if
         end tell
-        """
+        '''
 
+        script = _wrap_as_json_script(tell_body)
         result = self._run_applescript(script)
-
-        # Parse result
-        parts = result.split("|", 6)  # Max 7 parts
-        if len(parts) >= 6:
-            return {
-                "id": parts[0],
-                "subject": parts[1],
-                "sender": parts[2],
-                "date_received": parts[3],
-                "read_status": parts[4].lower() == "true",
-                "flagged": parts[5].lower() == "true",
-                "content": parts[6] if len(parts) > 6 else "",
-            }
-
-        raise MailMessageNotFoundError(f"Could not parse message: {message_id}")
+        return parse_applescript_json(result)
 
     def send_email(
         self,

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -18,6 +18,40 @@ from .utils import escape_applescript_string, sanitize_input
 logger = logging.getLogger(__name__)
 
 
+def _wrap_as_json_script(body: str) -> str:
+    """Wrap a tell-block body with ASObjC imports and an NSJSONSerialization return.
+
+    The `body` must:
+      - Contain a `tell application "Mail" ... end tell` block.
+      - Assign the final result to an AppleScript variable named `resultData`
+        inside that tell block.
+      - Use `try/on error errMsg / return "ERROR: " & errMsg / end try` for
+        failure cases (the wrapper does not add a try/catch).
+
+    The wrapper:
+      - Prepends `use framework "Foundation"` and `use scripting additions`.
+      - After the tell block, serializes `resultData` via NSJSONSerialization
+        and returns the resulting NSString as text.
+
+    Args:
+        body: AppleScript tell-block source setting `resultData`.
+
+    Returns:
+        Full AppleScript source ready for osascript.
+    """
+    return (
+        'use framework "Foundation"\n'
+        "use scripting additions\n"
+        "\n"
+        f"{body}\n"
+        "\n"
+        "set jsonData to (current application's NSJSONSerialization's "
+        "dataWithJSONObject:resultData options:0 |error|:(missing value))\n"
+        "return (current application's NSString's alloc()'s "
+        "initWithData:jsonData encoding:4) as text\n"
+    )
+
+
 class AppleMailConnector:
     """Interface to Apple Mail via AppleScript."""
 

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -232,7 +232,7 @@ class AppleMailConnector:
 
             set resultData to {{}}
             repeat with msg in matchedMessages
-                set msgRecord to {{id:(id of msg as text), subject:(subject of msg), sender:(sender of msg), date_received:(date received of msg as text), read_status:(read status of msg)}}
+                set msgRecord to {{|id|:(id of msg as text), subject:(subject of msg), sender:(sender of msg), date_received:(date received of msg as text), read_status:(read status of msg)}}
                 set end of resultData to msgRecord
             end repeat
         end tell
@@ -277,7 +277,7 @@ class AppleMailConnector:
                         set msg to first message of mb whose id is {message_id_safe}
                         {content_clause}
 
-                        set resultData to {{id:(id of msg as text), subject:(subject of msg), sender:(sender of msg), date_received:(date received of msg as text), read_status:(read status of msg), flagged:(flagged status of msg), content:msgContent}}
+                        set resultData to {{|id|:(id of msg as text), subject:(subject of msg), sender:(sender of msg), date_received:(date received of msg as text), read_status:(read status of msg), flagged:(flagged status of msg), content:msgContent}}
                         exit repeat
                     end try
                 end repeat
@@ -529,7 +529,7 @@ class AppleMailConnector:
 
                         set resultData to {{}}
                         repeat with att in attList
-                            set attRecord to {{|name|:(name of att), mime_type:(MIME type of att), size:(file size of att), downloaded:(downloaded of att)}}
+                            set attRecord to {{|name|:(name of att), mime_type:(MIME type of att), |size|:(file size of att), downloaded:(downloaded of att)}}
                             set end of resultData to attRecord
                         end repeat
                         exit repeat

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -5,7 +5,7 @@ AppleScript-based connector for Apple Mail.
 import logging
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from .exceptions import (
     MailAccountNotFoundError,
@@ -141,7 +141,7 @@ class AppleMailConnector:
 
         script = _wrap_as_json_script(tell_body)
         result = self._run_applescript(script)
-        return parse_applescript_json(result)
+        return cast(list[dict[str, Any]], parse_applescript_json(result))
 
     def list_mailboxes(self, account: str) -> list[dict[str, Any]]:
         """List all mailboxes for an account.
@@ -171,7 +171,7 @@ class AppleMailConnector:
 
         script = _wrap_as_json_script(tell_body)
         result = self._run_applescript(script)
-        return parse_applescript_json(result)
+        return cast(list[dict[str, Any]], parse_applescript_json(result))
 
     def search_messages(
         self,
@@ -236,7 +236,7 @@ class AppleMailConnector:
 
         script = _wrap_as_json_script(tell_body)
         result = self._run_applescript(script)
-        return parse_applescript_json(result)
+        return cast(list[dict[str, Any]], parse_applescript_json(result))
 
     def get_message(self, message_id: str, include_content: bool = True) -> dict[str, Any]:
         """
@@ -288,7 +288,7 @@ class AppleMailConnector:
 
         script = _wrap_as_json_script(tell_body)
         result = self._run_applescript(script)
-        return parse_applescript_json(result)
+        return cast(dict[str, Any], parse_applescript_json(result))
 
     def send_email(
         self,
@@ -542,7 +542,7 @@ class AppleMailConnector:
 
         script = _wrap_as_json_script(tell_body)
         result = self._run_applescript(script)
-        return parse_applescript_json(result)
+        return cast(list[dict[str, Any]], parse_applescript_json(result))
 
     def save_attachments(
         self,

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -133,7 +133,9 @@ class AppleMailConnector:
         tell application "Mail"
             set resultData to {}
             repeat with acc in accounts
-                set accRecord to {name:(name of acc), email_addresses:(email addresses of acc)}
+                set accEmails to email addresses of acc
+                if accEmails is missing value then set accEmails to {}
+                set accRecord to {|name|:(name of acc), email_addresses:accEmails}
                 set end of resultData to accRecord
             end repeat
         end tell
@@ -163,7 +165,9 @@ class AppleMailConnector:
             set resultData to {{}}
 
             repeat with mb in mailboxes of accountRef
-                set mbRecord to {{name:(name of mb), unread_count:(unread count of mb)}}
+                set mbUnread to unread count of mb
+                if mbUnread is missing value then set mbUnread to 0
+                set mbRecord to {{|name|:(name of mb), unread_count:mbUnread}}
                 set end of resultData to mbRecord
             end repeat
         end tell
@@ -525,7 +529,7 @@ class AppleMailConnector:
 
                         set resultData to {{}}
                         repeat with att in attList
-                            set attRecord to {{name:(name of att), mime_type:(MIME type of att), size:(file size of att), downloaded:(downloaded of att)}}
+                            set attRecord to {{|name|:(name of att), mime_type:(MIME type of att), size:(file size of att), downloaded:(downloaded of att)}}
                             set end of resultData to attRecord
                         end repeat
                         exit repeat

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -539,58 +539,35 @@ class AppleMailConnector:
         """
         message_id_safe = escape_applescript_string(sanitize_input(message_id))
 
-        script = f"""
+        tell_body = f'''
         tell application "Mail"
-            -- Search all accounts for message
+            set resultData to missing value
             repeat with acc in accounts
                 repeat with mb in mailboxes of acc
                     try
                         set msg to first message of mb whose id is {message_id_safe}
                         set attList to mail attachments of msg
 
-                        set resultList to {{}}
+                        set resultData to {{}}
                         repeat with att in attList
-                            set attName to name of att
-                            set attType to MIME type of att
-                            set attSize to file size of att
-                            set attDownloaded to downloaded of att
-
-                            set attData to attName & "|" & attType & "|" & attSize & "|" & attDownloaded
-                            set end of resultList to attData
+                            set attRecord to {{name:(name of att), mime_type:(MIME type of att), size:(file size of att), downloaded:(downloaded of att)}}
+                            set end of resultData to attRecord
                         end repeat
-
-                        -- Join with newlines
-                        set AppleScript's text item delimiters to linefeed
-                        set output to resultList as text
-                        set AppleScript's text item delimiters to ""
-
-                        return output
+                        exit repeat
                     end try
                 end repeat
+                if resultData is not missing value then exit repeat
             end repeat
 
-            error "Message not found"
+            if resultData is missing value then
+                error "Can't get message: not found"
+            end if
         end tell
-        """
+        '''
 
+        script = _wrap_as_json_script(tell_body)
         result = self._run_applescript(script)
-
-        # Parse results
-        attachments = []
-        if result:
-            for line in result.split("\n"):
-                if not line:
-                    continue
-                parts = line.split("|")
-                if len(parts) >= 4:
-                    attachments.append({
-                        "name": parts[0],
-                        "mime_type": parts[1],
-                        "size": int(parts[2]) if parts[2].isdigit() else 0,
-                        "downloaded": parts[3].lower() == "true",
-                    })
-
-        return attachments
+        return parse_applescript_json(result)
 
     def save_attachments(
         self,

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -13,7 +13,7 @@ from .exceptions import (
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
 )
-from .utils import escape_applescript_string, sanitize_input
+from .utils import escape_applescript_string, parse_applescript_json, sanitize_input
 
 logger = logging.getLogger(__name__)
 
@@ -25,8 +25,12 @@ def _wrap_as_json_script(body: str) -> str:
       - Contain a `tell application "Mail" ... end tell` block.
       - Assign the final result to an AppleScript variable named `resultData`
         inside that tell block.
-      - Use `try/on error errMsg / return "ERROR: " & errMsg / end try` for
-        failure cases (the wrapper does not add a try/catch).
+      - Handle failures EITHER by letting AppleScript errors propagate via
+        stderr (preserves _run_applescript's typed exception mapping, e.g.,
+        MailAccountNotFoundError) OR by catching them in a try block and
+        returning "ERROR: <message>" (surfaces as MailAppleScriptError on
+        the Python side). Use the stderr path when the caller relies on
+        typed exceptions; use the "ERROR:" path otherwise.
 
     The wrapper:
       - Prepends `use framework "Foundation"` and `use scripting additions`.
@@ -241,52 +245,23 @@ class AppleMailConnector:
         whose_clause = " and ".join(conditions) if conditions else "true"
         limit_clause = f"items 1 thru {limit} of" if limit else ""
 
-        script = f"""
+        tell_body = f'''
         tell application "Mail"
             set accountRef to account "{account_safe}"
             set mailboxRef to mailbox "{mailbox_safe}" of accountRef
             set matchedMessages to {limit_clause} (messages of mailboxRef whose {whose_clause})
 
-            set resultList to {{}}
+            set resultData to {{}}
             repeat with msg in matchedMessages
-                set msgId to id of msg as text
-                set msgSubject to subject of msg
-                set msgSender to sender of msg
-                set msgDate to date received of msg as text
-                set msgRead to read status of msg
-
-                set msgData to msgId & "|" & msgSubject & "|" & msgSender & "|" & msgDate & "|" & msgRead
-                set end of resultList to msgData
+                set msgRecord to {{id:(id of msg as text), subject:(subject of msg), sender:(sender of msg), date_received:(date received of msg as text), read_status:(read status of msg)}}
+                set end of resultData to msgRecord
             end repeat
-
-            -- Join with newlines
-            set AppleScript's text item delimiters to linefeed
-            set output to resultList as text
-            set AppleScript's text item delimiters to ""
-
-            return output
         end tell
-        """
+        '''
 
+        script = _wrap_as_json_script(tell_body)
         result = self._run_applescript(script)
-
-        # Parse results
-        messages = []
-        if result:
-            for line in result.split("\n"):
-                if not line:
-                    continue
-                parts = line.split("|")
-                if len(parts) >= 5:
-                    messages.append({
-                        "id": parts[0],
-                        "subject": parts[1],
-                        "sender": parts[2],
-                        "date_received": parts[3],
-                        "read_status": parts[4].lower() == "true",
-                    })
-
-        return messages
+        return parse_applescript_json(result)
 
     def get_message(self, message_id: str, include_content: bool = True) -> dict[str, Any]:
         """

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -164,39 +164,34 @@ class AppleMailConnector:
         return accounts
 
     def list_mailboxes(self, account: str) -> list[dict[str, Any]]:
-        """
-        List all mailboxes for an account.
+        """List all mailboxes for an account.
 
         Args:
-            account: Account name
+            account: Account name.
 
         Returns:
-            List of mailbox dictionaries
+            List of dicts with keys: name, unread_count.
 
         Raises:
-            MailAccountNotFoundError: If account doesn't exist
+            MailAccountNotFoundError: If account doesn't exist.
         """
         account_safe = escape_applescript_string(sanitize_input(account))
 
-        script = f"""
+        tell_body = f'''
         tell application "Mail"
             set accountRef to account "{account_safe}"
-            set mailboxList to {{}}
+            set resultData to {{}}
 
             repeat with mb in mailboxes of accountRef
-                set mbInfo to {{mbName:(name of mb), unreadCount:(unread count of mb)}}
-                set end of mailboxList to mbInfo
+                set mbRecord to {{name:(name of mb), unread_count:(unread count of mb)}}
+                set end of resultData to mbRecord
             end repeat
-
-            return mailboxList
         end tell
-        """
+        '''
 
+        script = _wrap_as_json_script(tell_body)
         result = self._run_applescript(script)
-
-        # TODO: Parse AppleScript records properly
-        # For now return raw
-        return [{"raw": result}]
+        return parse_applescript_json(result)
 
     def search_messages(
         self,

--- a/src/apple_mail_mcp/utils.py
+++ b/src/apple_mail_mcp/utils.py
@@ -2,6 +2,7 @@
 Utility functions for Apple Mail MCP.
 """
 
+import json
 import re
 from typing import Any
 
@@ -290,3 +291,32 @@ def get_flag_index(color: str) -> int:
         )
 
     return color_map[color_lower]
+
+
+def parse_applescript_json(result: str) -> Any:
+    """Parse JSON emitted by an AppleScript helper, or raise on ERROR: prefix.
+
+    AppleScript scripts wrapped with _wrap_as_json_script return either:
+    - A JSON-serialized string (list, dict, or scalar), or
+    - "ERROR: <message>" when the tell-block catches an error.
+
+    Note: the "ERROR:" prefix is a sentinel only valid because _wrap_as_json_script
+    returns list/dict payloads — a bare JSON string starting with "ERROR:" would be
+    misread. Wrapped scripts must never return a bare-string top-level value.
+
+    Args:
+        result: Raw stdout from _run_applescript().
+
+    Returns:
+        Deserialized JSON (list, dict, str, int, bool, or None).
+
+    Raises:
+        MailAppleScriptError: If the result starts with "ERROR:".
+        json.JSONDecodeError: If the result is neither an error nor valid JSON.
+    """
+    from .exceptions import MailAppleScriptError
+
+    stripped = result.strip()
+    if stripped.startswith("ERROR:"):
+        raise MailAppleScriptError(stripped[len("ERROR:"):].strip())
+    return json.loads(stripped)

--- a/tests/unit/test_attachments.py
+++ b/tests/unit/test_attachments.py
@@ -117,7 +117,10 @@ class TestGetAttachments:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         """Test listing attachments from a message."""
-        mock_run.return_value = "document.pdf|application/pdf|524288|true\nimage.jpg|image/jpeg|102400|true"
+        mock_run.return_value = (
+            '[{"name":"document.pdf","mime_type":"application/pdf","size":524288,"downloaded":true},'
+            '{"name":"image.jpg","mime_type":"image/jpeg","size":102400,"downloaded":true}]'
+        )
 
         result = connector.get_attachments("12345")
 
@@ -132,11 +135,21 @@ class TestGetAttachments:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         """Test getting attachments from message with none."""
-        mock_run.return_value = ""
+        mock_run.return_value = "[]"
 
         result = connector.get_attachments("12345")
 
         assert result == []
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_attachments_handles_pipe_in_name(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = (
+            '[{"name":"q1|q2.pdf","mime_type":"application/pdf","size":1000,"downloaded":true}]'
+        )
+        result = connector.get_attachments("12345")
+        assert result[0]["name"] == "q1|q2.pdf"
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_get_attachments_message_not_found(

--- a/tests/unit/test_attachments.py
+++ b/tests/unit/test_attachments.py
@@ -161,6 +161,16 @@ class TestGetAttachments:
         with pytest.raises(MailMessageNotFoundError):
             connector.get_attachments("99999")
 
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_attachments_script_quotes_name_key(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """The AppleScript must use |name| so NSJSONSerialization preserves it."""
+        mock_run.return_value = "[]"
+        connector.get_attachments("12345")
+        script = mock_run.call_args[0][0]
+        assert "|name|:(name of att)" in script
+
 
 class TestSaveAttachments:
     """Tests for saving attachments."""

--- a/tests/unit/test_attachments.py
+++ b/tests/unit/test_attachments.py
@@ -171,6 +171,21 @@ class TestGetAttachments:
         script = mock_run.call_args[0][0]
         assert "|name|:(name of att)" in script
 
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_attachments_script_quotes_size_key(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Guard against NSJSONSerialization silently dropping the 'size' key.
+
+        AppleScript record key `size:` collides with NSSize/NSObject selectors
+        and gets stripped during NSDictionary conversion. Must be `|size|:`.
+        """
+        mock_run.return_value = "[]"
+        connector.get_attachments("msg-1")
+        script = mock_run.call_args[0][0]
+        assert "|size|:(file size of att)" in script
+        assert ", size:(file size of att)" not in script
+
 
 class TestSaveAttachments:
     """Tests for saving attachments."""

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -92,7 +92,11 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         """Test basic message search."""
-        mock_run.return_value = "12345|Test Subject|sender@example.com|Mon Jan 1 2024|false"
+        mock_run.return_value = (
+            '[{"id":"12345","subject":"Test Subject",'
+            '"sender":"sender@example.com","date_received":"Mon Jan 1 2024",'
+            '"read_status":false}]'
+        )
 
         result = connector.search_messages("Gmail", "INBOX")
 
@@ -102,12 +106,51 @@ class TestAppleMailConnector:
         assert result[0]["sender"] == "sender@example.com"
         assert result[0]["read_status"] is False
 
+    # Note: validates the Python-side JSON parse. Real end-to-end correctness
+    # (AppleScript actually emitting valid JSON when the data contains '|')
+    # is proven by integration tests.
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_handles_pipe_in_subject(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Subject containing '|' must not break parsing (the bug this refactor fixes)."""
+        mock_run.return_value = (
+            '[{"id":"abc","subject":"Q3 Report | Draft",'
+            '"sender":"boss@example.com","date_received":"Wed Feb 5 2025",'
+            '"read_status":true}]'
+        )
+        result = connector.search_messages("Gmail", "INBOX")
+        assert len(result) == 1
+        assert result[0]["subject"] == "Q3 Report | Draft"
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_propagates_account_not_found(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """If _run_applescript raises MailAccountNotFoundError, search_messages must not swallow it.
+
+        Regression guard: a previous version wrapped the tell-block in try/on error,
+        which downgraded MailAccountNotFoundError to MailAppleScriptError.
+        """
+        mock_run.side_effect = MailAccountNotFoundError("Can't get account \"NoSuch\".")
+        with pytest.raises(MailAccountNotFoundError):
+            connector.search_messages("NoSuch", "INBOX")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_propagates_mailbox_not_found(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Similar regression guard for MailMailboxNotFoundError."""
+        mock_run.side_effect = MailMailboxNotFoundError("Can't get mailbox \"NoSuch\".")
+        with pytest.raises(MailMailboxNotFoundError):
+            connector.search_messages("Gmail", "NoSuch")
+
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_with_filters(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         """Test message search with filters."""
-        mock_run.return_value = ""
+        mock_run.return_value = "[]"
 
         connector.search_messages(
             "Gmail",

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -240,6 +240,22 @@ class TestAppleMailConnector:
         assert "items 1 thru 10" in call_args
 
     @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_script_quotes_id_key(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Guard against NSJSONSerialization silently dropping the 'id' key.
+
+        AppleScript record key `id:` collides with NSObject's id selector and
+        gets stripped during NSDictionary conversion. Must be quoted as `|id|:`.
+        """
+        mock_run.return_value = "[]"
+        connector.search_messages("Gmail", "INBOX")
+        script = mock_run.call_args[0][0]
+        assert "|id|:(id of msg as text)" in script
+        # The bare form must not appear in the msgRecord literal — it would collide.
+        assert ", id:(id of msg" not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
     def test_get_message(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
@@ -270,6 +286,16 @@ class TestAppleMailConnector:
         )
         result = connector.get_message("99", include_content=True)
         assert result["content"] == "col1|col2|col3"
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_message_script_quotes_id_key(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Same guard as test_search_messages_script_quotes_id_key, for get_message."""
+        mock_run.return_value = '{"id":"x","subject":"","sender":"","date_received":"","read_status":false,"flagged":false,"content":""}'
+        connector.get_message("x")
+        script = mock_run.call_args[0][0]
+        assert "|id|:(id of msg as text)" in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_send_email_basic(

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -78,6 +78,28 @@ class TestAppleMailConnector:
             connector._run_applescript("test script")
 
     @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_accounts_returns_structured_data(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = (
+            '[{"name":"Gmail","email_addresses":["me@gmail.com"]},'
+            '{"name":"Work","email_addresses":["me@work.com","alt@work.com"]}]'
+        )
+        result = connector.list_accounts()
+        assert result == [
+            {"name": "Gmail", "email_addresses": ["me@gmail.com"]},
+            {"name": "Work", "email_addresses": ["me@work.com", "alt@work.com"]},
+        ]
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_accounts_empty(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "[]"
+        result = connector.list_accounts()
+        assert result == []
+
+    @patch.object(AppleMailConnector, "_run_applescript")
     def test_list_mailboxes_returns_structured_data(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -78,14 +78,28 @@ class TestAppleMailConnector:
             connector._run_applescript("test script")
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_list_mailboxes(
+    def test_list_mailboxes_returns_structured_data(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """Test listing mailboxes."""
-        mock_run.return_value = "mailbox data"
-
+        mock_run.return_value = (
+            '[{"name":"INBOX","unread_count":5},'
+            '{"name":"Sent","unread_count":0},'
+            '{"name":"Projects/Client A","unread_count":3}]'
+        )
         result = connector.list_mailboxes("Gmail")
-        assert len(result) > 0
+        assert result == [
+            {"name": "INBOX", "unread_count": 5},
+            {"name": "Sent", "unread_count": 0},
+            {"name": "Projects/Client A", "unread_count": 3},
+        ]
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_mailboxes_propagates_account_not_found(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.side_effect = MailAccountNotFoundError("Can't get account \"NoSuch\".")
+        with pytest.raises(MailAccountNotFoundError):
+            connector.list_mailboxes("NoSuch")
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_basic(

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -9,7 +9,7 @@ from apple_mail_mcp.exceptions import (
     MailAppleScriptError,
     MailMailboxNotFoundError,
 )
-from apple_mail_mcp.mail_connector import AppleMailConnector
+from apple_mail_mcp.mail_connector import AppleMailConnector, _wrap_as_json_script
 
 
 class TestAppleMailConnector:
@@ -208,3 +208,28 @@ class TestAppleMailConnector:
         """Test marking with empty list."""
         result = connector.mark_as_read([])
         assert result == 0
+
+
+class TestWrapAsJsonScript:
+    def test_wrapper_contains_framework_directive(self) -> None:
+        script = _wrap_as_json_script('tell application "Mail"\n    set resultData to {}\nend tell')
+        assert 'use framework "Foundation"' in script
+        assert "use scripting additions" in script
+
+    def test_wrapper_appends_json_serialization(self) -> None:
+        script = _wrap_as_json_script('tell application "Mail"\n    set resultData to {}\nend tell')
+        assert "NSJSONSerialization" in script
+        assert "dataWithJSONObject:resultData" in script
+
+    def test_wrapper_preserves_body(self) -> None:
+        body = 'tell application "Mail"\n    set resultData to {name:"INBOX"}\nend tell'
+        script = _wrap_as_json_script(body)
+        assert body in script
+
+    def test_wrapper_orders_framework_before_body_before_epilogue(self) -> None:
+        body = 'tell application "Mail"\n    set resultData to {name:"INBOX"}\nend tell'
+        script = _wrap_as_json_script(body)
+        framework_idx = script.index('use framework "Foundation"')
+        body_idx = script.index(body)
+        epilogue_idx = script.index("NSJSONSerialization")
+        assert framework_idx < body_idx < epilogue_idx

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -100,6 +100,31 @@ class TestAppleMailConnector:
         assert result == []
 
     @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_accounts_handles_empty_email_addresses(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """An account with no email addresses must return email_addresses as []."""
+        mock_run.return_value = '[{"name":"LocalOnly","email_addresses":[]}]'
+        result = connector.list_accounts()
+        assert result == [{"name": "LocalOnly", "email_addresses": []}]
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_accounts_script_quotes_name_key(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """The AppleScript must use |name| (quoted) so NSJSONSerialization keeps it.
+
+        Unquoted `name:` in the record literal causes the key to be silently
+        dropped during ASObjC -> NSDictionary conversion because `name` collides
+        with NSObject's `name` property. Regression guard for real Mail.app bug.
+        """
+        mock_run.return_value = "[]"
+        connector.list_accounts()
+        script = mock_run.call_args[0][0]
+        assert "|name|:(name of acc)" in script
+        assert "{name:(name of acc)" not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
     def test_list_mailboxes_returns_structured_data(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
@@ -122,6 +147,16 @@ class TestAppleMailConnector:
         mock_run.side_effect = MailAccountNotFoundError("Can't get account \"NoSuch\".")
         with pytest.raises(MailAccountNotFoundError):
             connector.list_mailboxes("NoSuch")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_mailboxes_script_quotes_name_key(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """The AppleScript must use |name| so NSJSONSerialization preserves it."""
+        mock_run.return_value = "[]"
+        connector.list_mailboxes("Gmail")
+        script = mock_run.call_args[0][0]
+        assert "|name|:(name of mb)" in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_basic(

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -173,7 +173,11 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         """Test getting a message."""
-        mock_run.return_value = "12345|Subject|sender@example.com|Mon Jan 1 2024|true|false|Message body"
+        mock_run.return_value = (
+            '{"id":"12345","subject":"Subject","sender":"sender@example.com",'
+            '"date_received":"Mon Jan 1 2024","read_status":true,"flagged":false,'
+            '"content":"Message body"}'
+        )
 
         result = connector.get_message("12345", include_content=True)
 
@@ -182,6 +186,19 @@ class TestAppleMailConnector:
         assert result["content"] == "Message body"
         assert result["read_status"] is True
         assert result["flagged"] is False
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_message_handles_pipe_in_content(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Body containing '|' must not break parsing."""
+        mock_run.return_value = (
+            '{"id":"99","subject":"x","sender":"a@b.com",'
+            '"date_received":"Mon Jan 1 2024","read_status":false,"flagged":false,'
+            '"content":"col1|col2|col3"}'
+        )
+        result = connector.get_message("99", include_content=True)
+        assert result["content"] == "col1|col2|col3"
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_send_email_basic(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,9 +1,14 @@
 """Unit tests for utility functions."""
 
+import json
 
+import pytest
+
+from apple_mail_mcp.exceptions import MailAppleScriptError
 from apple_mail_mcp.utils import (
     escape_applescript_string,
     format_applescript_list,
+    parse_applescript_json,
     parse_applescript_list,
     parse_date_filter,
     sanitize_input,
@@ -125,3 +130,45 @@ class TestSanitizeInput:
         long_string = "a" * 20000
         result = sanitize_input(long_string)
         assert len(result) == 10000
+
+
+class TestParseAppleScriptJson:
+    def test_parses_valid_json_list(self) -> None:
+        result = parse_applescript_json('[{"name": "INBOX", "unread_count": 5}]')
+        assert result == [{"name": "INBOX", "unread_count": 5}]
+
+    def test_parses_valid_json_object(self) -> None:
+        result = parse_applescript_json('{"id": "abc", "read_status": true}')
+        assert result == {"id": "abc", "read_status": True}
+
+    def test_parses_empty_list(self) -> None:
+        assert parse_applescript_json("[]") == []
+
+    def test_strips_whitespace(self) -> None:
+        assert parse_applescript_json("  [1,2,3]  \n") == [1, 2, 3]
+
+    def test_raises_on_error_prefix(self) -> None:
+        with pytest.raises(MailAppleScriptError, match="boom"):
+            parse_applescript_json("ERROR: boom")
+
+    def test_raises_on_error_prefix_with_whitespace(self) -> None:
+        with pytest.raises(MailAppleScriptError, match="something broke"):
+            parse_applescript_json("ERROR:   something broke  ")
+
+    def test_raises_on_malformed_json(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            parse_applescript_json("{not valid")
+
+    def test_parses_null(self) -> None:
+        assert parse_applescript_json("null") is None
+
+    def test_parses_quoted_string(self) -> None:
+        assert parse_applescript_json('"hello"') == "hello"
+
+    def test_parses_integer(self) -> None:
+        assert parse_applescript_json("42") == 42
+
+    def test_raises_on_empty_error_message(self) -> None:
+        """'ERROR:' with no message still raises (edge case)."""
+        with pytest.raises(MailAppleScriptError):
+            parse_applescript_json("ERROR:")


### PR DESCRIPTION
## Summary

Replaces the project's pipe-delimited AppleScript output with JSON emitted via ASObjC + `NSJSONSerialization`. This fixes the long-standing bug where any field containing `|` (email subjects, bodies, attachment names) silently broke parsing — documented as the project's biggest technical debt.

### Core changes

- Added `parse_applescript_json()` in [utils.py](src/apple_mail_mcp/utils.py) and `_wrap_as_json_script()` in [mail_connector.py](src/apple_mail_mcp/mail_connector.py). Each AppleScript assigns to `resultData` and the wrapper appends a `NSJSONSerialization` epilogue.
- Refactored all 5 affected methods: `search_messages`, `get_message`, `get_attachments`, `list_mailboxes`, `list_accounts`. The last two previously returned `[{"raw": str}]` placeholder shapes — now return proper structured data matching the tools' documented contract.
- Typed-exception propagation preserved: methods with typed exceptions (`MailAccountNotFoundError`, `MailMessageNotFoundError`) let AppleScript errors propagate via stderr where `_run_applescript` maps substrings to specific exception types.

### Bugs caught during integration smoke

Three `NSJSONSerialization` selector-collision bugs that would have shipped silently:
- Unquoted `name:` key → dropped (collides with NSObject's `name`). Fixed in 3 scripts.
- Unquoted `id:` key → dropped (collides with NSObject's `id`). Fixed in 2 scripts.
- Unquoted `size:` key → dropped (collides with NSSize/NSObject's `size`). Fixed in `get_attachments`.

All colliding keys now use AppleScript vertical-bar quoting (`|name|`, `|id|`, `|size|`). Regression guards assert the correct form appears in each generated script.

### Docs

- [.claude/skills/applescript-mail/SKILL.md](.claude/skills/applescript-mail/SKILL.md) — new "Emitting JSON from AppleScript" section covering the helper pattern, selector-collision gotchas, and missing-value coercion.
- [.claude/CLAUDE.md](.claude/CLAUDE.md) — removed pipe-delimited gotcha; refreshed skill summary line.
- Related skills (performance-patterns, integration-testing) refreshed to remove stale "pipe-delimited" references.

Closes #23.

## Test plan
- [x] `make test` — 251 unit tests pass (3 new pipe-tolerance + 5 script-quoting + 2 regression-guard tests added beyond existing coverage)
- [x] `make test-e2e` — 20 E2E tests still pass (connector mocked at server layer)
- [x] `make check-all` — lint, mypy strict, complexity, version-sync, parity all green; coverage 95%
- [x] Integration smoke via `osascript` against real Mail.app — `list_accounts` returns 5 accounts with structured data, `list_mailboxes` returns proper `{"name","unread_count"}` records. Selector-collision bugs caught and fixed before ship.
- [ ] GitHub Actions `Tests` workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)