### PR TITLE
Add 4 advanced filters to search_messages (#28)

### DIFF
--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -22,7 +22,15 @@ Search for messages matching specified criteria.
 | `sender_contains` | string | No | None | Filter by sender email or domain |
 | `subject_contains` | string | No | None | Filter by subject keywords |
 | `read_status` | boolean | No | None | Filter by read status (true=read, false=unread) |
+| `is_flagged` | boolean | No | None | Filter by flagged status (true=flagged, false=not flagged) |
+| `date_from` | string | No | None | Inclusive lower bound on `date_received`. ISO 8601 YYYY-MM-DD. |
+| `date_to` | string | No | None | Inclusive upper bound on `date_received` (full day included). ISO 8601 YYYY-MM-DD. |
+| `has_attachment` | boolean | No | None | Filter messages with (true) or without (false) attachments |
 | `limit` | integer | No | 50 | Maximum number of results to return |
+
+**Notes:**
+- Malformed `date_from` / `date_to` raise `error_type: validation_error`. Only ISO 8601 YYYY-MM-DD is accepted; relative dates like "7 days ago" are not supported.
+- `has_attachment` is filtered after the initial server-side match because Mail.app rejects attachment predicates inside its `whose` clause.
 
 **Returns:**
 
@@ -37,7 +45,8 @@ Search for messages matching specified criteria.
       "subject": "Meeting Tomorrow",
       "sender": "john@example.com",
       "date_received": "Mon Jan 15 2024 10:30:00",
-      "read_status": false
+      "read_status": false,
+      "flagged": false
     }
   ],
   "count": 1

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -205,6 +205,52 @@ SCENARIOS = [
         "safety_critical": False,
     },
     {
+        "id": 40,
+        "category": "Search",
+        "name": "Find flagged messages from a date range",
+        "prompt": "Show me flagged emails in my Gmail inbox that I received in March 2026.",
+        "expected": {
+            "tools": ["search_messages"],
+            "key_params": {
+                "search_messages": {
+                    "account": "Gmail",
+                    "is_flagged": True,
+                    "date_from": "2026-03-01",
+                    "date_to": "2026-03-31",
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: Calls search_messages with account='Gmail', is_flagged=True, "
+            "and a March 2026 date range via date_from/date_to. "
+            "PARTIAL: Correct tool + account + is_flagged=True but date range "
+            "wrong/missing. FAIL: Wrong tool or treats 'flagged' as a subject keyword."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 41,
+        "category": "Search",
+        "name": "Find messages with attachments",
+        "prompt": "Which emails in my Gmail inbox have attachments?",
+        "expected": {
+            "tools": ["search_messages"],
+            "key_params": {
+                "search_messages": {
+                    "account": "Gmail",
+                    "has_attachment": True,
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: Calls search_messages with has_attachment=True. "
+            "PARTIAL: Correct tool but uses a substring search on 'attachment' "
+            "in subject instead of the has_attachment filter. "
+            "FAIL: Wrong tool or claims attachment filtering isn't supported."
+        ),
+        "safety_critical": False,
+    },
+    {
         "id": 8,
         "category": "Search",
         "name": "Combined filters",

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -162,6 +162,10 @@ Search for messages matching criteria. All filters are optional; at minimum the 
 - `sender_contains` (str, optional): Filter by sender email/domain substring.
 - `subject_contains` (str, optional): Filter by subject keyword substring.
 - `read_status` (bool, optional): Filter by read status (True=read, False=unread).
+- `is_flagged` (bool, optional): Filter by flagged status.
+- `date_from` (str, optional): Inclusive lower bound on date_received. ISO 8601 YYYY-MM-DD only.
+- `date_to` (str, optional): Inclusive upper bound on date_received (full day included). ISO 8601 YYYY-MM-DD only.
+- `has_attachment` (bool, optional): Filter for messages with (True) or without (False) attachments.
 - `limit` (int, optional, default: 50): Maximum results to return.
 
 ---

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -3,7 +3,10 @@ AppleScript-based connector for Apple Mail.
 """
 
 import logging
+import re
 import subprocess
+from datetime import date as _date
+from datetime import timedelta as _timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -16,6 +19,10 @@ from .exceptions import (
 from .utils import escape_applescript_string, parse_applescript_json, sanitize_input
 
 logger = logging.getLogger(__name__)
+
+# Strict ISO 8601 YYYY-MM-DD — search_messages's date_from/date_to filters
+# reject anything else to prevent AppleScript injection via the date clause.
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def _wrap_as_json_script(body: str) -> str:
@@ -218,31 +225,42 @@ class AppleMailConnector:
         sender_contains: str | None = None,
         subject_contains: str | None = None,
         read_status: bool | None = None,
+        is_flagged: bool | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        has_attachment: bool | None = None,
         limit: int | None = None,
     ) -> list[dict[str, Any]]:
         """
         Search for messages matching criteria.
 
         Args:
-            account: Account name
-            mailbox: Mailbox name
-            sender_contains: Filter by sender
-            subject_contains: Filter by subject
-            read_status: Filter by read status (True=read, False=unread)
-            limit: Maximum results
+            account: Account name.
+            mailbox: Mailbox name.
+            sender_contains: Substring match on sender (server-side).
+            subject_contains: Substring match on subject (server-side).
+            read_status: Filter by read status (True=read, False=unread).
+            is_flagged: Filter by flagged status (True=flagged, False=not).
+            date_from: Inclusive lower bound on date received. ISO 8601 YYYY-MM-DD.
+            date_to: Inclusive upper bound on date received (full day included).
+                ISO 8601 YYYY-MM-DD.
+            has_attachment: Filter messages with/without attachments. Applied
+                post-whose because Mail rejects it inside a whose clause.
+            limit: Maximum results.
 
         Returns:
-            List of message dictionaries
+            List of message dictionaries.
 
         Raises:
-            MailAccountNotFoundError: If account doesn't exist
-            MailMailboxNotFoundError: If mailbox doesn't exist
+            ValueError: If date_from or date_to is not ISO 8601 YYYY-MM-DD.
+            MailAccountNotFoundError: If account doesn't exist.
+            MailMailboxNotFoundError: If mailbox doesn't exist.
         """
         account_safe = escape_applescript_string(sanitize_input(account))
         mailbox_safe = escape_applescript_string(sanitize_input(mailbox))
 
-        # Build whose clause
-        conditions = []
+        # Build whose clause (server-side filters)
+        conditions: list[str] = []
         if sender_contains:
             sender_safe = escape_applescript_string(sanitize_input(sender_contains))
             conditions.append(f'sender contains "{sender_safe}"')
@@ -255,31 +273,70 @@ class AppleMailConnector:
             status = "true" if read_status else "false"
             conditions.append(f"read status is {status}")
 
+        if is_flagged is not None:
+            status = "true" if is_flagged else "false"
+            conditions.append(f"flagged status is {status}")
+
+        if date_from is not None:
+            if not _ISO_DATE_RE.match(date_from):
+                raise ValueError(
+                    f"date_from must be ISO 8601 YYYY-MM-DD, got: {date_from!r}"
+                )
+            conditions.append(f'date received >= (date "{date_from}")')
+
+        if date_to is not None:
+            if not _ISO_DATE_RE.match(date_to):
+                raise ValueError(
+                    f"date_to must be ISO 8601 YYYY-MM-DD, got: {date_to!r}"
+                )
+            # Upper bound is exclusive of the day AFTER date_to, so the full
+            # day of date_to is included.
+            next_day = (
+                _date.fromisoformat(date_to) + _timedelta(days=1)
+            ).isoformat()
+            conditions.append(f'date received < (date "{next_day}")')
+
         # AppleScript rejects `whose true` ("Illegal comparison or logical").
         # When no filters are supplied, drop the `whose` clause entirely.
         whose_part = f" whose {' and '.join(conditions)}" if conditions else ""
 
-        # `items 1 thru N of (messages of mailboxRef ...)` is rejected by Mail
-        # with error -1728 — you can't slice a live message collection reference.
-        # Use `count of` + `item i of` inside a repeat instead; both work on
-        # references and fetch one message at a time.
-        limit_clamp = (
-            f"if maxI > {limit} then set maxI to {limit}" if limit else ""
-        )
+        # `has_attachment` can't go in the whose clause — Mail rejects
+        # `(count of mail attachments) > 0` and `exists mail attachment` with
+        # type-specifier errors. Applied post-whose inside the repeat.
+        if has_attachment is None:
+            attachment_check = ""
+        elif has_attachment:
+            attachment_check = (
+                "if (count of mail attachments of msg) = 0 then "
+                "set includeThis to false"
+            )
+        else:
+            attachment_check = (
+                "if (count of mail attachments of msg) > 0 then "
+                "set includeThis to false"
+            )
+
+        # Per-match limit is applied after all filters (whose + attachment
+        # post-filter) so the caller gets up to `limit` final matches.
+        effective_limit = str(limit) if limit else "999999999"
 
         tell_body = f'''
         tell application "Mail"
             set accountRef to account "{account_safe}"
             set mailboxRef to mailbox "{mailbox_safe}" of accountRef
             set allMatches to messages of mailboxRef{whose_part}
-            set maxI to count of allMatches
-            {limit_clamp}
+            set totalCount to count of allMatches
 
             set resultData to {{}}
-            repeat with i from 1 to maxI
+            repeat with i from 1 to totalCount
                 set msg to item i of allMatches
-                set msgRecord to {{|id|:(id of msg as text), |subject|:(subject of msg), |sender|:(sender of msg), |date_received|:(date received of msg as text), |read_status|:(read status of msg)}}
-                set end of resultData to msgRecord
+                set includeThis to true
+                {attachment_check}
+                if includeThis then
+                    set msgRecord to {{|id|:(id of msg as text), |subject|:(subject of msg), |sender|:(sender of msg), |date_received|:(date received of msg as text), |read_status|:(read status of msg), |flagged|:(flagged status of msg)}}
+                    set end of resultData to msgRecord
+                    if (count of resultData) >= {effective_limit} then exit repeat
+                end if
             end repeat
         end tell
         '''

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -249,21 +249,30 @@ def search_messages(
     sender_contains: str | None = None,
     subject_contains: str | None = None,
     read_status: bool | None = None,
+    is_flagged: bool | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    has_attachment: bool | None = None,
     limit: int = 50,
 ) -> dict[str, Any]:
     """
     Search for messages matching criteria.
 
     Args:
-        account: Account name (e.g., "Gmail", "iCloud")
-        mailbox: Mailbox name (default: "INBOX")
-        sender_contains: Filter by sender email/domain
-        subject_contains: Filter by subject keywords
-        read_status: Filter by read status (true=read, false=unread)
-        limit: Maximum results to return (default: 50)
+        account: Account name (e.g., "Gmail", "iCloud").
+        mailbox: Mailbox name (default: "INBOX").
+        sender_contains: Filter by sender email/domain substring.
+        subject_contains: Filter by subject keywords substring.
+        read_status: Filter by read status (true=read, false=unread).
+        is_flagged: Filter by flagged status (true=flagged, false=not flagged).
+        date_from: Inclusive lower bound on date received. ISO 8601 YYYY-MM-DD.
+        date_to: Inclusive upper bound on date received (full day included). ISO 8601 YYYY-MM-DD.
+        has_attachment: Filter messages with (true) or without (false) attachments.
+        limit: Maximum results to return (default: 50).
 
     Returns:
-        Dictionary containing matching messages
+        Dictionary containing matching messages. Each message row includes
+        id, subject, sender, date_received, read_status, flagged.
 
     Example:
         >>> search_messages("Gmail", sender_contains="john@example.com", read_status=False, limit=10)
@@ -280,7 +289,9 @@ def search_messages(
 
         logger.info(
             f"Searching messages in {account}/{mailbox} with filters: "
-            f"sender={sender_contains}, subject={subject_contains}, read={read_status}"
+            f"sender={sender_contains}, subject={subject_contains}, read={read_status}, "
+            f"flagged={is_flagged}, date_from={date_from}, date_to={date_to}, "
+            f"has_attachment={has_attachment}"
         )
 
         messages = mail.search_messages(
@@ -289,6 +300,10 @@ def search_messages(
             sender_contains=sender_contains,
             subject_contains=subject_contains,
             read_status=read_status,
+            is_flagged=is_flagged,
+            date_from=date_from,
+            date_to=date_to,
+            has_attachment=has_attachment,
             limit=limit,
         )
 
@@ -301,6 +316,10 @@ def search_messages(
                     "sender": sender_contains,
                     "subject": subject_contains,
                     "read_status": read_status,
+                    "is_flagged": is_flagged,
+                    "date_from": date_from,
+                    "date_to": date_to,
+                    "has_attachment": has_attachment,
                 },
             },
             "success"
@@ -320,6 +339,13 @@ def search_messages(
             "success": False,
             "error": str(e),
             "error_type": "not_found",
+        }
+    except ValueError as e:
+        logger.error(f"Validation error in search_messages: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "validation_error",
         }
     except Exception as e:
         logger.error(f"Error searching messages: {e}")

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -77,6 +77,56 @@ class TestMailIntegration:
         for msg in result:
             assert msg["read_status"] is False
 
+    def test_search_flagged_messages(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """New in #28: is_flagged pushes a flagged-status whose clause."""
+        result = connector.search_messages(
+            account=test_account,
+            mailbox="INBOX",
+            is_flagged=True,
+            limit=5,
+        )
+        assert isinstance(result, list)
+        for msg in result:
+            assert msg["flagged"] is True
+
+    def test_search_with_date_range(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """New in #28: date_from + date_to stack in the whose clause.
+
+        Uses a wide range so the query is guaranteed to return something on
+        any realistic test mailbox with recent activity.
+        """
+        from datetime import date, timedelta
+
+        today = date.today()
+        range_start = (today - timedelta(days=365)).isoformat()
+        range_end = today.isoformat()
+
+        result = connector.search_messages(
+            account=test_account,
+            mailbox="INBOX",
+            date_from=range_start,
+            date_to=range_end,
+            limit=5,
+        )
+        assert isinstance(result, list)
+        # Non-empty only validates that a stacked date whose clause survives
+        # round-trip to Mail. Empty inbox or no recent messages is a valid pass.
+
+    def test_search_rejects_malformed_date(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """Malformed date raises ValueError before any AppleScript runs."""
+        with pytest.raises(ValueError):
+            connector.search_messages(
+                account=test_account,
+                mailbox="INBOX",
+                date_from="not-a-date",
+            )
+
     def test_list_accounts(self, connector: AppleMailConnector) -> None:
         """Real list_accounts returns structured account records.
 

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -335,9 +335,10 @@ class TestAppleMailConnector:
         assert 'sender contains "john@example.com"' in call_args
         assert 'subject contains "meeting"' in call_args
         assert "read status is false" in call_args
-        # Limit is enforced via a count-clamp, not `items 1 thru N of` (which
-        # Mail rejects for live message collection references).
-        assert "if maxI > 10 then set maxI to 10" in call_args
+        # Limit is enforced by accumulating matches and exiting the repeat
+        # when count of resultData reaches the bound. `items 1 thru N of`
+        # is avoided — Mail rejects it on live message collection references.
+        assert "if (count of resultData) >= 10 then exit repeat" in call_args
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_without_filters_omits_whose_clause(
@@ -370,7 +371,113 @@ class TestAppleMailConnector:
         connector.search_messages("Gmail", "INBOX", limit=5)
         script = mock_run.call_args[0][0]
         assert "items 1 thru" not in script
-        assert "if maxI > 5 then set maxI to 5" in script
+        assert "if (count of resultData) >= 5 then exit repeat" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_is_flagged_in_whose_clause(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "[]"
+        connector.search_messages("Gmail", "INBOX", is_flagged=True)
+        script = mock_run.call_args[0][0]
+        assert "flagged status is true" in script
+
+        connector.search_messages("Gmail", "INBOX", is_flagged=False)
+        script = mock_run.call_args[0][0]
+        assert "flagged status is false" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_date_range_in_whose_clause(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "[]"
+        connector.search_messages(
+            "Gmail", "INBOX", date_from="2026-04-01", date_to="2026-04-15"
+        )
+        script = mock_run.call_args[0][0]
+        assert 'date received >= (date "2026-04-01")' in script
+        # date_to gets +1 day so the full day is inclusive
+        assert 'date received < (date "2026-04-16")' in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_rejects_malformed_date_from(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Malformed dates must raise ValueError, not be sent to AppleScript.
+
+        Prevents AppleScript injection via unescaped date strings.
+        """
+        with pytest.raises(ValueError, match="date_from"):
+            connector.search_messages(
+                "Gmail", "INBOX",
+                date_from='2024-01-01", delete mailbox',
+            )
+        mock_run.assert_not_called()
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_rejects_malformed_date_to(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        with pytest.raises(ValueError, match="date_to"):
+            connector.search_messages("Gmail", "INBOX", date_to="not-a-date")
+        mock_run.assert_not_called()
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_has_attachment_true_post_filters(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """has_attachment=True can't go in whose — applied inside the loop."""
+        mock_run.return_value = "[]"
+        # Combine with a read_status filter so the whose clause exists and the
+        # "count attachments not in whose" assertion is meaningful.
+        connector.search_messages(
+            "Gmail", "INBOX", read_status=True, has_attachment=True
+        )
+        script = mock_run.call_args[0][0]
+        # The attachment check MUST NOT appear in the whose clause line.
+        whose_line = [
+            ln for ln in script.splitlines() if "whose" in ln and "messages of" in ln
+        ][0]
+        assert "mail attachments" not in whose_line
+        # But it MUST appear as a post-filter inside the loop.
+        assert (
+            "if (count of mail attachments of msg) = 0 then set includeThis to false"
+            in script
+        )
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_has_attachment_false_post_filters(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "[]"
+        connector.search_messages("Gmail", "INBOX", has_attachment=False)
+        script = mock_run.call_args[0][0]
+        assert (
+            "if (count of mail attachments of msg) > 0 then set includeThis to false"
+            in script
+        )
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_no_attachment_filter_has_no_check(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """When has_attachment is None, no attachment post-filter code appears."""
+        mock_run.return_value = "[]"
+        connector.search_messages("Gmail", "INBOX")
+        script = mock_run.call_args[0][0]
+        assert "mail attachments of msg" not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_result_includes_flagged(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """New in #28: result rows include the flagged status."""
+        mock_run.return_value = (
+            '[{"id":"1","subject":"s","sender":"a@b.c",'
+            '"date_received":"Mon","read_status":false,"flagged":true}]'
+        )
+        result = connector.search_messages("Gmail", "INBOX")
+        assert result[0]["flagged"] is True
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_script_quotes_id_key(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -255,6 +255,10 @@ class TestSearchMessages:
             sender_contains="alice@example.com",
             subject_contains=None,
             read_status=False,
+            is_flagged=None,
+            date_from=None,
+            date_to=None,
+            has_attachment=None,
             limit=10,
         )
         mock_logger.log_operation.assert_called_once()
@@ -283,6 +287,63 @@ class TestSearchMessages:
 
         assert result["success"] is False
         assert result["error_type"] == "not_found"
+
+    def test_advanced_filters_propagate_to_connector(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """New in #28: is_flagged, date_from, date_to, has_attachment must
+        pass through to the connector and appear in the audit log."""
+        mock_mail.search_messages.return_value = []
+
+        result = search_messages(
+            "Gmail",
+            mailbox="INBOX",
+            is_flagged=True,
+            date_from="2026-04-01",
+            date_to="2026-04-15",
+            has_attachment=True,
+            limit=25,
+        )
+
+        assert result["success"] is True
+        mock_mail.search_messages.assert_called_once_with(
+            account="Gmail",
+            mailbox="INBOX",
+            sender_contains=None,
+            subject_contains=None,
+            read_status=None,
+            is_flagged=True,
+            date_from="2026-04-01",
+            date_to="2026-04-15",
+            has_attachment=True,
+            limit=25,
+        )
+        logged_params = mock_logger.log_operation.call_args.args[1]
+        assert logged_params["filters"] == {
+            "sender": None,
+            "subject": None,
+            "read_status": None,
+            "is_flagged": True,
+            "date_from": "2026-04-01",
+            "date_to": "2026-04-15",
+            "has_attachment": True,
+        }
+
+    def test_malformed_date_maps_to_validation_error(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """Connector raises ValueError on bad date; server surfaces
+        error_type: validation_error (not generic unknown)."""
+        mock_mail.search_messages.side_effect = ValueError(
+            "date_from must be ISO 8601 YYYY-MM-DD, got: 'nope'"
+        )
+
+        result = search_messages("Gmail", date_from="nope")
+
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        assert "date_from" in result["error"]
+        mock_logger.log_operation.assert_not_called()
 
     def test_unexpected_exception_maps_to_unknown(
         self, mock_mail: MagicMock, mock_logger: MagicMock


### PR DESCRIPTION
## Summary

Extends `search_messages` with 4 new optional filters per issue #28:

- **`is_flagged`** (bool) — flagged status whose-clause filter
- **`date_from`** / **`date_to`** (ISO 8601 YYYY-MM-DD) — date-received range. Full day inclusive on both ends.
- **`has_attachment`** (bool) — with/without attachments

Also adds **`flagged`** to each result row (symmetric with the new filter; backward-compatible addition — callers asserting on specific keys aren't broken).

## Design decisions (all in the approved plan)

1. **ISO 8601 only.** Malformed dates raise `ValueError` → `error_type: validation_error`. Prevents AppleScript injection. Relative-date sugar (`"7 days ago"`) deferred for future enhancement.
2. **`date_to` is full-day inclusive.** Python adds 1 day internally; AppleScript uses `date received < date "<next_day>"`. Natural user expectation.
3. **`has_attachment` is post-whose.** Mail rejects it inside `whose` clauses — verified live against real Gmail (`-1728: Can't get every mail attachment`; `Can't make mail attachment into type specifier`). Filter applied inside the repeat loop on concrete message refs.
4. **Result shape gains `flagged`.** 6 keys per row now, was 5. E2E tests don't pin the key count; no downstream breakage.
5. **Loop restructure** to an accumulator pattern so `limit` counts accepted rows (not iterations). Needed because `has_attachment` post-filter can reject.

## Process note

This PR started without a proper plan. The user caught the pattern mid-implementation and moved me back to plan mode; I wrote the design decisions down first, got them approved, then continued. A **feedback memory** is now saved to carry this discipline into future sessions.

## Tests

- Unit: 275 pass (8 new connector tests + 2 new server tests covering the 4 filters, their validation, propagation, audit log, and script-shape guards)
- E2E: 22 pass (no changes to the dispatch layer)
- Integration: 3 new tests verified against real Gmail:
  - `test_search_flagged_messages` — returns only flagged messages
  - `test_search_with_date_range` — stacked date-range whose clause works
  - `test_search_rejects_malformed_date` — ValueError before AppleScript
- `make check-all` — green (lint, mypy strict, complexity, version-sync, parity, 90% coverage)

## Docs

- `docs/reference/TOOLS.md`: search_messages parameter table expanded, inclusivity note, flagged in return shape
- `evals/agent_tool_usability/tool_descriptions.md`: 4 new param lines
- `evals/agent_tool_usability/scenarios.py`: 2 new Search scenarios (IDs 40, 41) exercising the new filters

Closes #28.

## Out of scope
- Relative-date sugar. Happy to file a follow-up if you want it.
- Other search filters (cc, body, label, mailbox_contains, etc.).

## Test plan
- [x] `make test` — 275 unit pass
- [x] `make test-e2e` — 22 pass
- [x] `make check-all` — green
- [x] Integration verified against real Mail (3 new tests + 3 existing search tests pass)
- [ ] GitHub Actions `Tests` workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)