### PR TITLE
Enforce version sync in pre-commit hook (#25)

### DIFF
--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,7 +1,9 @@
 #!/bin/bash
-# Pre-commit hook: block commits to main, warn on version bump without CHANGELOG.
+# Pre-commit hook: block commits to main, verify version sync, warn on version
+# bump without CHANGELOG.
 set -euo pipefail
 
+REPO_ROOT=$(git rev-parse --show-toplevel)
 BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
 
 # Block commits to main (allow release/* branches and hotfixes)
@@ -14,6 +16,14 @@ if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
         echo "Create a feature branch: git checkout -b feature/issue-N-description"
         exit 1
     fi
+fi
+
+# Verify version string is consistent across pyproject.toml, __init__.py,
+# CLAUDE.md, and CHANGELOG.md. Fast (<100ms); worth running on every commit.
+if ! "$REPO_ROOT/scripts/check_version_sync.sh" > /dev/null 2>&1; then
+    echo "ERROR: Version strings are out of sync. Run the check manually:"
+    echo "  ./scripts/check_version_sync.sh"
+    exit 1
 fi
 
 # Warn if pyproject.toml version changed but CHANGELOG not staged


### PR DESCRIPTION
## Summary
- The existing `scripts/git-hooks/pre-commit` hook already blocked commits to main and warned on CHANGELOG drift, but did **not** enforce version sync. This PR adds a call to `scripts/check_version_sync.sh` inside the hook so drift between `pyproject.toml`, `__init__.py`, and `.claude/CLAUDE.md` fails the commit locally instead of surfacing later in CI.
- No new tooling or dependencies. Check is fast (~50ms) and runs on every commit.
- Contributors opt in via the existing `./scripts/install-git-hooks.sh` step (already documented in CONTRIBUTING.md).

Closes #25.

## Test plan
- [x] Hook passes on the current clean tree (all versions at 0.3.0)
- [x] Hook fails with `exit 1` when `__init__.py` is modified to a mismatched version (verified by temporarily setting it to `0.2.99`)
- [x] `make check-all` still green
- [ ] GitHub Actions green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)