### PR TITLE
release: v0.4.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Mail via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.3.0 | **Tests:** 221 unit / 20 e2e | **Coverage:** 94%
+**Version:** v0.4.0 | **Tests:** 251 unit / 21 e2e | **Coverage:** 95%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-19
+
+Quality and infrastructure milestone. No new MCP tools; focus on test coverage, safety, and parsing robustness.
+
+### Added
+- Test-mode safety system (`MAIL_TEST_MODE`, `MAIL_TEST_ACCOUNT`) — account-gated destructive operations are constrained to a designated test account and sends are constrained to RFC 2606 reserved domains (#19)
+- Three-tier sliding-window rate limiting (general / send / expensive) replacing the previous stub (#17)
+- Proper MCP elicitation for destructive operation confirmation, replacing the previous stub (#18)
+- Unit tests for all 14 `server.py` MCP tool handlers, lifting coverage from 0 % to 99 % (#16)
+- E2E tests exercising FastMCP tool registration, schema, and invocation — 20 in-process tests covering all 14 tools (#21)
+- stdio subprocess smoke test verifying the real MCP transport layer (#50)
+- Blind-agent eval framework under `evals/agent_tool_usability/` — 36 scenarios across 9 categories, runnable against any OpenRouter-accessible model (#22)
+- `docs/guides/COMPLEXITY.md` — rationale and exception table for the CC ≤ 20 ceiling (#24)
+- IMAP hybrid-approach research document (#15)
+
+### Changed
+- AppleScript output now emits JSON via ASObjC + `NSJSONSerialization` instead of the fragile pipe-delimited format that broke silently when any field contained `|` (#23). Finishes previously-placeholder `list_accounts` and `list_mailboxes` return shapes.
+- Coverage threshold raised from 60 % to 90 % in both `pyproject.toml` and CI, matching the documented target (#20)
+- Pre-commit hook now enforces version sync across `pyproject.toml`, `__init__.py`, and `.claude/CLAUDE.md` — failures block the commit locally instead of surfacing later in CI (#25)
+
+### Fixed
+- Three `NSJSONSerialization` selector-collision bugs discovered during the JSON-output migration's integration smoke: `name`, `id`, and `size` AppleScript record keys were silently dropped and are now quoted as `|name|`, `|id|`, `|size|` (#23)
+
 ## [0.3.0] - 2025-10-11
 
 Phase 3: Smart reply and forward.

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -17,7 +17,7 @@ server.py (FastMCP)
 mail_connector.py (AppleMailConnector)
   |-- AppleScript generation
   |-- subprocess.run(["osascript", "-"])
-  |-- Output parsing (pipe-delimited)
+  |-- Output parsing (JSON via ASObjC NSJSONSerialization)
   |-- Error routing (stderr -> typed exceptions)
         |
         v

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -4,7 +4,7 @@ Complete reference for all MCP tools provided by the Apple Mail MCP server.
 
 ## Overview
 
-**Current Version:** v0.3.0 (Phase 3)
+**Current Version:** v0.4.0 (Phase 3)
 **Total Tools:** 14 (5 from Phase 1 + 7 from Phase 2 + 2 from Phase 3)
 
 ## Phase 1 Tools (v0.1.0) - Core Foundation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-mail-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for Apple Mail integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_mail_mcp/__init__.py
+++ b/src/apple_mail_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Mail MCP Server
 A Model Context Protocol server for Apple Mail integration.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-mcp"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Release v0.4.0

Quality and infrastructure milestone. No new MCP tools; focus on test coverage, safety, parsing robustness, and developer tooling.

Full notes in [CHANGELOG.md](CHANGELOG.md#040---2026-04-19).

## Highlights
- **Safety + rate limiting + elicitation** (#17 #18 #19): Destructive ops are now account-gated in test mode, rate-limited in three tiers, and confirmation-gated via MCP elicitation.
- **Test coverage to 95%** (#16 #20 #21 #50): server.py from 0% → 99%; E2E tests in-process (20) and via stdio subprocess (1); coverage threshold raised to 90%.
- **JSON output from AppleScript** (#23): Replaces pipe-delimited parsing with NSJSONSerialization via ASObjC. Finishes previously-broken `list_accounts` / `list_mailboxes`. Integration smoke caught three `NSJSONSerialization` selector-collision bugs before ship (`name`, `id`, `size` keys silently dropped — now quoted).
- **Blind agent evals** (#22): 36 scenarios across 9 categories in `evals/agent_tool_usability/`, runnable against any OpenRouter model.
- **Developer tooling** (#24 #25): Pre-commit hook enforces version sync; complexity threshold and exceptions documented.

## Closed issues
#15 #16 #17 #18 #19 #20 #21 #22 #23 #24 #25 #37 #50

## Deferred to v0.4.1 (#57)
- pip-audit found 4 transitive-dep vulns (authlib, cryptography, pytest-dev, python-multipart). None are direct deps; none touch paths this project uses. Bumping via `uv lock --upgrade` deferred to avoid lock churn mid-release.
- Three integration tests promised by #23's design doc (`list_accounts`, `get_message`, `get_attachments` shape assertions vs real Mail.app) — flagged by release review, folded into #57.

## Release checklist
- [x] Milestone v0.4.0: 13/13 closed
- [x] Version bumped: pyproject, __init__, CLAUDE.md, TOOLS.md, uv.lock
- [x] CHANGELOG entry added
- [x] `make check-all` — lint, typecheck, complexity, version-sync, parity all green
- [x] Coverage 95.4% (fail_under 90%)
- [x] Release code review: Ship
- [ ] CI green on this PR
- [ ] Rebase-merge; tag `v0.4.0` on main; push tag; close milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)