### PR TITLE
release: v0.4.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Mail via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.4.0 | **Tests:** 251 unit / 21 e2e | **Coverage:** 95%
+**Version:** v0.4.1 | **Tests:** 254 unit / 21 e2e | **Coverage:** 95%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-19
+
+Patch release: dep hygiene and v0.4.0 follow-ups. Four connector bugs that unit tests couldn't catch were surfaced by running the three new integration tests against real Mail.app.
+
+### Added
+- Integration tests for `list_accounts`, `get_message`, and `get_attachments` against real Mail.app, fulfilling the #23 design doc commitment (#57)
+
+### Changed
+- Bumped transitive deps to clear `pip-audit` findings from the v0.4.0 release: `authlib` 1.6.9 → 1.7.0, `cryptography` 46.0.6 → 46.0.7, `pytest` 9.0.2 → 9.0.3, `python-multipart` 0.0.22 → 0.0.26. `fastmcp`/`mcp`/`pydantic`/`starlette`/`uvicorn` unchanged (#57)
+
+### Fixed
+- `search_messages` with no filter conditions emitted `messages of mailboxRef whose true` — Mail rejected with error -1726. The `whose` clause is now dropped entirely when no filters are supplied (#57)
+- `search_messages` with a `limit` emitted `items 1 thru N of (messages of mailboxRef …)` — Mail rejected with error -1728. Replaced with a `count of` + indexed `item i of` repeat loop (#57)
+- `_run_applescript` error-substring matcher checked for straight-apostrophe `Can't`, but macOS stderr uses curly `Can’t`. `MailAccountNotFoundError` and `MailMailboxNotFoundError` were silently degraded to generic errors. Curly apostrophes are now normalized before dispatch (#57)
+- Several AppleScript record keys (`subject`, `sender`, `content`, `date_received`, `read_status`, `flagged`, `mime_type`, `downloaded`, `email_addresses`, `unread_count`) were silently dropped by NSJSONSerialization when values came from live Mail objects. Extended the prior `|name|` / `|id|` / `|size|` quoting to **every** record key across all 5 JSON-emitting methods (#57)
+
 ## [0.4.0] - 2026-04-19
 
 Quality and infrastructure milestone. No new MCP tools; focus on test coverage, safety, and parsing robustness.

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -4,7 +4,7 @@ Complete reference for all MCP tools provided by the Apple Mail MCP server.
 
 ## Overview
 
-**Current Version:** v0.4.0 (Phase 3)
+**Current Version:** v0.4.1 (Phase 3)
 **Total Tools:** 14 (5 from Phase 1 + 7 from Phase 2 + 2 from Phase 3)
 
 ## Phase 1 Tools (v0.1.0) - Core Foundation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-mail-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "MCP server for Apple Mail integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_mail_mcp/__init__.py
+++ b/src/apple_mail_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Mail MCP Server
 A Model Context Protocol server for Apple Mail integration.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-mcp"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Release v0.4.1

Patch release. One merged PR (#59) addressing v0.4.0 follow-ups + bugs surfaced by actually running the new integration tests against real Mail.app.

Full notes in [CHANGELOG.md](CHANGELOG.md#041---2026-04-19).

## Highlights
- **Dep hygiene**: All 4 `pip-audit` findings from the v0.4.0 release cleared via targeted `uv lock --upgrade-package`. fastmcp/mcp/pydantic/starlette/uvicorn unchanged.
- **Four connector bugs** caught by integration tests that unit tests couldn't see:
  - `whose true` rejected by Mail when no filters supplied (#57)
  - `items 1 thru N of (messages …)` rejected — replaced with `count of` + `item i of` loop
  - Curly-apostrophe (`Can’t`) in macOS stderr bypassed typed-exception mapping — now normalized
  - NSJSONSerialization silently dropped `subject`/`sender`/`content` and several other record keys for live Mail objects — extended `|key|` quoting to every key
- **Three new integration tests** (`list_accounts`, `get_message`, `get_attachments`), fulfilling the #23 design-doc commitment.

## Closed issues
#57

## Release checklist
- [x] Milestone v0.4.1: 1/1 closed
- [x] Version bumped across 5 files + `uv.lock`
- [x] CHANGELOG entry added
- [x] `make check-all` green — lint, typecheck, 254 unit + 21 e2e pass, coverage 95%, complexity, version-sync, parity
- [x] `uv run pip-audit` — zero findings
- [x] Release code review: Ship
- [ ] CI green on this PR
- [ ] Rebase-merge; tag `v0.4.1` on main; push tag; close milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)