### PR TITLE
Add stdio subprocess smoke test for MCP server (#50)

### DIFF
--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -11,9 +11,10 @@
 
 ### E2E Scope
 
-`make test-e2e` covers the FastMCP dispatch layer in-process: tool registration,
-schemas, and happy-path invocation for all 14 tools, with the connector mocked.
-It does NOT cover the stdio subprocess layer (tracked in issue #50).
+`make test-e2e` covers two layers:
+
+1. **In-process FastMCP dispatch** ([tests/e2e/test_mcp_tools.py](../../tests/e2e/test_mcp_tools.py)) — tool registration, schemas, and happy-path invocation for all 14 tools, with the connector mocked.
+2. **Real stdio transport** ([tests/e2e/test_stdio_transport.py](../../tests/e2e/test_stdio_transport.py)) — spawns the server as a subprocess, completes the MCP handshake over stdio, and asserts `list_tools` returns the expected 14 tools. Catches startup errors, banner/stdout contamination, and JSON-RPC framing bugs that the in-process layer cannot surface.
 
 ## Running Tests
 

--- a/tests/e2e/test_stdio_transport.py
+++ b/tests/e2e/test_stdio_transport.py
@@ -1,0 +1,72 @@
+"""Smoke tests for the MCP server over the real stdio transport.
+
+These tests spawn the server as a subprocess and connect via the MCP client
+SDK. They catch a different class of bug than tests/e2e/test_mcp_tools.py:
+
+- Startup errors (import failures, missing env, FastMCP banner interfering
+  with stdout framing).
+- JSON-RPC framing issues over pipes.
+- Stream lifecycle bugs (handshake timeout, stream closure, premature EOF).
+
+In-process FastMCP tests mock the transport — these tests don't.
+
+Keep scope narrow: a handshake + list_tools round-trip is enough to cover
+the transport layer. Per-tool behavior is the job of test_mcp_tools.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+pytestmark = pytest.mark.e2e
+
+EXPECTED_TOOLS = {
+    "list_mailboxes",
+    "search_messages",
+    "get_message",
+    "send_email",
+    "mark_as_read",
+    "send_email_with_attachments",
+    "get_attachments",
+    "save_attachments",
+    "move_messages",
+    "flag_message",
+    "create_mailbox",
+    "delete_messages",
+    "reply_to_message",
+    "forward_message",
+}
+
+# Per #50 acceptance: test must complete within 15 seconds.
+HANDSHAKE_TIMEOUT_SECONDS = 15.0
+
+
+async def _list_tools_over_stdio() -> set[str]:
+    """Spawn the server, complete the MCP handshake, and return the tool names."""
+    params = StdioServerParameters(
+        command="uv",
+        args=["run", "python", "-m", "apple_mail_mcp.server"],
+        env=None,
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.list_tools()
+            return {t.name for t in result.tools}
+
+
+async def test_stdio_subprocess_lists_all_tools() -> None:
+    """The real stdio handshake surfaces all 14 tools a client would see.
+
+    If this fails where test_mcp_tools.py passes, the bug is in the transport
+    layer: banner output contaminating stdout, stream closure, JSON-RPC framing,
+    or protocol-version negotiation.
+    """
+    names = await asyncio.wait_for(
+        _list_tools_over_stdio(), timeout=HANDSHAKE_TIMEOUT_SECONDS
+    )
+    assert names == EXPECTED_TOOLS


### PR DESCRIPTION
## Summary
- Adds `tests/e2e/test_stdio_transport.py`: spawns the server via `uv run python -m apple_mail_mcp.server`, connects with the MCP client SDK over real stdio, completes the `initialize` handshake, and asserts `list_tools` returns the expected 14 tools.
- Completes in ~1s locally; 15s `asyncio.wait_for` ceiling per the issue's acceptance criterion.
- Updates `docs/guides/TESTING.md` to describe both E2E layers (in-process FastMCP and real stdio transport) and what each catches.

This closes the transport-layer gap left open by #21. It catches failures that in-process tests cannot: startup errors, banner/stdout contamination, JSON-RPC framing, stream lifecycle.

Closes #50.

## Test plan
- [x] `make test-e2e` — 21 tests pass (20 in-process + 1 stdio smoke)
- [x] `make check-all` — all gates green
- [x] New test completes well under the 15s ceiling (~1s locally)
- [ ] GitHub Actions `Tests` workflow green on this PR (macos-latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)