### PR TITLE
Add list_rules MCP tool (#27)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,12 +23,12 @@ make coverage              # Coverage report
 
 **Running the server:** `uv run python -m apple_mail_mcp.server` or via Claude Desktop config.
 
-## API Surface (15 MCP tools)
+## API Surface (16 MCP tools)
 
 **Core (Phase 1):** list_mailboxes, search_messages, get_message, send_email, mark_as_read
 **Attachments & Management (Phase 2):** send_email_with_attachments, get_attachments, save_attachments, move_messages, flag_message, create_mailbox, delete_messages
 **Reply/Forward (Phase 3):** reply_to_message, forward_message
-**Discovery (Phase 4):** list_accounts
+**Discovery (Phase 4):** list_accounts, list_rules
 
 ## Core Principles
 

--- a/.claude/skills/api-design/SKILL.md
+++ b/.claude/skills/api-design/SKILL.md
@@ -5,7 +5,7 @@ description: Use BEFORE adding any new tool, parameter, or endpoint to the Apple
 
 # Apple Mail MCP API Design
 
-The current API has 15 tools organized into 4 phases. Tool count should grow slowly and deliberately. Every new tool request must pass through the decision tree.
+The current API has 16 tools organized into 4 phases. Tool count should grow slowly and deliberately. Every new tool request must pass through the decision tree.
 
 ## Decision Tree: Use BEFORE Adding Any Tool
 

--- a/.claude/skills/applescript-mail/SKILL.md
+++ b/.claude/skills/applescript-mail/SKILL.md
@@ -121,7 +121,7 @@ messages whose sender contains "user" and subject contains "report"
 
 1. **No scheduled sending** — Mail.app has no AppleScript support for delayed/scheduled sends
 2. **No thread/conversation access** — Messages are individual objects; no thread grouping in AppleScript API
-3. **No rule management** — Mail rules cannot be read or modified via AppleScript
+3. **Rule management is partial** — Rules are *readable* (`rules` collection, `name`, `enabled`, conditions/actions), but have no stable `id` and must be addressed positionally or by non-unique name. Mutation paths (creating, updating, deleting) are more complex and not yet implemented.
 4. **No smart mailbox access** — Smart mailboxes are not exposed to AppleScript
 5. **Rich text body** — `content of message` returns plain text; HTML body requires alternate approach
 6. **Read receipt** — Cannot request or detect read receipts

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -13,8 +13,8 @@
 
 `make test-e2e` covers two layers:
 
-1. **In-process FastMCP dispatch** ([tests/e2e/test_mcp_tools.py](../../tests/e2e/test_mcp_tools.py)) — tool registration, schemas, and happy-path invocation for all 15 tools, with the connector mocked.
-2. **Real stdio transport** ([tests/e2e/test_stdio_transport.py](../../tests/e2e/test_stdio_transport.py)) — spawns the server as a subprocess, completes the MCP handshake over stdio, and asserts `list_tools` returns the expected 15 tools. Catches startup errors, banner/stdout contamination, and JSON-RPC framing bugs that the in-process layer cannot surface.
+1. **In-process FastMCP dispatch** ([tests/e2e/test_mcp_tools.py](../../tests/e2e/test_mcp_tools.py)) — tool registration, schemas, and happy-path invocation for all 16 tools, with the connector mocked.
+2. **Real stdio transport** ([tests/e2e/test_stdio_transport.py](../../tests/e2e/test_stdio_transport.py)) — spawns the server as a subprocess, completes the MCP handshake over stdio, and asserts `list_tools` returns the expected 16 tools. Catches startup errors, banner/stdout contamination, and JSON-RPC framing bugs that the in-process layer cannot surface.
 
 ## Running Tests
 

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -5,7 +5,7 @@ Complete reference for all MCP tools provided by the Apple Mail MCP server.
 ## Overview
 
 **Current Version:** v0.5.0 (Phase 4)
-**Total Tools:** 15 (5 from Phase 1 + 7 from Phase 2 + 2 from Phase 3 + 1 from Phase 4)
+**Total Tools:** 16 (5 from Phase 1 + 7 from Phase 2 + 2 from Phase 3 + 2 from Phase 4)
 
 ## Phase 1 Tools (v0.1.0) - Core Foundation
 
@@ -978,6 +978,37 @@ send_email(
 ---
 
 ## Phase 4 Tools (v0.5.0)
+
+### list_rules
+
+List all Mail.app rules (read-only). Returns each rule's name and enabled state.
+
+**Parameters:** None.
+
+**Returns:**
+
+```json
+{
+  "success": true,
+  "rules": [
+    {"name": "Junk filter", "enabled": true},
+    {"name": "News From Apple", "enabled": false}
+  ],
+  "count": 2
+}
+```
+
+**Field notes:**
+
+- `name`: Rule display name. **Not guaranteed unique** — Mail.app allows multiple rules with the same name.
+- `enabled`: Reflects the rule's toggle in Mail.app's Rules preferences.
+
+**Limitations:**
+
+- Read-only. Mutation (enable/disable, create, update, delete) is tracked as a separate enhancement.
+- Rules have no stable id via AppleScript. Addressing a specific rule for future mutation would require positional (index) or name-based (ambiguous) handles.
+
+---
 
 ### list_accounts
 

--- a/evals/agent_tool_usability/run_eval.py
+++ b/evals/agent_tool_usability/run_eval.py
@@ -54,7 +54,7 @@ List the exact tool calls you would make, in order, with all parameters. Explain
 {tool_descriptions}"""
 
 TOOL_NAMES = [
-    "list_accounts", "list_mailboxes", "search_messages", "get_message",
+    "list_accounts", "list_rules", "list_mailboxes", "search_messages", "get_message",
     "send_email", "send_email_with_attachments",
     "get_attachments", "save_attachments",
     "mark_as_read", "flag_message",

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -39,6 +39,22 @@ SCENARIOS = [
         "safety_critical": False,
     },
     {
+        "id": 39,
+        "category": "Discovery",
+        "name": "List configured rules",
+        "prompt": "What mail rules do I have set up?",
+        "expected": {
+            "tools": ["list_rules"],
+            "key_params": {"list_rules": {}},
+        },
+        "scoring_notes": (
+            "PASS: Calls list_rules with no parameters. "
+            "PARTIAL: Mentions list_rules but calls an unrelated tool first. "
+            "FAIL: Invents rules, claims rules aren't accessible, or calls a different tool."
+        ),
+        "safety_critical": False,
+    },
+    {
         "id": 38,
         "category": "Discovery",
         "name": "Find enabled accounts only",

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -100,6 +100,14 @@ List all mailboxes for an account. Returns each mailbox's name and unread_count.
 
 ---
 
+### list_rules
+
+List all Mail.app rules (read-only). Returns each rule's name and enabled state. Rule names are not guaranteed unique and rules have no stable id — address them carefully if you plan to act on a specific one.
+
+**Parameters:** None.
+
+---
+
 ### mark_as_read
 
 Mark messages as read or unread.

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -152,6 +152,33 @@ class AppleMailConnector:
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
+    def list_rules(self) -> list[dict[str, Any]]:
+        """List all Mail.app rules.
+
+        Returns:
+            List of rule dicts with keys:
+              - name: rule display name (NOT guaranteed unique — Mail allows duplicates)
+              - enabled: whether the rule is currently enabled
+
+        Note:
+            Mail.app does not expose a stable rule id via AppleScript, so rules
+            can only be addressed positionally or by name (with duplicate-name
+            ambiguity). Read-only for now; see the CRUD follow-up issue.
+        """
+        tell_body = """
+        tell application "Mail"
+            set resultData to {}
+            repeat with r in rules
+                set ruleRecord to {|name|:(name of r), |enabled|:(enabled of r)}
+                set end of resultData to ruleRecord
+            end repeat
+        end tell
+        """
+
+        script = _wrap_as_json_script(tell_body)
+        result = self._run_applescript(script)
+        return cast(list[dict[str, Any]], parse_applescript_json(result))
+
     def list_mailboxes(self, account: str) -> list[dict[str, Any]]:
         """List all mailboxes for an account.
 

--- a/src/apple_mail_mcp/security.py
+++ b/src/apple_mail_mcp/security.py
@@ -119,6 +119,7 @@ TIER_LIMITS: dict[str, tuple[int, float]] = {
 
 OPERATION_TIERS: dict[str, str] = {
     "list_accounts": "cheap_reads",
+    "list_rules": "cheap_reads",
     "list_mailboxes": "cheap_reads",
     "get_message": "cheap_reads",
     "get_attachments": "cheap_reads",

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -141,6 +141,52 @@ def list_accounts() -> dict[str, Any]:
 
 
 @mcp.tool()
+def list_rules() -> dict[str, Any]:
+    """
+    List all Mail.app rules (read-only).
+
+    Returns each rule's display name and enabled state. Rule names are NOT
+    guaranteed unique — Mail allows duplicates — and rules have no stable
+    id via AppleScript. This tool is read-only; mutation (enable/disable,
+    create, delete) is tracked as a separate enhancement.
+
+    Returns:
+        Dictionary containing the rules list.
+
+    Example:
+        >>> list_rules()
+        {"success": True, "rules": [
+            {"name": "Junk filter", "enabled": True},
+            {"name": "News From Apple", "enabled": False}, ...
+        ], "count": 2}
+    """
+    try:
+        rate_err = check_rate_limit("list_rules", {})
+        if rate_err:
+            return rate_err
+
+        logger.info("Listing rules")
+
+        rules = mail.list_rules()
+
+        operation_logger.log_operation("list_rules", {}, "success")
+
+        return {
+            "success": True,
+            "rules": rules,
+            "count": len(rules),
+        }
+
+    except Exception as e:
+        logger.error(f"Error listing rules: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "unknown",
+        }
+
+
+@mcp.tool()
 def list_mailboxes(account: str) -> dict[str, Any]:
     """
     List all mailboxes for an account.

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -23,6 +23,7 @@ pytestmark = pytest.mark.e2e
 
 EXPECTED_TOOLS = {
     "list_accounts",
+    "list_rules",
     "list_mailboxes",
     "search_messages",
     "get_message",
@@ -110,6 +111,12 @@ INVOCATION_CASES: list[tuple[str, dict[str, Any], str, Any]] = [
         [{"id": "UUID-1", "name": "Gmail",
           "email_addresses": ["me@gmail.com"],
           "account_type": "imap", "enabled": True}],
+    ),
+    (
+        "list_rules",
+        {},
+        "list_rules",
+        [{"name": "Junk filter", "enabled": True}],
     ),
     (
         "list_mailboxes",

--- a/tests/e2e/test_stdio_transport.py
+++ b/tests/e2e/test_stdio_transport.py
@@ -26,6 +26,7 @@ pytestmark = pytest.mark.e2e
 
 EXPECTED_TOOLS = {
     "list_accounts",
+    "list_rules",
     "list_mailboxes",
     "search_messages",
     "get_message",

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -99,6 +99,20 @@ class TestMailIntegration:
             # No "raw" key left over from the old placeholder
             assert "raw" not in acct
 
+    def test_list_rules(self, connector: AppleMailConnector) -> None:
+        """Real list_rules returns structured rule records.
+
+        Rules list may be empty for a user who has never configured any. Empty
+        is a valid pass. Non-empty entries must have name + enabled with the
+        right types.
+        """
+        result = connector.list_rules()
+        assert isinstance(result, list)
+        for rule in result:
+            assert set(rule.keys()) >= {"name", "enabled"}
+            assert isinstance(rule["name"], str) and rule["name"]
+            assert isinstance(rule["enabled"], bool)
+
     def test_get_message(
         self, connector: AppleMailConnector, test_account: str
     ) -> None:

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -160,6 +160,53 @@ class TestAppleMailConnector:
         assert "|id|:(id of acc as text)" in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_rules_returns_structured_data(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = (
+            '[{"name":"News From Apple","enabled":false},'
+            '{"name":"Junk filter","enabled":true}]'
+        )
+        result = connector.list_rules()
+        assert result == [
+            {"name": "News From Apple", "enabled": False},
+            {"name": "Junk filter", "enabled": True},
+        ]
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_rules_empty(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "[]"
+        result = connector.list_rules()
+        assert result == []
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_rules_allows_duplicate_names(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Mail allows multiple rules with the same name — connector returns both."""
+        mock_run.return_value = (
+            '[{"name":"Send to OmniFocus","enabled":false},'
+            '{"name":"Send to OmniFocus","enabled":true}]'
+        )
+        result = connector.list_rules()
+        assert len(result) == 2
+        assert result[0]["name"] == result[1]["name"]
+        assert result[0]["enabled"] != result[1]["enabled"]
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_rules_script_quotes_keys(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Record keys must be |quoted| per the v0.4.1 selector-collision rule."""
+        mock_run.return_value = "[]"
+        connector.list_rules()
+        script = mock_run.call_args[0][0]
+        assert "|name|:(name of r)" in script
+        assert "|enabled|:(enabled of r)" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
     def test_list_accounts_script_quotes_name_key(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -220,10 +220,11 @@ class TestCheckRateLimit:
 
     def test_all_operations_have_tier_assigned(self) -> None:
         expected_ops = {
-            "list_accounts", "list_mailboxes", "get_message", "get_attachments",
-            "save_attachments", "search_messages", "mark_as_read", "move_messages",
-            "flag_message", "create_mailbox", "delete_messages", "reply_to_message",
-            "send_email", "send_email_with_attachments", "forward_message",
+            "list_accounts", "list_rules", "list_mailboxes", "get_message",
+            "get_attachments", "save_attachments", "search_messages", "mark_as_read",
+            "move_messages", "flag_message", "create_mailbox", "delete_messages",
+            "reply_to_message", "send_email", "send_email_with_attachments",
+            "forward_message",
         }
         assert set(OPERATION_TIERS.keys()) == expected_ops
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -36,6 +36,7 @@ from apple_mail_mcp.server import (
     get_message,
     list_accounts,
     list_mailboxes,
+    list_rules,
     mark_as_read,
     move_messages,
     reply_to_message,
@@ -120,6 +121,53 @@ class TestListAccounts:
         mock_mail.list_accounts.side_effect = RuntimeError("boom")
 
         result = list_accounts()
+
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# 0b. list_rules
+# ---------------------------------------------------------------------------
+
+
+class TestListRules:
+    def test_success_returns_rules_and_logs(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.list_rules.return_value = [
+            {"name": "Junk filter", "enabled": True},
+            {"name": "News", "enabled": False},
+        ]
+
+        result = list_rules()
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert len(result["rules"]) == 2
+        mock_mail.list_rules.assert_called_once_with()
+        mock_logger.log_operation.assert_called_once_with(
+            "list_rules", {}, "success"
+        )
+
+    def test_empty_returns_empty_list(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.list_rules.return_value = []
+
+        result = list_rules()
+
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["rules"] == []
+
+    def test_unexpected_exception_maps_to_unknown(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.list_rules.side_effect = RuntimeError("boom")
+
+        result = list_rules()
 
         assert result["success"] is False
         assert result["error_type"] == "unknown"


### PR DESCRIPTION
## Summary

Read-only enumeration of Mail.app rules. Second tool in the Phase 4 Discovery category; brings total MCP surface to **16 tools**.

Also corrects a stale claim in the `applescript-mail` skill that said rules were inaccessible via AppleScript — they aren't; they're just awkward.

## Scope: read-only, by design

Returns `{name, enabled}` per rule. Rich fields (conditions, actions, color, stop-evaluating) are deliberately excluded until a design pass. Mutation is deliberately excluded because:

- Rules have no stable `id` via AppleScript (`id of rule` raises).
- Mail allows duplicate rule names (author's own machine has two `Send to OmniFocus` rules), so name-based handles are ambiguous.
- Rule conditions/actions are a nested, quirky schema.

**Rule CRUD is tracked as [#63](../../issues/63)** per explicit user ask during this feature.

## Connector

New `list_rules()` on `AppleMailConnector` following the established JSON-via-ASObjC pattern with `|quoted|` record keys.

## Server

New `@mcp.tool() list_rules()`. Rate-limited in `cheap_reads`. No test-mode safety gate (read-only, no account parameter).

## Tests
- 4 connector unit tests (incl. duplicate-name case + key-quoting guard)
- 3 server unit tests
- Security tier-assignment test extended
- E2E `EXPECTED_TOOLS` 15 → 16 in both in-process and stdio suites; parametrized invocation case added
- Integration test verified against real Mail.app

## Docs
- `CLAUDE.md`: 15 → 16 tools; Phase 4 bullet updated
- `docs/reference/TOOLS.md`: Phase 4 entry with field notes + limitations
- `api-design` skill: tool-count bump
- `TESTING.md`: 15 → 16
- `applescript-mail` skill: corrected the "rules cannot be accessed" claim
- Evals: `TOOL_NAMES`, `tool_descriptions.md` entry, new Discovery scenario (id=39)

Closes #27.

## Test plan
- [x] `make test` — 265 unit tests pass
- [x] `make test-e2e` — 22 pass
- [x] `make check-all` — green (parity clean, no connector-unexposed warnings)
- [x] `make test-integration::test_list_rules` — passes against real Mail.app (5 rules enumerated)
- [ ] GitHub Actions `Tests` workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)