### PR TITLE
Expose list_accounts as MCP tool (#26)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,11 +23,12 @@ make coverage              # Coverage report
 
 **Running the server:** `uv run python -m apple_mail_mcp.server` or via Claude Desktop config.
 
-## API Surface (14 MCP tools)
+## API Surface (15 MCP tools)
 
 **Core (Phase 1):** list_mailboxes, search_messages, get_message, send_email, mark_as_read
 **Attachments & Management (Phase 2):** send_email_with_attachments, get_attachments, save_attachments, move_messages, flag_message, create_mailbox, delete_messages
 **Reply/Forward (Phase 3):** reply_to_message, forward_message
+**Discovery (Phase 4):** list_accounts
 
 ## Core Principles
 

--- a/.claude/skills/api-design/SKILL.md
+++ b/.claude/skills/api-design/SKILL.md
@@ -5,7 +5,7 @@ description: Use BEFORE adding any new tool, parameter, or endpoint to the Apple
 
 # Apple Mail MCP API Design
 
-The current API has 14 tools organized into 3 phases. Tool count should grow slowly and deliberately. Every new tool request must pass through the decision tree.
+The current API has 15 tools organized into 4 phases. Tool count should grow slowly and deliberately. Every new tool request must pass through the decision tree.
 
 ## Decision Tree: Use BEFORE Adding Any Tool
 

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -13,8 +13,8 @@
 
 `make test-e2e` covers two layers:
 
-1. **In-process FastMCP dispatch** ([tests/e2e/test_mcp_tools.py](../../tests/e2e/test_mcp_tools.py)) — tool registration, schemas, and happy-path invocation for all 14 tools, with the connector mocked.
-2. **Real stdio transport** ([tests/e2e/test_stdio_transport.py](../../tests/e2e/test_stdio_transport.py)) — spawns the server as a subprocess, completes the MCP handshake over stdio, and asserts `list_tools` returns the expected 14 tools. Catches startup errors, banner/stdout contamination, and JSON-RPC framing bugs that the in-process layer cannot surface.
+1. **In-process FastMCP dispatch** ([tests/e2e/test_mcp_tools.py](../../tests/e2e/test_mcp_tools.py)) — tool registration, schemas, and happy-path invocation for all 15 tools, with the connector mocked.
+2. **Real stdio transport** ([tests/e2e/test_stdio_transport.py](../../tests/e2e/test_stdio_transport.py)) — spawns the server as a subprocess, completes the MCP handshake over stdio, and asserts `list_tools` returns the expected 15 tools. Catches startup errors, banner/stdout contamination, and JSON-RPC framing bugs that the in-process layer cannot surface.
 
 ## Running Tests
 

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -4,8 +4,8 @@ Complete reference for all MCP tools provided by the Apple Mail MCP server.
 
 ## Overview
 
-**Current Version:** v0.4.1 (Phase 3)
-**Total Tools:** 14 (5 from Phase 1 + 7 from Phase 2 + 2 from Phase 3)
+**Current Version:** v0.5.0 (Phase 4)
+**Total Tools:** 15 (5 from Phase 1 + 7 from Phase 2 + 2 from Phase 3 + 1 from Phase 4)
 
 ## Phase 1 Tools (v0.1.0) - Core Foundation
 
@@ -977,10 +977,55 @@ send_email(
 
 ---
 
+## Phase 4 Tools (v0.5.0)
+
+### list_accounts
+
+List all configured email accounts in Apple Mail, with identity, type, and enabled state. Account ids are stable across name changes — prefer them over names when chaining into other tools.
+
+**Parameters:** None.
+
+**Returns:**
+
+```json
+{
+  "success": true,
+  "accounts": [
+    {
+      "id": "B21B254B-CC54-4DA4-B3D9-793E57A8E908",
+      "name": "Gmail",
+      "email_addresses": ["me@gmail.com"],
+      "account_type": "imap",
+      "enabled": true
+    }
+  ],
+  "count": 1
+}
+```
+
+**Field notes:**
+
+- `id`: Account UUID. Stable across display-name changes; future tools may accept this in place of `name`.
+- `account_type`: One of `imap`, `pop`, `iCloud`, `hotmail`, `iCal`, `smtp`. Derived from Mail's internal type constant.
+- `enabled`: `false` for accounts the user has disabled in Mail.app preferences.
+
+**Examples:**
+
+```python
+# Discover accounts before chaining into a mailbox listing
+accounts = list_accounts()
+first_enabled = next(a for a in accounts["accounts"] if a["enabled"])
+list_mailboxes(first_enabled["name"])
+```
+
+---
+
 ## API Stability
 
-- **Phase 1 (v0.1.x)**: Current tools are stable
-- **Phase 2 (v0.2.x)**: New tools will be added, existing tools unchanged
-- **Phase 3+ (v0.3.x+)**: Advanced features, backward compatible
+- **Phase 1 (v0.1.x)**: Core tools stable
+- **Phase 2 (v0.2.x)**: Attachments + management
+- **Phase 3 (v0.3.x)**: Reply/forward
+- **Phase 4 (v0.5.x)**: Discovery (list_accounts)
+- **Phase 5+**: Further enhancements, backward compatible
 
 Breaking changes will only occur in major versions (1.0.0, 2.0.0, etc.).

--- a/evals/agent_tool_usability/run_eval.py
+++ b/evals/agent_tool_usability/run_eval.py
@@ -54,7 +54,7 @@ List the exact tool calls you would make, in order, with all parameters. Explain
 {tool_descriptions}"""
 
 TOOL_NAMES = [
-    "list_mailboxes", "search_messages", "get_message",
+    "list_accounts", "list_mailboxes", "search_messages", "get_message",
     "send_email", "send_email_with_attachments",
     "get_attachments", "save_attachments",
     "mark_as_read", "flag_message",

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -20,8 +20,40 @@ response text. It is rule-based (not model-based) to avoid self-scoring bias.
 
 SCENARIOS = [
     # =========================================================================
-    # Category 1: Discovery (list_mailboxes)
+    # Category 1: Discovery (list_accounts, list_mailboxes)
     # =========================================================================
+    {
+        "id": 37,
+        "category": "Discovery",
+        "name": "List configured accounts",
+        "prompt": "What email accounts do I have configured?",
+        "expected": {
+            "tools": ["list_accounts"],
+            "key_params": {"list_accounts": {}},
+        },
+        "scoring_notes": (
+            "PASS: Calls list_accounts with no parameters. "
+            "PARTIAL: Mentions list_accounts but also calls an unrelated tool first. "
+            "FAIL: Calls list_mailboxes (which requires an account name) or invents accounts."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 38,
+        "category": "Discovery",
+        "name": "Find enabled accounts only",
+        "prompt": "Which of my accounts are currently enabled?",
+        "expected": {
+            "tools": ["list_accounts"],
+            "key_params": {"list_accounts": {}},
+        },
+        "scoring_notes": (
+            "PASS: Calls list_accounts and filters by enabled=True in the response. "
+            "PARTIAL: Calls list_accounts but doesn't address the 'enabled' filter. "
+            "FAIL: Calls a different tool."
+        ),
+        "safety_critical": False,
+    },
     {
         "id": 1,
         "category": "Discovery",

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -83,6 +83,14 @@ Get full details of a specific message.
 
 ---
 
+### list_accounts
+
+List all configured email accounts. Returns each account's id (UUID), name, email_addresses, account_type (`imap`, `pop`, `iCloud`, etc.), and enabled state. Call first to discover accounts before any other tool that needs an account name.
+
+**Parameters:** None.
+
+---
+
 ### list_mailboxes
 
 List all mailboxes for an account. Returns each mailbox's name and unread_count. Call once per account to discover mailbox names — there is no cross-account listing.

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -130,8 +130,11 @@ class AppleMailConnector:
 
         Returns:
             List of account dicts with keys:
+              - id: account UUID (stable across name changes)
               - name: account display name
               - email_addresses: list of associated email addresses
+              - account_type: lowercase Mail type (e.g., "imap", "pop", "iCloud")
+              - enabled: whether the account is currently enabled in Mail.app
         """
         tell_body = """
         tell application "Mail"
@@ -139,7 +142,7 @@ class AppleMailConnector:
             repeat with acc in accounts
                 set accEmails to email addresses of acc
                 if accEmails is missing value then set accEmails to {}
-                set accRecord to {|name|:(name of acc), |email_addresses|:accEmails}
+                set accRecord to {|id|:(id of acc as text), |name|:(name of acc), |email_addresses|:accEmails, |account_type|:((account type of acc) as text), |enabled|:(enabled of acc)}
                 set end of resultData to accRecord
             end repeat
         end tell

--- a/src/apple_mail_mcp/security.py
+++ b/src/apple_mail_mcp/security.py
@@ -118,6 +118,7 @@ TIER_LIMITS: dict[str, tuple[int, float]] = {
 }
 
 OPERATION_TIERS: dict[str, str] = {
+    "list_accounts": "cheap_reads",
     "list_mailboxes": "cheap_reads",
     "get_message": "cheap_reads",
     "get_attachments": "cheap_reads",

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -96,6 +96,51 @@ async def _elicit_confirmation(
 
 
 @mcp.tool()
+def list_accounts() -> dict[str, Any]:
+    """
+    List all configured email accounts in Apple Mail.
+
+    Returns each account's id (UUID), display name, email addresses,
+    account type, and enabled state. Account ids are stable across name
+    changes; prefer them over names for identifying accounts.
+
+    Returns:
+        Dictionary containing the accounts list.
+
+    Example:
+        >>> list_accounts()
+        {"success": True, "accounts": [
+            {"id": "B21B254B-...", "name": "Gmail", "email_addresses": ["me@gmail.com"],
+             "account_type": "imap", "enabled": True}, ...
+        ]}
+    """
+    try:
+        rate_err = check_rate_limit("list_accounts", {})
+        if rate_err:
+            return rate_err
+
+        logger.info("Listing accounts")
+
+        accounts = mail.list_accounts()
+
+        operation_logger.log_operation("list_accounts", {}, "success")
+
+        return {
+            "success": True,
+            "accounts": accounts,
+            "count": len(accounts),
+        }
+
+    except Exception as e:
+        logger.error(f"Error listing accounts: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "unknown",
+        }
+
+
+@mcp.tool()
 def list_mailboxes(account: str) -> dict[str, Any]:
     """
     List all mailboxes for an account.

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -22,6 +22,7 @@ from apple_mail_mcp import server
 pytestmark = pytest.mark.e2e
 
 EXPECTED_TOOLS = {
+    "list_accounts",
     "list_mailboxes",
     "search_messages",
     "get_message",
@@ -64,17 +65,6 @@ class TestToolRegistration:
         names = {t.name for t in tools}
         assert names == EXPECTED_TOOLS
 
-    async def test_list_accounts_not_exposed_as_tool(self) -> None:
-        """list_accounts exists on the connector but is intentionally not an MCP tool.
-
-        This mirrors the known warning from scripts/check_client_server_parity.sh.
-        If list_accounts is ever exposed, update check_client_server_parity.sh
-        AND delete this test.
-        """
-        tools = await server.mcp.list_tools()
-        names = {t.name for t in tools}
-        assert "list_accounts" not in names
-
     async def test_every_tool_has_description(self) -> None:
         tools = await server.mcp.list_tools()
         missing = [t.name for t in tools if not (t.description and t.description.strip())]
@@ -113,6 +103,14 @@ _TMP_FILE = "__TMP_FILE__"
 
 # (tool_name, call_args, connector_method, connector_return_value)
 INVOCATION_CASES: list[tuple[str, dict[str, Any], str, Any]] = [
+    (
+        "list_accounts",
+        {},
+        "list_accounts",
+        [{"id": "UUID-1", "name": "Gmail",
+          "email_addresses": ["me@gmail.com"],
+          "account_type": "imap", "enabled": True}],
+    ),
     (
         "list_mailboxes",
         {"account": "TestAccount"},

--- a/tests/e2e/test_stdio_transport.py
+++ b/tests/e2e/test_stdio_transport.py
@@ -25,6 +25,7 @@ from mcp.client.stdio import stdio_client
 pytestmark = pytest.mark.e2e
 
 EXPECTED_TOOLS = {
+    "list_accounts",
     "list_mailboxes",
     "search_messages",
     "get_message",

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -82,15 +82,20 @@ class TestMailIntegration:
 
         Guards against the pre-0.4.0 `[{"raw": str}]` placeholder shape and
         the NSJSONSerialization `|name|` selector-collision bug fixed in #23.
+        Exercises the v0.5.0 fields added in #26: id, account_type, enabled.
         """
         result = connector.list_accounts()
         assert isinstance(result, list)
         assert len(result) >= 1
         for acct in result:
-            assert set(acct.keys()) >= {"name", "email_addresses"}
-            assert isinstance(acct["name"], str)
-            assert acct["name"]  # non-empty
+            assert set(acct.keys()) >= {
+                "id", "name", "email_addresses", "account_type", "enabled",
+            }
+            assert isinstance(acct["id"], str) and acct["id"]
+            assert isinstance(acct["name"], str) and acct["name"]
             assert isinstance(acct["email_addresses"], list)
+            assert isinstance(acct["account_type"], str) and acct["account_type"]
+            assert isinstance(acct["enabled"], bool)
             # No "raw" key left over from the old placeholder
             assert "raw" not in acct
 

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -109,13 +109,19 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         mock_run.return_value = (
-            '[{"name":"Gmail","email_addresses":["me@gmail.com"]},'
-            '{"name":"Work","email_addresses":["me@work.com","alt@work.com"]}]'
+            '[{"id":"UUID-1","name":"Gmail","email_addresses":["me@gmail.com"],'
+            '"account_type":"imap","enabled":true},'
+            '{"id":"UUID-2","name":"Work","email_addresses":["me@work.com","alt@work.com"],'
+            '"account_type":"iCloud","enabled":false}]'
         )
         result = connector.list_accounts()
         assert result == [
-            {"name": "Gmail", "email_addresses": ["me@gmail.com"]},
-            {"name": "Work", "email_addresses": ["me@work.com", "alt@work.com"]},
+            {"id": "UUID-1", "name": "Gmail",
+             "email_addresses": ["me@gmail.com"],
+             "account_type": "imap", "enabled": True},
+            {"id": "UUID-2", "name": "Work",
+             "email_addresses": ["me@work.com", "alt@work.com"],
+             "account_type": "iCloud", "enabled": False},
         ]
 
     @patch.object(AppleMailConnector, "_run_applescript")
@@ -131,9 +137,27 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         """An account with no email addresses must return email_addresses as []."""
-        mock_run.return_value = '[{"name":"LocalOnly","email_addresses":[]}]'
+        mock_run.return_value = (
+            '[{"id":"UUID-3","name":"LocalOnly","email_addresses":[],'
+            '"account_type":"imap","enabled":true}]'
+        )
         result = connector.list_accounts()
-        assert result == [{"name": "LocalOnly", "email_addresses": []}]
+        assert result == [{
+            "id": "UUID-3", "name": "LocalOnly", "email_addresses": [],
+            "account_type": "imap", "enabled": True,
+        }]
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_accounts_script_includes_type_and_enabled(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Generated AppleScript must extract account_type (as text) and enabled."""
+        mock_run.return_value = "[]"
+        connector.list_accounts()
+        script = mock_run.call_args[0][0]
+        assert "|account_type|:((account type of acc) as text)" in script
+        assert "|enabled|:(enabled of acc)" in script
+        assert "|id|:(id of acc as text)" in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_list_accounts_script_quotes_name_key(

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -220,9 +220,9 @@ class TestCheckRateLimit:
 
     def test_all_operations_have_tier_assigned(self) -> None:
         expected_ops = {
-            "list_mailboxes", "get_message", "get_attachments", "save_attachments",
-            "search_messages", "mark_as_read", "move_messages", "flag_message",
-            "create_mailbox", "delete_messages", "reply_to_message",
+            "list_accounts", "list_mailboxes", "get_message", "get_attachments",
+            "save_attachments", "search_messages", "mark_as_read", "move_messages",
+            "flag_message", "create_mailbox", "delete_messages", "reply_to_message",
             "send_email", "send_email_with_attachments", "forward_message",
         }
         assert set(OPERATION_TIERS.keys()) == expected_ops

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -34,6 +34,7 @@ from apple_mail_mcp.server import (
     forward_message,
     get_attachments,
     get_message,
+    list_accounts,
     list_mailboxes,
     mark_as_read,
     move_messages,
@@ -71,6 +72,58 @@ def mock_ctx_decline() -> MagicMock:
     ctx = MagicMock()
     ctx.elicit = AsyncMock(return_value=DeclinedElicitation())
     return ctx
+
+
+# ---------------------------------------------------------------------------
+# 0. list_accounts
+# ---------------------------------------------------------------------------
+
+
+class TestListAccounts:
+    def test_success_returns_accounts_and_logs(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.list_accounts.return_value = [
+            {"id": "UUID-1", "name": "Gmail",
+             "email_addresses": ["me@gmail.com"],
+             "account_type": "imap", "enabled": True},
+            {"id": "UUID-2", "name": "iCloud",
+             "email_addresses": ["me@icloud.com"],
+             "account_type": "iCloud", "enabled": True},
+        ]
+
+        result = list_accounts()
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert len(result["accounts"]) == 2
+        assert result["accounts"][0]["id"] == "UUID-1"
+        mock_mail.list_accounts.assert_called_once_with()
+        mock_logger.log_operation.assert_called_once_with(
+            "list_accounts", {}, "success"
+        )
+
+    def test_empty_returns_empty_list(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.list_accounts.return_value = []
+
+        result = list_accounts()
+
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["accounts"] == []
+
+    def test_unexpected_exception_maps_to_unknown(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.list_accounts.side_effect = RuntimeError("boom")
+
+        result = list_accounts()
+
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "boom" in result["error"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First tool in a new Phase 4 "Discovery" category. Brings total MCP surface to **15 tools**. Closes the pre-existing client-server parity warning (`list_accounts` was an internal connector method not exposed as a tool).

## Connector: expanded return shape

`list_accounts()` now returns 5 fields per account, up from 2:

```json
{"id": "UUID", "name": "Gmail", "email_addresses": ["me@gmail.com"],
 "account_type": "imap", "enabled": true}
```

- `id` — Mail.app account UUID (stable across name changes).
- `account_type` — coerced from Mail's internal constant to text (`imap` / `pop` / `iCloud` / etc.).
- `enabled` — matches the account's toggle in Mail.app preferences.

All 5 record keys are `|quoted|` per the quote-every-key rule from v0.4.1.

## Server

New `@mcp.tool() list_accounts()`. No account parameter, so no `check_test_mode_safety` call — discovery is not account-gated. Rate-limited in `cheap_reads` alongside `list_mailboxes`.

## Test updates
- Connector unit tests expanded for the new fields.
- Server tests: new `TestListAccounts` class (3 tests).
- E2E: `EXPECTED_TOOLS` 14 → 15 in both in-process and stdio transport tests; parametrized invocation case added. Removed the no-longer-true `test_list_accounts_not_exposed_as_tool` guard.
- Integration `test_list_accounts` asserts the 5 documented fields; verified against real Mail.app.

## Docs
- CLAUDE.md: 14 → 15 tools, new Phase 4 bullet.
- `docs/reference/TOOLS.md`: full Phase 4 section.
- api-design skill: 14 → 15 / 3 → 4 phases.
- `evals/agent_tool_usability/`: `run_eval.py` TOOL_NAMES, `tool_descriptions.md` entry, two new Discovery scenarios (#37, #38).

## Follow-up

[#61](../../issues/61) filed: account-gated tools (`list_mailboxes`, `search_messages`, `move_messages`, `create_mailbox`) should eventually accept UUIDs in addition to display names. Naming the tool `list_accounts` matches the existing `list_mailboxes` convention; the issue was originally titled `get_accounts`.

Closes #26.

## Test plan
- [x] `make test` — 258 unit tests pass
- [x] `make test-e2e` — 21 pass (15 registration/invocation + 1 stdio + 5 others)
- [x] `make check-all` — green including the (now-gone) parity warning
- [x] `make test-integration` — `test_list_accounts` passes against real Mail.app
- [ ] GitHub Actions `Tests` workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)