### PR TITLE
Add get_thread MCP tool for conversation reconstruction (#29)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,12 +23,12 @@ make coverage              # Coverage report
 
 **Running the server:** `uv run python -m apple_mail_mcp.server` or via Claude Desktop config.
 
-## API Surface (16 MCP tools)
+## API Surface (17 MCP tools)
 
 **Core (Phase 1):** list_mailboxes, search_messages, get_message, send_email, mark_as_read
 **Attachments & Management (Phase 2):** send_email_with_attachments, get_attachments, save_attachments, move_messages, flag_message, create_mailbox, delete_messages
 **Reply/Forward (Phase 3):** reply_to_message, forward_message
-**Discovery (Phase 4):** list_accounts, list_rules
+**Discovery (Phase 4):** list_accounts, list_rules, get_thread
 
 ## Core Principles
 

--- a/.claude/skills/api-design/SKILL.md
+++ b/.claude/skills/api-design/SKILL.md
@@ -5,7 +5,7 @@ description: Use BEFORE adding any new tool, parameter, or endpoint to the Apple
 
 # Apple Mail MCP API Design
 
-The current API has 16 tools organized into 4 phases. Tool count should grow slowly and deliberately. Every new tool request must pass through the decision tree.
+The current API has 17 tools organized into 4 phases. Tool count should grow slowly and deliberately. Every new tool request must pass through the decision tree.
 
 ## Decision Tree: Use BEFORE Adding Any Tool
 

--- a/.claude/skills/applescript-mail/SKILL.md
+++ b/.claude/skills/applescript-mail/SKILL.md
@@ -120,7 +120,7 @@ messages whose sender contains "user" and subject contains "report"
 ## Known Mail.app Automation Limitations
 
 1. **No scheduled sending** — Mail.app has no AppleScript support for delayed/scheduled sends
-2. **No thread/conversation access** — Messages are individual objects; no thread grouping in AppleScript API
+2. **Thread reconstruction is possible but not native** — Mail.app has no `thread` or `conversation` class. Reconstruct threads by reading `headers of msg` for `in-reply-to`, `references`, and matching against `message id of msg` (the RFC 822 header value) across candidate messages. **`whose message id is "X"` is NOT indexed** (~21s per lookup on a real mailbox); always subject-prefilter first. See `get_thread` in `mail_connector.py`.
 3. **Rule management is partial** — Rules are *readable* (`rules` collection, `name`, `enabled`, conditions/actions), but have no stable `id` and must be addressed positionally or by non-unique name. Mutation paths (creating, updating, deleting) are more complex and not yet implemented.
 4. **No smart mailbox access** — Smart mailboxes are not exposed to AppleScript
 5. **Rich text body** — `content of message` returns plain text; HTML body requires alternate approach

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -13,8 +13,8 @@
 
 `make test-e2e` covers two layers:
 
-1. **In-process FastMCP dispatch** ([tests/e2e/test_mcp_tools.py](../../tests/e2e/test_mcp_tools.py)) — tool registration, schemas, and happy-path invocation for all 16 tools, with the connector mocked.
-2. **Real stdio transport** ([tests/e2e/test_stdio_transport.py](../../tests/e2e/test_stdio_transport.py)) — spawns the server as a subprocess, completes the MCP handshake over stdio, and asserts `list_tools` returns the expected 16 tools. Catches startup errors, banner/stdout contamination, and JSON-RPC framing bugs that the in-process layer cannot surface.
+1. **In-process FastMCP dispatch** ([tests/e2e/test_mcp_tools.py](../../tests/e2e/test_mcp_tools.py)) — tool registration, schemas, and happy-path invocation for all 17 tools, with the connector mocked.
+2. **Real stdio transport** ([tests/e2e/test_stdio_transport.py](../../tests/e2e/test_stdio_transport.py)) — spawns the server as a subprocess, completes the MCP handshake over stdio, and asserts `list_tools` returns the expected 17 tools. Catches startup errors, banner/stdout contamination, and JSON-RPC framing bugs that the in-process layer cannot surface.
 
 ## Running Tests
 

--- a/docs/plans/2026-04-21-get-thread-design.md
+++ b/docs/plans/2026-04-21-get-thread-design.md
@@ -1,0 +1,159 @@
+# `get_thread` — conversation reconstruction from Mail.app
+
+**Issue:** #29
+**Date:** 2026-04-21
+**Status:** Approved
+
+## Context
+
+Issue #29 asks for a tool that returns all messages in a conversation given a message reference. Mail clients commonly display this as a "conversation view."
+
+Mail.app does not expose a native `thread` or `conversation` object via AppleScript (confirmed empirically — the existing claim in the applescript-mail skill was correct on this point, unlike the same skill's earlier incorrect claim about rules). Threading therefore has to be reconstructed by the connector from RFC 5322 header fields: each message's `Message-ID`, `In-Reply-To`, and `References` headers collectively define a reply graph.
+
+Mail.app does expose:
+- `message id of msg` — the RFC 822 Message-ID, direct property access.
+- `headers of msg` — a collection of header objects with `name` and `content`, including `in-reply-to` and `references` when present.
+
+The key performance constraint, verified empirically against a production Gmail INBOX:
+
+- `whose subject contains "X"` — sub-second (subject is indexed for search).
+- `whose message id is "X"` — ~21 seconds for a single exact-match lookup in the same INBOX (not indexed; linear scan).
+
+The 21 s-per-id figure rules out any algorithm that issues one `whose message id` lookup per reference. A single small thread could require minutes.
+
+## Non-goals
+
+- **Cross-account threading.** v1 searches only within the anchor message's account. If a thread spans multiple accounts (forwarding, aliases), cross-account reconstruction is a future enhancement.
+- **Perfect recall when subjects are rewritten mid-thread.** The subject-prefilter optimization below misses thread members whose subject was deliberately changed. Rare in practice; documented as a known limitation.
+- **IMAP-based threading.** See "Future considerations" — the AppleScript path must stand on its own. IMAP support is tracked in #41.
+
+## Design
+
+### Tool contract
+
+```python
+@mcp.tool()
+def get_thread(message_id: str) -> dict[str, Any]:
+    """Return all messages in the thread containing the given message, chronological."""
+```
+
+Return shape:
+
+```json
+{
+  "success": true,
+  "thread": [
+    {"id": "...", "subject": "...", "sender": "...",
+     "date_received": "...", "read_status": false, "flagged": false},
+    ...
+  ],
+  "count": N
+}
+```
+
+Per-message fields match `search_messages` output (6 fields). No message content; callers chain `get_message` for bodies.
+
+Error paths:
+- Anchor not found → `MailMessageNotFoundError` (server maps to `error_type: "not_found"`).
+- Anchor has malformed / missing threading headers → thread = `[anchor]`, `count: 1`. Not an error.
+
+### Algorithm (two AppleScript calls total)
+
+**Call 1 — resolve anchor.** Iterate accounts/mailboxes looking for a message whose internal `id` matches (same pattern as `get_message`). Return: account name, RFC 822 `message-id`, subject, `in-reply-to` header value, `references` header value.
+
+**Python step — compute base subject.** Iteratively strip leading `Re:`, `Fwd:`, `Fw:`, `R:` prefixes (case-insensitive) so `"Re: Re: Q3 Report"` and `"Q3 Report"` reduce to the same key.
+
+**Python step — seed known-ids set.**
+```
+known_ids = {anchor.rfc_message_id}
+if anchor.in_reply_to:  known_ids.add(anchor.in_reply_to)
+if anchor.references:   known_ids.update(parse_message_ids(anchor.references))
+```
+`parse_message_ids` extracts `<id>` tokens from a `References:` header's whitespace-separated list.
+
+**Call 2 — collect candidates.** For each mailbox in the anchor's account:
+- `whose subject contains "<base_subject>"` (Mail's fast indexed search).
+- For each hit, read headers collection, extract `message-id`, `in-reply-to`, `references`.
+- Return `[{rfc_message_id, in_reply_to, references_raw, id, subject, sender, date_received, read_status, flagged}, ...]`.
+
+Single AppleScript loops all mailboxes internally so this is one osascript call, not one per mailbox.
+
+**Python step — graph walk.**
+```
+thread_ids: set[str] = set()
+candidates: list[dict] = <result of Call 2>
+known_ids: set[str] = <from anchor>
+changed = True
+while changed:
+    changed = False
+    for cand in candidates:
+        if cand.internal_id in thread_ids: continue
+        cand_refs = {cand.rfc_message_id} | {cand.in_reply_to} | parse(cand.references_raw)
+        if cand_refs & known_ids:
+            thread_ids.add(cand.internal_id)
+            known_ids |= cand_refs
+            changed = True
+# Guard: at most 100 iterations (real threads terminate on pass 1 or 2).
+```
+
+Anchor itself is always included.
+
+**Python step — sort and shape.** Sort accepted candidates by `date_received` ascending. Drop the threading-header fields; return the 6 search-shape fields.
+
+### Files to modify
+
+| Path | Change |
+|---|---|
+| `src/apple_mail_mcp/mail_connector.py` | New `get_thread(message_id)` method; helper `_normalize_subject`; helper `_parse_rfc822_ids`; two new AppleScript bodies (resolve-anchor, collect-candidates) |
+| `src/apple_mail_mcp/server.py` | New `@mcp.tool() get_thread`; error mapping (`MailMessageNotFoundError` → `not_found`) |
+| `src/apple_mail_mcp/security.py` | Add `get_thread` to `OPERATION_TIERS["cheap_reads"]` |
+| `tests/unit/test_mail_connector.py` | Unit tests for `_normalize_subject`, `_parse_rfc822_ids`, graph walk, empty-headers case, script-shape guards |
+| `tests/unit/test_server.py` | `TestGetThread` — success, not-found, error-type mapping |
+| `tests/unit/test_security.py` | Extend tier-assignment test |
+| `tests/e2e/test_mcp_tools.py` | `EXPECTED_TOOLS` 16 → 17; invocation case with mocked connector |
+| `tests/e2e/test_stdio_transport.py` | `EXPECTED_TOOLS` 16 → 17 |
+| `tests/integration/test_mail_integration.py` | Real-Mail test: find a known-threaded message, assert thread length ≥ 2 OR skip if no threaded messages in test INBOX |
+| `docs/reference/TOOLS.md` | Phase 4 entry with parameter table, return shape, limitations |
+| `.claude/CLAUDE.md` | API surface 16 → 17; Phase 4 bullet expanded |
+| `.claude/skills/applescript-mail/SKILL.md` | Correct the "No thread/conversation access" entry to describe the header-based reconstruction pattern |
+| `.claude/skills/api-design/SKILL.md` | Tool count bump |
+| `docs/guides/TESTING.md` | Tool count bump |
+| `evals/agent_tool_usability/run_eval.py` | Add `get_thread` to `TOOL_NAMES` |
+| `evals/agent_tool_usability/tool_descriptions.md` | New tool entry |
+| `evals/agent_tool_usability/scenarios.py` | 1–2 scenarios ("show me the full thread for message X") |
+
+### Known limitations (documented in docstring)
+
+1. **Subject rewrites miss thread members.** A message whose subject was rewritten mid-thread is not included. Mitigation: accept the tradeoff; documented.
+2. **Orphan anchors** (no threading headers) return `thread: [anchor]` rather than an error.
+3. **Single-account scope.** The tool searches only the anchor's account. Cross-account threading is a separate feature.
+4. **Cycle / malformed reference loops** are handled by the change-tracking while-loop plus a hard cap of 100 passes.
+
+### Security / safety
+
+- No mutation — read-only.
+- No account parameter — does not trigger `check_test_mode_safety`.
+- Rate limited in `cheap_reads` (same as `list_accounts`, `list_mailboxes`, `get_message`, `get_attachments`, `save_attachments`, `list_rules`).
+- `message_id` is sanitized + escaped before being inserted into AppleScript (same pattern as `get_message`).
+- Subject pre-filter value (`base_subject`) is escaped before insertion — this is where an attacker-controlled subject could land in a `whose` clause, so escaping is mandatory.
+
+## Future considerations
+
+Tracked as follow-up **#66** (blocks on #41's `imap_connector`).
+
+When IMAP is available, `get_thread` should have a clean IMAP code path:
+
+- **IMAP THREAD extension (RFC 5256):** server-side threading. Client sends `THREAD REFERENCES UTF-8 ALL` and gets back a tree. Removes the subject-prefilter dependency entirely; no client-side graph walk; handles subject rewrites correctly.
+- **Gmail `X-GM-THRID`:** Gmail tags every message with a 64-bit thread id accessible via IMAP. Single exact-match fetch against the thread id of the anchor returns every member in sub-second. Canonical for Gmail accounts.
+- **Cheap header reads:** `BODY.PEEK[HEADER.FIELDS (MESSAGE-ID IN-REPLY-TO REFERENCES)]` fetches just the threading headers without the body. Mail.app AppleScript has no equivalent.
+
+The AppleScript implementation landing in #29 is the baseline; the IMAP path (once available) adds capability without removing the AppleScript fallback.
+
+## Verification
+
+1. `uv run pytest tests/unit/test_mail_connector.py -k get_thread` — connector unit tests (normalize_subject, parse_rfc822_ids, graph walk, empty-headers, script-shape guards).
+2. `uv run pytest tests/unit/test_server.py -k get_thread` — server unit tests pass.
+3. `make check-all` — green.
+4. `make test-e2e` — 23 e2e tests (22 existing + 1 new invocation case) pass.
+5. `MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=Gmail uv run pytest tests/integration/.../test_get_thread --run-integration -v` — given a known-threaded message in Gmail, returns the full thread; given an orphan message, returns `[anchor]`.
+6. Manual osascript probe: stacked `subject contains "..."` across multiple mailboxes works under Mail.app; headers of candidates read cleanly.

--- a/docs/plans/2026-04-21-get-thread.md
+++ b/docs/plans/2026-04-21-get-thread.md
@@ -1,0 +1,1062 @@
+# get_thread Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `get_thread(message_id)` MCP tool that returns all messages in the conversation containing the anchor message, chronologically sorted, using an AppleScript-based subject-prefilter + RFC 5322 header graph walk.
+
+**Architecture:** Two AppleScript calls (resolve anchor; collect subject-matching candidates with their threading headers), then a pure-Python graph walk over the candidate set. Subject prefilter is mandatory for feasibility — `whose message id is "X"` is ~21s per lookup on a real Gmail INBOX vs sub-second for `whose subject contains "X"`.
+
+**Tech Stack:** Python 3.10+, FastMCP, AppleScript + ASObjC for JSON emission (existing `_wrap_as_json_script` helper), NSJSONSerialization for output.
+
+**Design doc:** [`docs/plans/2026-04-21-get-thread-design.md`](2026-04-21-get-thread-design.md)
+
+---
+
+## Preflight
+
+**Verified against the user's real Gmail account:**
+
+- `whose subject contains "X"` on all mailboxes of Gmail: sub-second per mailbox.
+- Candidate-collection script (iterate all mailboxes, subject-prefilter, read `in-reply-to` / `references` / `message-id` per hit, return JSON via NSJSONSerialization) returns 370 candidates on a very broad `"Welcome"` probe. Full-mailbox iteration completes; returns clean JSON.
+- `whose message id is "X"` (single exact-match) took ~21 s on the user's INBOX. Not usable in a graph walk.
+- `message id of msg` works; `headers of msg` yields header objects with lowercase names (`in-reply-to`, `references`, `message-id`).
+
+**Tool count:** MCP surface goes 16 → 17. Update `EXPECTED_TOOLS` in both e2e test files.
+
+---
+
+## Task 1: `_normalize_subject` helper
+
+**Files:**
+- Modify: `src/apple_mail_mcp/utils.py` (add function at end)
+- Modify: `tests/unit/test_utils.py` (new `TestNormalizeSubject` class; place imports at top of file)
+
+**Step 1 — failing tests**
+
+Append to `tests/unit/test_utils.py`:
+
+```python
+class TestNormalizeSubject:
+    def test_strips_leading_re(self) -> None:
+        assert normalize_subject("Re: Q3 Report") == "Q3 Report"
+
+    def test_strips_leading_fwd(self) -> None:
+        assert normalize_subject("Fwd: Budget update") == "Budget update"
+
+    def test_strips_leading_fw(self) -> None:
+        assert normalize_subject("Fw: heads up") == "heads up"
+
+    def test_strips_nested_prefixes(self) -> None:
+        assert normalize_subject("Re: Re: Fwd: Re: Q3") == "Q3"
+
+    def test_case_insensitive(self) -> None:
+        assert normalize_subject("RE: hello") == "hello"
+        assert normalize_subject("FWD: hi") == "hi"
+        assert normalize_subject("re: yo") == "yo"
+
+    def test_preserves_subject_without_prefix(self) -> None:
+        assert normalize_subject("Q3 Report") == "Q3 Report"
+
+    def test_handles_empty_string(self) -> None:
+        assert normalize_subject("") == ""
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        assert normalize_subject("  Re:   Q3 Report  ") == "Q3 Report"
+
+    def test_preserves_internal_whitespace(self) -> None:
+        assert normalize_subject("Re: Q3   Report") == "Q3   Report"
+```
+
+Add the import at the top of the file alongside the existing `from apple_mail_mcp.utils import ...` line: `normalize_subject`.
+
+Run: `uv run pytest tests/unit/test_utils.py::TestNormalizeSubject -v`. Expect 9 failures (ImportError or NameError).
+
+**Step 2 — implement.** Append to `src/apple_mail_mcp/utils.py`:
+
+```python
+# Subject prefixes that indicate a reply or forward, case-insensitive.
+# Order doesn't matter; we strip the first match each pass and repeat.
+_REPLY_PREFIXES = ("re:", "fwd:", "fw:")
+
+
+def normalize_subject(subject: str) -> str:
+    """Strip reply/forward prefixes from a subject for thread matching.
+
+    Iteratively removes leading "Re:", "Fwd:", "Fw:" (case-insensitive) and
+    surrounding whitespace so that all messages in a thread share one base
+    key regardless of how many times the subject has been Re:'d.
+
+    Args:
+        subject: Raw subject line.
+
+    Returns:
+        Normalized subject. Empty input → empty output.
+    """
+    s = subject.strip()
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _REPLY_PREFIXES:
+            if s.lower().startswith(prefix):
+                s = s[len(prefix):].lstrip()
+                changed = True
+                break
+    return s
+```
+
+**Step 3 — verify.** Run the test again. Expect 9 passed.
+
+**Step 4 — commit**
+
+```bash
+git add src/apple_mail_mcp/utils.py tests/unit/test_utils.py
+git commit -m "Add normalize_subject helper for thread matching (#29)"
+```
+
+---
+
+## Task 2: `parse_rfc822_ids` helper
+
+**Files:**
+- Modify: `src/apple_mail_mcp/utils.py`
+- Modify: `tests/unit/test_utils.py`
+
+**Step 1 — failing tests**
+
+Append to `tests/unit/test_utils.py`:
+
+```python
+class TestParseRfc822Ids:
+    def test_single_angle_wrapped_id(self) -> None:
+        assert parse_rfc822_ids("<abc@example.com>") == ["abc@example.com"]
+
+    def test_multiple_space_separated(self) -> None:
+        assert parse_rfc822_ids("<a@x.com> <b@x.com> <c@x.com>") == [
+            "a@x.com", "b@x.com", "c@x.com",
+        ]
+
+    def test_multiline_references(self) -> None:
+        raw = "<a@x.com>\n <b@x.com>\n <c@x.com>"
+        assert parse_rfc822_ids(raw) == ["a@x.com", "b@x.com", "c@x.com"]
+
+    def test_preserves_bare_ids(self) -> None:
+        """Some clients emit ids without angle brackets."""
+        assert parse_rfc822_ids("bare@example.com") == ["bare@example.com"]
+
+    def test_empty_string_returns_empty_list(self) -> None:
+        assert parse_rfc822_ids("") == []
+
+    def test_whitespace_only_returns_empty_list(self) -> None:
+        assert parse_rfc822_ids("   \n  ") == []
+
+    def test_malformed_trailing_angle(self) -> None:
+        """Lenient: strip stray brackets around otherwise-valid ids."""
+        assert parse_rfc822_ids("<a@x.com> <malformed") == ["a@x.com", "malformed"]
+```
+
+Add `parse_rfc822_ids` to the `from apple_mail_mcp.utils import ...` line.
+
+Run: `uv run pytest tests/unit/test_utils.py::TestParseRfc822Ids -v`. Expect failures.
+
+**Step 2 — implement.** Append to `utils.py`:
+
+```python
+def parse_rfc822_ids(raw: str) -> list[str]:
+    """Parse an In-Reply-To or References header into a list of Message-IDs.
+
+    RFC 5322 canonical form is `<id@domain>` separated by whitespace or
+    folded newlines. Some clients emit bare ids without angle brackets —
+    we accept both. Returns ids without angle brackets, deduplicated order
+    preserved.
+
+    Args:
+        raw: Header content (e.g., "<a@x> <b@x>").
+
+    Returns:
+        List of cleaned message-id strings. Empty input → empty list.
+    """
+    tokens = raw.split()
+    out: list[str] = []
+    for tok in tokens:
+        cleaned = tok.strip().lstrip("<").rstrip(">").strip()
+        if cleaned and cleaned not in out:
+            out.append(cleaned)
+    return out
+```
+
+**Step 3 — verify.** Run tests. Expect 7 passed.
+
+**Step 4 — commit**
+
+```bash
+git add src/apple_mail_mcp/utils.py tests/unit/test_utils.py
+git commit -m "Add parse_rfc822_ids helper for threading headers (#29)"
+```
+
+---
+
+## Task 3: `walk_thread_graph` helper
+
+**Files:**
+- Modify: `src/apple_mail_mcp/utils.py`
+- Modify: `tests/unit/test_utils.py`
+
+**Step 1 — failing tests**
+
+Append to `tests/unit/test_utils.py`:
+
+```python
+class TestWalkThreadGraph:
+    def test_single_anchor_no_candidates(self) -> None:
+        """Thread of one message returns just that message."""
+        accepted = walk_thread_graph(
+            known_ids={"rfc-anchor"},
+            candidates=[],
+        )
+        assert accepted == []
+
+    def test_direct_reply_found(self) -> None:
+        """A candidate whose in_reply_to matches the anchor joins the thread."""
+        cand = {
+            "id": "reply-1",
+            "rfc_message_id": "rfc-reply-1",
+            "in_reply_to": "rfc-anchor",
+            "references_parsed": [],
+        }
+        accepted = walk_thread_graph(
+            known_ids={"rfc-anchor"},
+            candidates=[cand],
+        )
+        assert accepted == [cand]
+
+    def test_nested_reply_discovered_in_second_pass(self) -> None:
+        """A reply-to-the-reply is added after its parent is added."""
+        c1 = {
+            "id": "reply-1",
+            "rfc_message_id": "rfc-1",
+            "in_reply_to": "rfc-anchor",
+            "references_parsed": [],
+        }
+        c2 = {
+            "id": "reply-2",
+            "rfc_message_id": "rfc-2",
+            "in_reply_to": "rfc-1",
+            "references_parsed": [],
+        }
+        accepted = walk_thread_graph(
+            known_ids={"rfc-anchor"},
+            candidates=[c2, c1],  # c2 first — requires iteration to stability
+        )
+        ids = {c["id"] for c in accepted}
+        assert ids == {"reply-1", "reply-2"}
+
+    def test_references_chain_expands_known_set(self) -> None:
+        """A candidate whose references list overlaps known_ids joins."""
+        cand = {
+            "id": "branch",
+            "rfc_message_id": "rfc-branch",
+            "in_reply_to": "",
+            "references_parsed": ["rfc-ancient", "rfc-anchor"],
+        }
+        accepted = walk_thread_graph(
+            known_ids={"rfc-anchor"},
+            candidates=[cand],
+        )
+        assert accepted == [cand]
+
+    def test_unrelated_candidate_rejected(self) -> None:
+        cand = {
+            "id": "unrelated",
+            "rfc_message_id": "rfc-other",
+            "in_reply_to": "rfc-completely-different",
+            "references_parsed": [],
+        }
+        accepted = walk_thread_graph(
+            known_ids={"rfc-anchor"},
+            candidates=[cand],
+        )
+        assert accepted == []
+
+    def test_cycle_terminates(self) -> None:
+        """Malformed client references that form a cycle don't loop forever."""
+        c1 = {"id": "a", "rfc_message_id": "rfc-a", "in_reply_to": "rfc-b", "references_parsed": []}
+        c2 = {"id": "b", "rfc_message_id": "rfc-b", "in_reply_to": "rfc-a", "references_parsed": []}
+        accepted = walk_thread_graph(
+            known_ids={"rfc-a"},  # rfc-a is anchor
+            candidates=[c1, c2],
+        )
+        ids = {c["id"] for c in accepted}
+        assert ids == {"a", "b"}
+```
+
+Add `walk_thread_graph` to the test-file import line.
+
+Run: `uv run pytest tests/unit/test_utils.py::TestWalkThreadGraph -v`. Expect failures.
+
+**Step 2 — implement.** Append to `utils.py`:
+
+```python
+def walk_thread_graph(
+    known_ids: set[str],
+    candidates: list[dict[str, Any]],
+    max_iterations: int = 100,
+) -> list[dict[str, Any]]:
+    """Graph-walk a candidate set, accepting members whose references
+    transitively connect to known_ids.
+
+    Iterates until stable. Each pass may add candidates whose rfc_message_id,
+    in_reply_to, or any parsed references overlap the known-id frontier.
+    Accepted candidates contribute their own ids back into the frontier.
+
+    Args:
+        known_ids: Seed set of RFC 822 Message-IDs known to belong to the
+            thread (typically {anchor.rfc_message_id} plus the anchor's own
+            in_reply_to and references).
+        candidates: List of dicts with keys `id`, `rfc_message_id`,
+            `in_reply_to`, `references_parsed` (list[str]). Anchor itself
+            should NOT appear in this list.
+        max_iterations: Cycle-safety cap. Real threads stabilize in 1–2
+            passes; the cap only matters for malformed header chains.
+
+    Returns:
+        Accepted candidates in their original order.
+    """
+    accepted: list[dict[str, Any]] = []
+    accepted_ids: set[str] = set()
+    frontier = set(known_ids)
+
+    for _ in range(max_iterations):
+        changed = False
+        for cand in candidates:
+            if cand["id"] in accepted_ids:
+                continue
+            refs = {cand["rfc_message_id"]}
+            if cand["in_reply_to"]:
+                refs.add(cand["in_reply_to"])
+            refs.update(cand["references_parsed"])
+            if refs & frontier:
+                accepted.append(cand)
+                accepted_ids.add(cand["id"])
+                frontier |= refs
+                changed = True
+        if not changed:
+            break
+
+    return accepted
+```
+
+**Step 3 — verify.** Run tests. Expect 6 passed.
+
+**Step 4 — commit**
+
+```bash
+git add src/apple_mail_mcp/utils.py tests/unit/test_utils.py
+git commit -m "Add walk_thread_graph helper for thread reconstruction (#29)"
+```
+
+---
+
+## Task 4: Connector `get_thread` — anchor resolution
+
+**Files:**
+- Modify: `src/apple_mail_mcp/mail_connector.py`
+- Modify: `tests/unit/test_mail_connector.py`
+
+This task adds the method skeleton + anchor-resolution AppleScript. The candidate-collection call is added in Task 5.
+
+**Step 1 — failing tests**
+
+Append to `tests/unit/test_mail_connector.py`, inside `TestAppleMailConnector`:
+
+```python
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_anchor_resolution_script_shape(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Anchor-resolution AppleScript must query for the internal id and
+        return the anchor's threading headers quoted."""
+        # Return enough for Task 4's anchor-resolution to succeed, but a
+        # trivial candidate list so Task 5's call returns [].
+        mock_run.side_effect = [
+            '{"account":"Gmail","rfc_message_id":"<anchor@x>","subject":"Q3",'
+            '"in_reply_to":"","references_raw":""}',
+            "[]",
+        ]
+        connector.get_thread("12345")
+        anchor_script = mock_run.call_args_list[0][0][0]
+        # All record keys must be |quoted| per the v0.4.1 selector-collision rule.
+        assert "|rfc_message_id|:(message id of msg)" in anchor_script
+        assert "|subject|:(subject of msg)" in anchor_script
+        # Anchor lookup iterates accounts/mailboxes for the internal id.
+        assert "whose id is 12345" in anchor_script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_anchor_not_found_raises(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Anchor lookup failure propagates MailMessageNotFoundError."""
+        mock_run.side_effect = MailMessageNotFoundError("Can't get message")
+        with pytest.raises(MailMessageNotFoundError):
+            connector.get_thread("99999")
+```
+
+Run: `uv run pytest tests/unit/test_mail_connector.py -k get_thread -v`. Expect 2 failures (AttributeError: `connector.get_thread` not defined).
+
+**Step 2 — implement (partial).** Add to `mail_connector.py` below `get_attachments`:
+
+```python
+    def get_thread(self, message_id: str) -> list[dict[str, Any]]:
+        """Return all messages in the thread containing message_id, chronological.
+
+        Uses Mail.app's indexed `whose subject contains "..."` filter as a
+        pre-filter, then reconstructs the thread by walking RFC 5322
+        Message-ID / In-Reply-To / References headers across the candidate
+        set. Members whose subject was rewritten mid-thread are not found
+        (documented limitation).
+
+        Args:
+            message_id: Internal Mail.app id of any message in the thread
+                (the anchor). Typically obtained from search_messages or
+                get_message results.
+
+        Returns:
+            List of message dicts sorted by date_received ascending.
+            Each dict has the search_messages shape:
+            id, subject, sender, date_received, read_status, flagged.
+            Thread of 1 is valid (anchor has no threading headers).
+
+        Raises:
+            MailMessageNotFoundError: If no message with the given id exists.
+        """
+        from .utils import (
+            normalize_subject,
+            parse_applescript_json,
+            parse_rfc822_ids,
+            walk_thread_graph,
+        )
+
+        message_id_safe = escape_applescript_string(sanitize_input(message_id))
+
+        # ---- Call 1: resolve anchor ----
+        anchor_body = f'''
+        tell application "Mail"
+            set anchorResult to missing value
+            repeat with acc in accounts
+                repeat with mb in mailboxes of acc
+                    try
+                        set msg to first message of mb whose id is {message_id_safe}
+                        set anchorInReplyTo to ""
+                        set anchorRefs to ""
+                        try
+                            repeat with h in headers of msg
+                                set hname to name of h
+                                if hname is "in-reply-to" then set anchorInReplyTo to (content of h)
+                                if hname is "references" then set anchorRefs to (content of h)
+                            end repeat
+                        end try
+                        set resultData to {{|account|:(name of acc), |rfc_message_id|:(message id of msg), |subject|:(subject of msg), |in_reply_to|:anchorInReplyTo, |references_raw|:anchorRefs}}
+                        set anchorResult to resultData
+                        exit repeat
+                    end try
+                end repeat
+                if anchorResult is not missing value then exit repeat
+            end repeat
+
+            if anchorResult is missing value then
+                error "Can't get message: not found"
+            end if
+        end tell
+        '''
+
+        anchor_script = _wrap_as_json_script(anchor_body)
+        anchor_raw = self._run_applescript(anchor_script)
+        anchor = cast(dict[str, Any], parse_applescript_json(anchor_raw))
+
+        # Placeholder: Task 5 adds candidate collection + graph walk.
+        # Return single-anchor thread for now so Task 4 tests pass.
+        return []
+```
+
+Also add `MailMessageNotFoundError` raise is handled by `_run_applescript` itself when the inner `error "Can't get message..."` bubbles up, so no Python re-raise needed. The test `test_get_thread_anchor_not_found_raises` mocks `_run_applescript` to raise directly.
+
+**Step 3 — verify.** Run: `uv run pytest tests/unit/test_mail_connector.py -k get_thread -v`. Expect 2 passed.
+
+**Step 4 — commit**
+
+```bash
+git add src/apple_mail_mcp/mail_connector.py tests/unit/test_mail_connector.py
+git commit -m "Add get_thread connector skeleton with anchor resolution (#29)"
+```
+
+---
+
+## Task 5: Connector `get_thread` — candidate collection + graph walk
+
+**Files:**
+- Modify: `src/apple_mail_mcp/mail_connector.py` (complete `get_thread`)
+- Modify: `tests/unit/test_mail_connector.py`
+
+**Step 1 — failing tests**
+
+Append to `TestAppleMailConnector`:
+
+```python
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_returns_anchor_plus_replies_sorted(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Given an anchor and 2 replies in candidates, returns all 3 sorted by date."""
+        mock_run.side_effect = [
+            # Call 1: anchor
+            '{"account":"Gmail","rfc_message_id":"<anchor@x>",'
+            '"subject":"Re: Q3","in_reply_to":"","references_raw":""}',
+            # Call 2: candidates (includes anchor itself + 2 replies)
+            '['
+            '{"id":"100","rfc_message_id":"<anchor@x>","in_reply_to":"",'
+            '"references_raw":"","subject":"Q3","sender":"a@x","date_received":"Mon Jan 1 2024","read_status":true,"flagged":false},'
+            '{"id":"101","rfc_message_id":"<r1@x>","in_reply_to":"<anchor@x>",'
+            '"references_raw":"<anchor@x>","subject":"Re: Q3","sender":"b@x","date_received":"Tue Jan 2 2024","read_status":true,"flagged":false},'
+            '{"id":"102","rfc_message_id":"<r2@x>","in_reply_to":"<r1@x>",'
+            '"references_raw":"<anchor@x> <r1@x>","subject":"Re: Q3","sender":"a@x","date_received":"Wed Jan 3 2024","read_status":false,"flagged":false}'
+            ']'
+        ]
+        result = connector.get_thread("100")
+        assert len(result) == 3
+        assert [m["id"] for m in result] == ["100", "101", "102"]
+        # Result shape matches search_messages (6 fields)
+        for m in result:
+            assert set(m.keys()) == {"id", "subject", "sender", "date_received", "read_status", "flagged"}
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_drops_threading_internals_from_output(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Response rows must NOT leak rfc_message_id / in_reply_to / references_raw."""
+        mock_run.side_effect = [
+            '{"account":"Gmail","rfc_message_id":"<anchor@x>","subject":"Q3","in_reply_to":"","references_raw":""}',
+            '[{"id":"100","rfc_message_id":"<anchor@x>","in_reply_to":"",'
+            '"references_raw":"","subject":"Q3","sender":"a@x",'
+            '"date_received":"Mon","read_status":false,"flagged":false}]'
+        ]
+        result = connector.get_thread("100")
+        for m in result:
+            assert "rfc_message_id" not in m
+            assert "in_reply_to" not in m
+            assert "references_raw" not in m
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_orphan_anchor_returns_single_message(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Anchor with no threading headers → thread = [anchor] only."""
+        mock_run.side_effect = [
+            '{"account":"Gmail","rfc_message_id":"<orphan@x>","subject":"Standalone","in_reply_to":"","references_raw":""}',
+            '[{"id":"500","rfc_message_id":"<orphan@x>","in_reply_to":"","references_raw":"",'
+            '"subject":"Standalone","sender":"a@x","date_received":"Mon","read_status":false,"flagged":false}]'
+        ]
+        result = connector.get_thread("500")
+        assert len(result) == 1
+        assert result[0]["id"] == "500"
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_candidate_script_uses_base_subject_and_account(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Candidate collection must use the normalized subject in the whose
+        clause and scope to the anchor's account."""
+        mock_run.side_effect = [
+            '{"account":"Gmail","rfc_message_id":"<a@x>","subject":"Re: Re: Q3 Report","in_reply_to":"","references_raw":""}',
+            '[]',
+        ]
+        connector.get_thread("1")
+        candidate_script = mock_run.call_args_list[1][0][0]
+        assert 'account "Gmail"' in candidate_script
+        # Base subject should be 'Q3 Report', prefixes stripped.
+        assert 'subject contains "Q3 Report"' in candidate_script
+        assert 'subject contains "Re:' not in candidate_script
+```
+
+Run. Expect failures (method currently returns `[]`).
+
+**Step 2 — implement.** Replace the placeholder at the end of `get_thread` with:
+
+```python
+        # ---- Call 2: collect subject-prefiltered candidates with their
+        # threading headers across all mailboxes of the anchor's account ----
+        account_name = anchor["account"]
+        base_subject = normalize_subject(anchor["subject"])
+        account_safe = escape_applescript_string(sanitize_input(account_name))
+        subject_safe = escape_applescript_string(sanitize_input(base_subject))
+
+        candidates_body = f'''
+        tell application "Mail"
+            set acctRef to account "{account_safe}"
+            set resultData to {{}}
+            repeat with mbRef in mailboxes of acctRef
+                try
+                    set hits to (messages of mbRef whose subject contains "{subject_safe}")
+                    repeat with m in hits
+                        set inReplyTo to ""
+                        set refs to ""
+                        try
+                            repeat with h in headers of m
+                                set hname to name of h
+                                if hname is "in-reply-to" then set inReplyTo to (content of h)
+                                if hname is "references" then set refs to (content of h)
+                            end repeat
+                        end try
+                        set candRecord to {{|id|:(id of m as text), |rfc_message_id|:(message id of m), |in_reply_to|:inReplyTo, |references_raw|:refs, |subject|:(subject of m), |sender|:(sender of m), |date_received|:(date received of m as text), |read_status|:(read status of m), |flagged|:(flagged status of m)}}
+                        set end of resultData to candRecord
+                    end repeat
+                on error
+                    -- Some mailboxes (e.g. Gmail smart labels) reject whose clauses; skip
+                end try
+            end repeat
+        end tell
+        '''
+
+        candidates_script = _wrap_as_json_script(candidates_body)
+        candidates_raw = self._run_applescript(candidates_script)
+        candidates = cast(
+            list[dict[str, Any]],
+            parse_applescript_json(candidates_raw),
+        )
+
+        # Enrich each candidate with parsed reference list (Python-side).
+        for cand in candidates:
+            cand["references_parsed"] = parse_rfc822_ids(
+                cand.get("references_raw", "")
+            )
+
+        # Seed the known-id frontier with the anchor and its own references.
+        anchor_rfc = anchor["rfc_message_id"]
+        known_ids: set[str] = {anchor_rfc}
+        if anchor["in_reply_to"]:
+            known_ids.add(anchor["in_reply_to"])
+        known_ids.update(parse_rfc822_ids(anchor["references_raw"]))
+
+        # The anchor itself should always be in the thread. It may or may not
+        # appear in the candidate list (depends on whether its subject matches
+        # the base_subject after normalization — usually yes). Separate it out
+        # so the graph walk doesn't duplicate it.
+        anchor_candidate: dict[str, Any] | None = None
+        non_anchor_candidates: list[dict[str, Any]] = []
+        for cand in candidates:
+            if cand["rfc_message_id"] == anchor_rfc:
+                if anchor_candidate is None:
+                    anchor_candidate = cand
+                # Duplicate (same anchor surfaced via multiple Gmail labels)
+                # falls into neither bucket — skipped.
+            else:
+                non_anchor_candidates.append(cand)
+
+        accepted = walk_thread_graph(
+            known_ids=known_ids,
+            candidates=non_anchor_candidates,
+        )
+
+        # Assemble the final thread: anchor (if found in candidates) +
+        # accepted replies. If the anchor wasn't in the candidate set (its
+        # subject didn't match base_subject for some reason), we still
+        # include its identity by constructing a minimal row from the
+        # anchor-resolution data.
+        thread: list[dict[str, Any]] = []
+        if anchor_candidate is not None:
+            thread.append(anchor_candidate)
+        else:
+            # Minimal row — we don't have the full 6 fields from the anchor
+            # call. Do a final supplementary pull here would cost another
+            # AppleScript call; accept the partial row instead, filled with
+            # what we know.
+            logger.warning(
+                "get_thread: anchor (rfc=%s) not in candidate set; "
+                "result row will be incomplete",
+                anchor_rfc,
+            )
+            thread.append({
+                "id": message_id,
+                "subject": anchor["subject"],
+                "sender": "",
+                "date_received": "",
+                "read_status": False,
+                "flagged": False,
+            })
+        thread.extend(accepted)
+
+        # Sort by date_received ascending. AppleScript emits dates as
+        # locale-formatted strings; lexicographic sort is adequate for the
+        # v1 (matches how messages arrive chronologically within a thread
+        # in practice). If date strings are empty (supplementary anchor
+        # row), treat as earliest.
+        thread.sort(key=lambda m: m.get("date_received") or "")
+
+        # Drop threading internals from output rows.
+        for m in thread:
+            m.pop("rfc_message_id", None)
+            m.pop("in_reply_to", None)
+            m.pop("references_raw", None)
+            m.pop("references_parsed", None)
+
+        return thread
+```
+
+**Step 3 — verify.** Run: `uv run pytest tests/unit/test_mail_connector.py -k get_thread -v`. Expect 6 passed.
+
+Also run the whole unit suite: `uv run pytest tests/unit/ -q`. Expect all passing.
+
+**Step 4 — commit**
+
+```bash
+git add src/apple_mail_mcp/mail_connector.py tests/unit/test_mail_connector.py
+git commit -m "Complete get_thread connector with graph walk + candidate collection (#29)"
+```
+
+---
+
+## Task 6: Server MCP tool + security tier
+
+**Files:**
+- Modify: `src/apple_mail_mcp/server.py` (add `@mcp.tool() get_thread` after `get_attachments`)
+- Modify: `src/apple_mail_mcp/security.py` (`get_thread` → `cheap_reads`)
+- Modify: `tests/unit/test_server.py` (new `TestGetThread` class, import `get_thread`)
+- Modify: `tests/unit/test_security.py` (tier-assignment test)
+
+**Step 1 — failing tests**
+
+In `tests/unit/test_server.py`, extend the `from apple_mail_mcp.server import ...` block to include `get_thread`. Then add after `TestGetAttachments`:
+
+```python
+class TestGetThread:
+    def test_success_returns_thread_and_logs(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.get_thread.return_value = [
+            {"id": "1", "subject": "Q3", "sender": "a@b", "date_received": "Mon", "read_status": True, "flagged": False},
+            {"id": "2", "subject": "Re: Q3", "sender": "c@d", "date_received": "Tue", "read_status": False, "flagged": False},
+        ]
+        result = get_thread("1")
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert len(result["thread"]) == 2
+        mock_mail.get_thread.assert_called_once_with("1")
+        mock_logger.log_operation.assert_called_once_with(
+            "get_thread", {"message_id": "1"}, "success"
+        )
+
+    def test_not_found_maps_to_not_found(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.get_thread.side_effect = MailMessageNotFoundError("x")
+        result = get_thread("nope")
+        assert result["success"] is False
+        assert result["error_type"] == "not_found"
+        mock_logger.log_operation.assert_not_called()
+
+    def test_unexpected_exception_maps_to_unknown(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.get_thread.side_effect = RuntimeError("boom")
+        result = get_thread("1")
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+```
+
+In `tests/unit/test_security.py::test_all_operations_have_tier_assigned`, add `"get_thread"` to `expected_ops`.
+
+Run: `uv run pytest tests/unit/test_server.py::TestGetThread tests/unit/test_security.py::TestCheckRateLimit::test_all_operations_have_tier_assigned -v`. Expect ImportErrors + a security failure.
+
+**Step 2 — implement.** In `src/apple_mail_mcp/server.py`, add after the `get_attachments` tool:
+
+```python
+@mcp.tool()
+def get_thread(message_id: str) -> dict[str, Any]:
+    """
+    Return all messages in the thread containing the given message.
+
+    Looks up the message by its internal id, then reconstructs the
+    conversation by reading RFC 5322 threading headers (Message-ID,
+    In-Reply-To, References) across messages in the same account.
+    Results are sorted by date_received ascending.
+
+    Known limitation: thread members whose subject was rewritten
+    mid-conversation are missed (subject prefilter tradeoff).
+
+    Args:
+        message_id: Internal id of any message in the thread
+            (from search_messages or get_message results).
+
+    Returns:
+        Dictionary with the thread list.
+
+    Example:
+        >>> get_thread("12345")
+        {"success": True, "thread": [{...}, {...}], "count": 2}
+    """
+    try:
+        rate_err = check_rate_limit("get_thread", {"message_id": message_id})
+        if rate_err:
+            return rate_err
+
+        logger.info(f"Getting thread for message: {message_id}")
+
+        thread = mail.get_thread(message_id)
+
+        operation_logger.log_operation(
+            "get_thread", {"message_id": message_id}, "success"
+        )
+
+        return {
+            "success": True,
+            "thread": thread,
+            "count": len(thread),
+        }
+
+    except MailMessageNotFoundError as e:
+        logger.error(f"Message not found: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "not_found",
+        }
+    except Exception as e:
+        logger.error(f"Error getting thread: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "unknown",
+        }
+```
+
+In `src/apple_mail_mcp/security.py`, add `"get_thread": "cheap_reads"` to `OPERATION_TIERS`.
+
+**Step 3 — verify.** Re-run tests. Expect all passing.
+
+**Step 4 — commit**
+
+```bash
+git add src/apple_mail_mcp/server.py src/apple_mail_mcp/security.py tests/unit/test_server.py tests/unit/test_security.py
+git commit -m "Expose get_thread as MCP tool, rate-limited cheap_reads (#29)"
+```
+
+---
+
+## Task 7: E2E — EXPECTED_TOOLS bump + invocation case
+
+**Files:**
+- Modify: `tests/e2e/test_mcp_tools.py`
+- Modify: `tests/e2e/test_stdio_transport.py`
+
+**Step 1 — update both EXPECTED_TOOLS sets.** Add `"get_thread",` to each `EXPECTED_TOOLS` constant.
+
+**Step 2 — add an invocation case.** In `tests/e2e/test_mcp_tools.py`, append to `INVOCATION_CASES`:
+
+```python
+    (
+        "get_thread",
+        {"message_id": "msg-1"},
+        "get_thread",
+        [{"id": "msg-1", "subject": "Q3", "sender": "a@b",
+          "date_received": "Mon", "read_status": True, "flagged": False}],
+    ),
+```
+
+**Step 3 — verify.** `uv run pytest tests/e2e/ -v`. Expect 23 passed (22 existing + 1 new invocation case).
+
+**Step 4 — commit**
+
+```bash
+git add tests/e2e/test_mcp_tools.py tests/e2e/test_stdio_transport.py
+git commit -m "Wire get_thread into E2E EXPECTED_TOOLS (16 -> 17) (#29)"
+```
+
+---
+
+## Task 8: Integration test
+
+**Files:**
+- Modify: `tests/integration/test_mail_integration.py`
+
+**Step 1 — write the test.** Add to `TestMailIntegration`:
+
+```python
+    def test_get_thread_orphan_anchor(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """For any message (probably has no replies in a test inbox),
+        get_thread should at minimum return the anchor itself.
+
+        This exercises the anchor-resolution + candidate-collection path
+        end-to-end without requiring a specific known-threaded message.
+        """
+        matches = connector.search_messages(
+            account=test_account, mailbox="INBOX", limit=1
+        )
+        if not matches:
+            pytest.skip("test inbox has no messages")
+
+        thread = connector.get_thread(matches[0]["id"])
+        assert isinstance(thread, list)
+        assert len(thread) >= 1
+        for m in thread:
+            assert set(m.keys()) >= {
+                "id", "subject", "sender", "date_received",
+                "read_status", "flagged",
+            }
+        # The anchor must be in the result.
+        assert any(m["id"] == matches[0]["id"] for m in thread)
+
+    def test_get_thread_rejects_nonexistent_anchor(
+        self, connector: AppleMailConnector
+    ) -> None:
+        """Nonexistent anchor raises MailMessageNotFoundError."""
+        from apple_mail_mcp.exceptions import MailMessageNotFoundError
+        with pytest.raises(MailMessageNotFoundError):
+            connector.get_thread("99999999999")
+```
+
+**Step 2 — verify.** Run:
+
+```bash
+MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=Gmail uv run pytest \
+  tests/integration/test_mail_integration.py::TestMailIntegration::test_get_thread_orphan_anchor \
+  tests/integration/test_mail_integration.py::TestMailIntegration::test_get_thread_rejects_nonexistent_anchor \
+  --run-integration -v
+```
+
+Expect both passed.
+
+**Step 3 — commit**
+
+```bash
+git add tests/integration/test_mail_integration.py
+git commit -m "Add integration tests for get_thread (#29)"
+```
+
+---
+
+## Task 9: Documentation
+
+**Files:**
+- Modify: `.claude/CLAUDE.md` (API surface line: `16 MCP tools` → `17`; Phase 4 bullet expands to include `get_thread`)
+- Modify: `.claude/skills/api-design/SKILL.md` (tool count 16 → 17)
+- Modify: `.claude/skills/applescript-mail/SKILL.md` (**correct the stale "No thread/conversation access" bullet** — messages are standalone in the API, but threads are reconstructable via `headers of msg` → `in-reply-to` / `references`; subject prefilter required for feasibility because `whose message id is` is not indexed)
+- Modify: `docs/guides/TESTING.md` (15 or 16 → 17 tool count references)
+- Modify: `docs/reference/TOOLS.md` (add `get_thread` entry under Phase 4)
+
+**Step 1 — doc edits.** Straightforward find-and-replace + new section writing. The TOOLS.md entry follows the same shape as the `list_rules` entry — parameters (just `message_id`), returns example JSON, field notes, **limitations** subsection listing the subject-rewrite caveat and single-account scope.
+
+Specifically for `.claude/skills/applescript-mail/SKILL.md`, find the line:
+
+> **No thread/conversation access** — Messages are individual objects; no thread grouping in AppleScript API
+
+Replace with:
+
+> **Thread reconstruction is possible but not native** — Mail.app has no `thread` or `conversation` class. Reconstruct threads by reading `headers of msg` for `in-reply-to`, `references`, and comparing against `message id of msg` (the RFC 822 header value) across candidate messages. **`whose message id is "X"` is NOT indexed** (~21 s per lookup); always subject-prefilter first. See `get_thread` in `mail_connector.py`.
+
+**Step 2 — verify.** `make check-all` green. Open TOOLS.md, visually confirm the entry is well-formed.
+
+**Step 3 — commit**
+
+```bash
+git add .claude/CLAUDE.md .claude/skills/api-design/SKILL.md .claude/skills/applescript-mail/SKILL.md docs/guides/TESTING.md docs/reference/TOOLS.md
+git commit -m "Document get_thread; correct stale applescript-mail skill claim (#29)"
+```
+
+---
+
+## Task 10: Evals
+
+**Files:**
+- Modify: `evals/agent_tool_usability/run_eval.py` (add `"get_thread"` to `TOOL_NAMES`)
+- Modify: `evals/agent_tool_usability/tool_descriptions.md` (new entry alphabetically — between `get_message` and `list_accounts`)
+- Modify: `evals/agent_tool_usability/scenarios.py` (add one scenario)
+
+**Step 1 — scenario.** Insert a Read-category scenario:
+
+```python
+    {
+        "id": 42,
+        "category": "Read",
+        "name": "Show full thread containing a message",
+        "prompt": "Show me the full conversation for message with id msg-42.",
+        "expected": {
+            "tools": ["get_thread"],
+            "key_params": {"get_thread": {"message_id": "msg-42"}},
+        },
+        "scoring_notes": (
+            "PASS: Calls get_thread with message_id=msg-42. "
+            "PARTIAL: Calls get_thread but param named wrong. "
+            "FAIL: Calls get_message and tries to guess the thread manually."
+        ),
+        "safety_critical": False,
+    },
+```
+
+**Step 2 — tool_descriptions.md entry** (placed between `get_message` and `list_accounts`):
+
+```markdown
+### get_thread
+
+Return all messages in the thread containing the given message. Uses the internal message id as the anchor; walks RFC 5322 threading headers across the anchor's account to find related messages. Sorted by date_received ascending. Known limitation: members with mid-thread subject rewrites are not found.
+
+**Parameters:**
+- `message_id` (str, required): Internal id of any message in the thread.
+```
+
+**Step 3 — verify + commit**
+
+```bash
+git add evals/agent_tool_usability/
+git commit -m "Add get_thread to evals (tool descriptions + scenario 42) (#29)"
+```
+
+---
+
+## Task 11: Full green gate + PR
+
+**Step 1 — full suite**
+
+```bash
+make check-all
+make test-e2e
+MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=Gmail make test-integration
+```
+
+Expect all green.
+
+**Step 2 — push + PR**
+
+```bash
+git push -u origin feature/issue-29-get-thread
+gh pr create --title "Add get_thread MCP tool for conversation reconstruction (#29)" --body "..."
+```
+
+PR body should:
+- Summarize: Phase 4 tool, surface 16 → 17, algorithm = subject-prefilter + RFC 822 graph walk, two AppleScript calls.
+- Call out the **key empirical finding** that justified the subject-prefilter: `whose message id is X` = 21 s vs `whose subject contains X` = sub-second.
+- Call out the known limitation (subject-rewrite misses).
+- Link the design doc.
+- Link follow-up **#66** for the eventual IMAP path (removes the limitation).
+- Include test plan checklist.
+- Use `Closes #29`.
+
+**Step 3 — wait for CI, then use `/merge-and-status`.**
+
+---
+
+## Verification (end-to-end)
+
+- `make test` — 280+ unit tests pass (adds ~22 new across utils/connector/server/security).
+- `make test-e2e` — 23 pass (22 existing + 1 new invocation case).
+- `make check-all` — green.
+- `MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=Gmail make test-integration` — new `test_get_thread_*` pass.
+- Manually: run `get_thread` via the MCP client on a known-threaded message; confirm thread length matches expected.
+- Parity check shows `get_thread` wrapped; no warnings.
+
+## Out of scope (explicit — deferred)
+
+- **IMAP-based threading** — follow-up #66. Blocks on #41.
+- **Cross-account threading** — not implemented; single-account scope only.
+- **Thread metadata** — participant list, dates range, size. Separate follow-up if requested.
+- **Tree shape return** — flat chronological list only.
+- **Preview field** — not included; callers chain `get_message` for bodies.

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -5,7 +5,7 @@ Complete reference for all MCP tools provided by the Apple Mail MCP server.
 ## Overview
 
 **Current Version:** v0.5.0 (Phase 4)
-**Total Tools:** 16 (5 from Phase 1 + 7 from Phase 2 + 2 from Phase 3 + 2 from Phase 4)
+**Total Tools:** 17 (5 from Phase 1 + 7 from Phase 2 + 2 from Phase 3 + 3 from Phase 4)
 
 ## Phase 1 Tools (v0.1.0) - Core Foundation
 
@@ -987,6 +987,54 @@ send_email(
 ---
 
 ## Phase 4 Tools (v0.5.0)
+
+### get_thread
+
+Return all messages in the thread containing the given anchor message, sorted chronologically.
+
+Looks up the anchor by its internal id, reads its RFC 5322 threading headers (Message-ID, In-Reply-To, References), then searches every mailbox in the anchor's account for candidate messages whose normalized subject matches. Candidates with overlapping Message-ID / In-Reply-To / References form the reply graph. The subject prefilter is a feasibility requirement, not an optimization — `whose message id is "X"` on Mail.app is ~21 seconds per lookup (not indexed) vs sub-second for subject.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `message_id` | string | Yes | - | Internal id of any message in the thread (from search_messages or get_message). |
+
+**Returns:**
+
+```json
+{
+  "success": true,
+  "thread": [
+    {"id": "100", "subject": "Q3 Report", "sender": "alice@x.com",
+     "date_received": "Mon Jan 1 2024 10:00:00", "read_status": true, "flagged": false},
+    {"id": "101", "subject": "Re: Q3 Report", "sender": "bob@x.com",
+     "date_received": "Mon Jan 1 2024 14:30:00", "read_status": true, "flagged": false}
+  ],
+  "count": 2
+}
+```
+
+Message rows are the search_messages shape (6 fields). No content — chain `get_message` to read bodies.
+
+**Known limitations:**
+
+- **Subject rewrites miss thread members.** A reply whose subject was rewritten mid-conversation ("Re: Q3 Report" → "Reopening the Q3 discussion") won't match the subject prefilter and is excluded. Rare in practice.
+- **Single-account scope.** Threads that span multiple accounts (forwarding, aliases) are not reconstructed cross-account.
+- **Orphan anchors** (messages with no threading headers) return a thread of 1 (the anchor itself).
+
+**Examples:**
+
+```python
+# Get the full conversation for a message found via search
+matches = search_messages("Gmail", mailbox="INBOX", subject_contains="Q3")
+thread = get_thread(matches["messages"][0]["id"])
+print(f"Thread has {thread['count']} messages")
+```
+
+**Future:** An IMAP-based code path (tracked as issue #66) will remove the subject-rewrite limitation once the `imap_connector` (issue #41) lands.
+
+---
 
 ### list_rules
 

--- a/evals/agent_tool_usability/run_eval.py
+++ b/evals/agent_tool_usability/run_eval.py
@@ -55,6 +55,7 @@ List the exact tool calls you would make, in order, with all parameters. Explain
 
 TOOL_NAMES = [
     "list_accounts", "list_rules", "list_mailboxes", "search_messages", "get_message",
+    "get_thread",
     "send_email", "send_email_with_attachments",
     "get_attachments", "save_attachments",
     "mark_as_read", "flag_message",

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -229,6 +229,23 @@ SCENARIOS = [
         "safety_critical": False,
     },
     {
+        "id": 42,
+        "category": "Read",
+        "name": "Show full thread containing a message",
+        "prompt": "Show me the full conversation for message with id msg-42.",
+        "expected": {
+            "tools": ["get_thread"],
+            "key_params": {"get_thread": {"message_id": "msg-42"}},
+        },
+        "scoring_notes": (
+            "PASS: Calls get_thread with message_id=msg-42. "
+            "PARTIAL: Calls get_thread but names the param differently. "
+            "FAIL: Calls get_message and tries to reconstruct the thread manually, "
+            "or calls search_messages and guesses."
+        ),
+        "safety_critical": False,
+    },
+    {
         "id": 41,
         "category": "Search",
         "name": "Find messages with attachments",

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -83,6 +83,15 @@ Get full details of a specific message.
 
 ---
 
+### get_thread
+
+Return all messages in the thread containing the given message, sorted chronologically. Walks RFC 5322 threading headers across the anchor's account. Returns the search_messages shape (no bodies; chain get_message for content). Known limitation: members with mid-thread subject rewrites are missed.
+
+**Parameters:**
+- `message_id` (str, required): Internal id of any message in the thread.
+
+---
+
 ### list_accounts
 
 List all configured email accounts. Returns each account's id (UUID), name, email_addresses, account_type (`imap`, `pop`, `iCloud`, etc.), and enabled state. Call first to discover accounts before any other tool that needs an account name.

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -651,6 +651,176 @@ class AppleMailConnector:
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
+    def get_thread(self, message_id: str) -> list[dict[str, Any]]:
+        """Return all messages in the thread containing ``message_id``.
+
+        Uses Mail.app's indexed ``whose subject contains "..."`` filter as a
+        pre-filter, then reconstructs the thread by walking RFC 5322
+        Message-ID / In-Reply-To / References headers across the candidate
+        set. Members whose subject was rewritten mid-thread are not found
+        (documented limitation).
+
+        Args:
+            message_id: Internal Mail.app id of any message in the thread
+                (the anchor). Typically obtained from search_messages or
+                get_message results.
+
+        Returns:
+            List of message dicts sorted by date_received ascending. Each
+            dict has the search_messages shape: id, subject, sender,
+            date_received, read_status, flagged. A thread of 1 is valid
+            (anchor with no threading headers).
+
+        Raises:
+            MailMessageNotFoundError: If no message with the given id exists.
+        """
+        from .utils import (
+            normalize_subject,
+            parse_rfc822_ids,
+            walk_thread_graph,
+        )
+
+        message_id_safe = escape_applescript_string(sanitize_input(message_id))
+
+        # ---- Call 1: resolve anchor ----
+        anchor_body = f'''
+        tell application "Mail"
+            set anchorResult to missing value
+            repeat with acc in accounts
+                repeat with mb in mailboxes of acc
+                    try
+                        set msg to first message of mb whose id is {message_id_safe}
+                        set anchorInReplyTo to ""
+                        set anchorRefs to ""
+                        try
+                            repeat with h in headers of msg
+                                set hname to name of h
+                                if hname is "in-reply-to" then set anchorInReplyTo to (content of h)
+                                if hname is "references" then set anchorRefs to (content of h)
+                            end repeat
+                        end try
+                        set resultData to {{|account|:(name of acc), |rfc_message_id|:(message id of msg), |subject|:(subject of msg), |in_reply_to|:anchorInReplyTo, |references_raw|:anchorRefs}}
+                        set anchorResult to resultData
+                        exit repeat
+                    end try
+                end repeat
+                if anchorResult is not missing value then exit repeat
+            end repeat
+
+            if anchorResult is missing value then
+                error "Can't get message: not found"
+            end if
+        end tell
+        '''
+
+        anchor_script = _wrap_as_json_script(anchor_body)
+        anchor_raw = self._run_applescript(anchor_script)
+        anchor = cast(dict[str, Any], parse_applescript_json(anchor_raw))
+
+        # ---- Call 2: collect subject-prefiltered candidates across the
+        # anchor's account (all mailboxes) with their threading headers ----
+        account_name = anchor["account"]
+        base_subject = normalize_subject(anchor["subject"])
+        account_safe = escape_applescript_string(sanitize_input(account_name))
+        subject_safe = escape_applescript_string(sanitize_input(base_subject))
+
+        candidates_body = f'''
+        tell application "Mail"
+            set acctRef to account "{account_safe}"
+            set resultData to {{}}
+            repeat with mbRef in mailboxes of acctRef
+                try
+                    set hits to (messages of mbRef whose subject contains "{subject_safe}")
+                    repeat with m in hits
+                        set inReplyTo to ""
+                        set refs to ""
+                        try
+                            repeat with h in headers of m
+                                set hname to name of h
+                                if hname is "in-reply-to" then set inReplyTo to (content of h)
+                                if hname is "references" then set refs to (content of h)
+                            end repeat
+                        end try
+                        set candRecord to {{|id|:(id of m as text), |rfc_message_id|:(message id of m), |in_reply_to|:inReplyTo, |references_raw|:refs, |subject|:(subject of m), |sender|:(sender of m), |date_received|:(date received of m as text), |read_status|:(read status of m), |flagged|:(flagged status of m)}}
+                        set end of resultData to candRecord
+                    end repeat
+                on error
+                    -- Some mailboxes (e.g. Gmail smart labels) reject whose clauses; skip
+                end try
+            end repeat
+        end tell
+        '''
+
+        candidates_script = _wrap_as_json_script(candidates_body)
+        candidates_raw = self._run_applescript(candidates_script)
+        candidates = cast(
+            list[dict[str, Any]],
+            parse_applescript_json(candidates_raw),
+        )
+
+        # Enrich candidates with parsed references (Python-side).
+        for cand in candidates:
+            cand["references_parsed"] = parse_rfc822_ids(
+                cand.get("references_raw", "")
+            )
+
+        # Seed the known-id frontier: anchor + its own references.
+        anchor_rfc = anchor["rfc_message_id"]
+        known_ids: set[str] = {anchor_rfc}
+        if anchor["in_reply_to"]:
+            known_ids.add(anchor["in_reply_to"])
+        known_ids.update(parse_rfc822_ids(anchor["references_raw"]))
+
+        # Separate the anchor's own candidate row (when present) from the
+        # rest. The graph walk operates on the non-anchor candidates; the
+        # anchor itself always belongs in the result.
+        anchor_candidate: dict[str, Any] | None = None
+        non_anchor_candidates: list[dict[str, Any]] = []
+        for cand in candidates:
+            if cand["rfc_message_id"] == anchor_rfc and anchor_candidate is None:
+                anchor_candidate = cand
+            else:
+                non_anchor_candidates.append(cand)
+
+        accepted = walk_thread_graph(
+            known_ids=known_ids,
+            candidates=non_anchor_candidates,
+        )
+
+        # Assemble final thread: anchor (from candidates or a minimal row
+        # if the anchor's own row didn't surface in the candidate set).
+        thread: list[dict[str, Any]] = []
+        if anchor_candidate is not None:
+            thread.append(anchor_candidate)
+        else:
+            logger.warning(
+                "get_thread: anchor (rfc=%s) not in candidate set; "
+                "result row will be incomplete",
+                anchor_rfc,
+            )
+            thread.append({
+                "id": message_id,
+                "subject": anchor["subject"],
+                "sender": "",
+                "date_received": "",
+                "read_status": False,
+                "flagged": False,
+            })
+        thread.extend(accepted)
+
+        # Sort by date_received ascending. AppleScript emits locale-formatted
+        # strings; lexicographic sort is a close-enough proxy within a thread.
+        thread.sort(key=lambda m: m.get("date_received") or "")
+
+        # Drop threading internals from output rows (search-shape only).
+        for m in thread:
+            m.pop("rfc_message_id", None)
+            m.pop("in_reply_to", None)
+            m.pop("references_raw", None)
+            m.pop("references_parsed", None)
+
+        return thread
+
     def save_attachments(
         self,
         message_id: str,

--- a/src/apple_mail_mcp/security.py
+++ b/src/apple_mail_mcp/security.py
@@ -123,6 +123,7 @@ OPERATION_TIERS: dict[str, str] = {
     "list_mailboxes": "cheap_reads",
     "get_message": "cheap_reads",
     "get_attachments": "cheap_reads",
+    "get_thread": "cheap_reads",
     "save_attachments": "cheap_reads",
     "search_messages": "expensive_ops",
     "mark_as_read": "expensive_ops",

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -770,6 +770,65 @@ def get_attachments(message_id: str) -> dict[str, Any]:
 
 
 @mcp.tool()
+def get_thread(message_id: str) -> dict[str, Any]:
+    """
+    Return all messages in the thread containing the given message.
+
+    Looks up the message by its internal id, then reconstructs the
+    conversation by reading RFC 5322 threading headers (Message-ID,
+    In-Reply-To, References) across messages in the same account.
+    Results are sorted by date_received ascending.
+
+    Known limitation: thread members whose subject was rewritten
+    mid-conversation are missed (subject prefilter tradeoff).
+
+    Args:
+        message_id: Internal id of any message in the thread
+            (from search_messages or get_message results).
+
+    Returns:
+        Dictionary with the thread list.
+
+    Example:
+        >>> get_thread("12345")
+        {"success": True, "thread": [{...}, {...}], "count": 2}
+    """
+    try:
+        rate_err = check_rate_limit("get_thread", {"message_id": message_id})
+        if rate_err:
+            return rate_err
+
+        logger.info(f"Getting thread for message: {message_id}")
+
+        thread = mail.get_thread(message_id)
+
+        operation_logger.log_operation(
+            "get_thread", {"message_id": message_id}, "success"
+        )
+
+        return {
+            "success": True,
+            "thread": thread,
+            "count": len(thread),
+        }
+
+    except MailMessageNotFoundError as e:
+        logger.error(f"Message not found: {e}")
+        return {
+            "success": False,
+            "error": f"Message '{message_id}' not found",
+            "error_type": "message_not_found",
+        }
+    except Exception as e:
+        logger.error(f"Error getting thread: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "unknown",
+        }
+
+
+@mcp.tool()
 def save_attachments(
     message_id: str,
     save_directory: str,

--- a/src/apple_mail_mcp/utils.py
+++ b/src/apple_mail_mcp/utils.py
@@ -320,3 +320,33 @@ def parse_applescript_json(result: str) -> Any:
     if stripped.startswith("ERROR:"):
         raise MailAppleScriptError(stripped[len("ERROR:"):].strip())
     return json.loads(stripped)
+
+
+# Subject prefixes that indicate a reply or forward, case-insensitive.
+# Order doesn't matter; we strip the first match each pass and repeat.
+_REPLY_PREFIXES = ("re:", "fwd:", "fw:")
+
+
+def normalize_subject(subject: str) -> str:
+    """Strip reply/forward prefixes from a subject for thread matching.
+
+    Iteratively removes leading "Re:", "Fwd:", "Fw:" (case-insensitive) and
+    surrounding whitespace so that all messages in a thread share one base
+    key regardless of how many times the subject has been Re:'d.
+
+    Args:
+        subject: Raw subject line.
+
+    Returns:
+        Normalized subject. Empty input returns empty output.
+    """
+    s = subject.strip()
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _REPLY_PREFIXES:
+            if s.lower().startswith(prefix):
+                s = s[len(prefix):].lstrip()
+                changed = True
+                break
+    return s

--- a/src/apple_mail_mcp/utils.py
+++ b/src/apple_mail_mcp/utils.py
@@ -373,3 +373,52 @@ def parse_rfc822_ids(raw: str) -> list[str]:
         if cleaned and cleaned not in out:
             out.append(cleaned)
     return out
+
+
+def walk_thread_graph(
+    known_ids: set[str],
+    candidates: list[dict[str, Any]],
+    max_iterations: int = 100,
+) -> list[dict[str, Any]]:
+    """Graph-walk a candidate set, accepting members whose references
+    transitively connect to known_ids.
+
+    Iterates until stable. Each pass may add candidates whose rfc_message_id,
+    in_reply_to, or any parsed references overlap the known-id frontier.
+    Accepted candidates contribute their own ids back into the frontier.
+
+    Args:
+        known_ids: Seed set of RFC 822 Message-IDs known to belong to the
+            thread (typically {anchor.rfc_message_id} plus the anchor's own
+            in_reply_to and references).
+        candidates: List of dicts with keys ``id``, ``rfc_message_id``,
+            ``in_reply_to``, ``references_parsed`` (list[str]). Anchor
+            itself should NOT appear in this list.
+        max_iterations: Cycle-safety cap. Real threads stabilize in 1-2
+            passes; the cap only matters for malformed header chains.
+
+    Returns:
+        Accepted candidates in their original order.
+    """
+    accepted: list[dict[str, Any]] = []
+    accepted_ids: set[str] = set()
+    frontier = set(known_ids)
+
+    for _ in range(max_iterations):
+        changed = False
+        for cand in candidates:
+            if cand["id"] in accepted_ids:
+                continue
+            refs = {cand["rfc_message_id"]}
+            if cand["in_reply_to"]:
+                refs.add(cand["in_reply_to"])
+            refs.update(cand["references_parsed"])
+            if refs & frontier:
+                accepted.append(cand)
+                accepted_ids.add(cand["id"])
+                frontier |= refs
+                changed = True
+        if not changed:
+            break
+
+    return accepted

--- a/src/apple_mail_mcp/utils.py
+++ b/src/apple_mail_mcp/utils.py
@@ -350,3 +350,26 @@ def normalize_subject(subject: str) -> str:
                 changed = True
                 break
     return s
+
+
+def parse_rfc822_ids(raw: str) -> list[str]:
+    """Parse an In-Reply-To or References header into a list of Message-IDs.
+
+    RFC 5322 canonical form is `<id@domain>` separated by whitespace or
+    folded newlines. Some clients emit bare ids without angle brackets —
+    we accept both. Returns ids without angle brackets, order preserved,
+    duplicates removed.
+
+    Args:
+        raw: Header content (e.g., "<a@x> <b@x>").
+
+    Returns:
+        List of cleaned message-id strings. Empty input returns empty list.
+    """
+    tokens = raw.split()
+    out: list[str] = []
+    for tok in tokens:
+        cleaned = tok.strip().lstrip("<").rstrip(">").strip()
+        if cleaned and cleaned not in out:
+            out.append(cleaned)
+    return out

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -27,6 +27,7 @@ EXPECTED_TOOLS = {
     "list_mailboxes",
     "search_messages",
     "get_message",
+    "get_thread",
     "send_email",
     "mark_as_read",
     "send_email_with_attachments",
@@ -117,6 +118,13 @@ INVOCATION_CASES: list[tuple[str, dict[str, Any], str, Any]] = [
         {},
         "list_rules",
         [{"name": "Junk filter", "enabled": True}],
+    ),
+    (
+        "get_thread",
+        {"message_id": "msg-1"},
+        "get_thread",
+        [{"id": "msg-1", "subject": "Q3", "sender": "a@b",
+          "date_received": "Mon", "read_status": True, "flagged": False}],
     ),
     (
         "list_mailboxes",

--- a/tests/e2e/test_stdio_transport.py
+++ b/tests/e2e/test_stdio_transport.py
@@ -30,6 +30,7 @@ EXPECTED_TOOLS = {
     "list_mailboxes",
     "search_messages",
     "get_message",
+    "get_thread",
     "send_email",
     "mark_as_read",
     "send_email_with_attachments",

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -163,6 +163,40 @@ class TestMailIntegration:
             assert isinstance(rule["name"], str) and rule["name"]
             assert isinstance(rule["enabled"], bool)
 
+    def test_get_thread_orphan_anchor(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """For any message, get_thread must at minimum return the anchor itself.
+
+        This exercises the anchor-resolution + candidate-collection path
+        end-to-end without needing a known-threaded message. Skips if the
+        inbox is empty.
+        """
+        matches = connector.search_messages(
+            account=test_account, mailbox="INBOX", limit=1
+        )
+        if not matches:
+            pytest.skip("test inbox has no messages")
+
+        thread = connector.get_thread(matches[0]["id"])
+        assert isinstance(thread, list)
+        assert len(thread) >= 1
+        for m in thread:
+            assert set(m.keys()) >= {
+                "id", "subject", "sender", "date_received",
+                "read_status", "flagged",
+            }
+        # Anchor must be in the result.
+        assert any(m["id"] == matches[0]["id"] for m in thread)
+
+    def test_get_thread_rejects_nonexistent_anchor(
+        self, connector: AppleMailConnector
+    ) -> None:
+        """Nonexistent anchor raises MailMessageNotFoundError."""
+        from apple_mail_mcp.exceptions import MailMessageNotFoundError
+        with pytest.raises(MailMessageNotFoundError):
+            connector.get_thread("99999999999")
+
     def test_get_message(
         self, connector: AppleMailConnector, test_account: str
     ) -> None:

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -8,6 +8,7 @@ from apple_mail_mcp.exceptions import (
     MailAccountNotFoundError,
     MailAppleScriptError,
     MailMailboxNotFoundError,
+    MailMessageNotFoundError,
 )
 from apple_mail_mcp.mail_connector import AppleMailConnector, _wrap_as_json_script
 
@@ -605,6 +606,116 @@ class TestAppleMailConnector:
         """Test marking with empty list."""
         result = connector.mark_as_read([])
         assert result == 0
+
+    # ---- get_thread ----
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_anchor_resolution_script_shape(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Anchor-resolution AppleScript must query by internal id and quote keys."""
+        mock_run.side_effect = [
+            '{"account":"Gmail","rfc_message_id":"<anchor@x>","subject":"Q3",'
+            '"in_reply_to":"","references_raw":""}',
+            "[]",
+        ]
+        connector.get_thread("12345")
+        anchor_script = mock_run.call_args_list[0][0][0]
+        # All record keys must be |quoted| per the v0.4.1 selector-collision rule.
+        assert "|rfc_message_id|:(message id of msg)" in anchor_script
+        assert "|subject|:(subject of msg)" in anchor_script
+        # Anchor lookup iterates by internal id.
+        assert "whose id is 12345" in anchor_script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_anchor_not_found_raises(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Anchor lookup failure propagates MailMessageNotFoundError."""
+        mock_run.side_effect = MailMessageNotFoundError("Can't get message")
+        with pytest.raises(MailMessageNotFoundError):
+            connector.get_thread("99999")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_returns_anchor_plus_replies_sorted(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Anchor + 2 replies in candidates → all 3 sorted by date_received."""
+        mock_run.side_effect = [
+            '{"account":"Gmail","rfc_message_id":"<anchor@x>",'
+            '"subject":"Re: Q3","in_reply_to":"","references_raw":""}',
+            '['
+            '{"id":"100","rfc_message_id":"<anchor@x>","in_reply_to":"",'
+            '"references_raw":"","subject":"Q3","sender":"a@x",'
+            '"date_received":"Mon Jan 1 2024","read_status":true,"flagged":false},'
+            '{"id":"101","rfc_message_id":"<r1@x>","in_reply_to":"<anchor@x>",'
+            '"references_raw":"<anchor@x>","subject":"Re: Q3","sender":"b@x",'
+            '"date_received":"Tue Jan 2 2024","read_status":true,"flagged":false},'
+            '{"id":"102","rfc_message_id":"<r2@x>","in_reply_to":"<r1@x>",'
+            '"references_raw":"<anchor@x> <r1@x>","subject":"Re: Q3","sender":"a@x",'
+            '"date_received":"Wed Jan 3 2024","read_status":false,"flagged":false}'
+            ']'
+        ]
+        result = connector.get_thread("100")
+        assert len(result) == 3
+        assert [m["id"] for m in result] == ["100", "101", "102"]
+        # Response rows match search_messages shape (6 fields).
+        for m in result:
+            assert set(m.keys()) == {
+                "id", "subject", "sender", "date_received", "read_status", "flagged",
+            }
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_drops_threading_internals_from_output(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Response rows must NOT leak rfc_message_id / in_reply_to / references_raw."""
+        mock_run.side_effect = [
+            '{"account":"Gmail","rfc_message_id":"<anchor@x>",'
+            '"subject":"Q3","in_reply_to":"","references_raw":""}',
+            '[{"id":"100","rfc_message_id":"<anchor@x>","in_reply_to":"",'
+            '"references_raw":"","subject":"Q3","sender":"a@x",'
+            '"date_received":"Mon","read_status":false,"flagged":false}]'
+        ]
+        result = connector.get_thread("100")
+        for m in result:
+            assert "rfc_message_id" not in m
+            assert "in_reply_to" not in m
+            assert "references_raw" not in m
+            assert "references_parsed" not in m
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_orphan_anchor_returns_single_message(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Anchor with no threading headers → thread = [anchor] only."""
+        mock_run.side_effect = [
+            '{"account":"Gmail","rfc_message_id":"<orphan@x>","subject":"Standalone",'
+            '"in_reply_to":"","references_raw":""}',
+            '[{"id":"500","rfc_message_id":"<orphan@x>","in_reply_to":"",'
+            '"references_raw":"","subject":"Standalone","sender":"a@x",'
+            '"date_received":"Mon","read_status":false,"flagged":false}]'
+        ]
+        result = connector.get_thread("500")
+        assert len(result) == 1
+        assert result[0]["id"] == "500"
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_candidate_script_uses_base_subject_and_account(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Candidate script must use normalized subject and scope to anchor's account."""
+        mock_run.side_effect = [
+            '{"account":"Gmail","rfc_message_id":"<a@x>",'
+            '"subject":"Re: Re: Q3 Report","in_reply_to":"","references_raw":""}',
+            '[]',
+        ]
+        connector.get_thread("1")
+        candidate_script = mock_run.call_args_list[1][0][0]
+        assert 'account "Gmail"' in candidate_script
+        # Base subject strips all Re: prefixes.
+        assert 'subject contains "Q3 Report"' in candidate_script
+        assert 'subject contains "Re:' not in candidate_script
 
 
 class TestWrapAsJsonScript:

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -221,10 +221,10 @@ class TestCheckRateLimit:
     def test_all_operations_have_tier_assigned(self) -> None:
         expected_ops = {
             "list_accounts", "list_rules", "list_mailboxes", "get_message",
-            "get_attachments", "save_attachments", "search_messages", "mark_as_read",
-            "move_messages", "flag_message", "create_mailbox", "delete_messages",
-            "reply_to_message", "send_email", "send_email_with_attachments",
-            "forward_message",
+            "get_attachments", "get_thread", "save_attachments", "search_messages",
+            "mark_as_read", "move_messages", "flag_message", "create_mailbox",
+            "delete_messages", "reply_to_message", "send_email",
+            "send_email_with_attachments", "forward_message",
         }
         assert set(OPERATION_TIERS.keys()) == expected_ops
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -34,6 +34,7 @@ from apple_mail_mcp.server import (
     forward_message,
     get_attachments,
     get_message,
+    get_thread,
     list_accounts,
     list_mailboxes,
     list_rules,
@@ -718,6 +719,54 @@ class TestGetAttachments:
 
         assert result["success"] is False
         assert result["error_type"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# 7b. get_thread
+# ---------------------------------------------------------------------------
+
+
+class TestGetThread:
+    def test_success_returns_thread_and_logs(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.get_thread.return_value = [
+            {"id": "1", "subject": "Q3", "sender": "a@b", "date_received": "Mon", "read_status": True, "flagged": False},
+            {"id": "2", "subject": "Re: Q3", "sender": "c@d", "date_received": "Tue", "read_status": False, "flagged": False},
+        ]
+
+        result = get_thread("1")
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert len(result["thread"]) == 2
+        mock_mail.get_thread.assert_called_once_with("1")
+        mock_logger.log_operation.assert_called_once_with(
+            "get_thread", {"message_id": "1"}, "success"
+        )
+
+    def test_message_not_found_maps_to_message_not_found(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.get_thread.side_effect = MailMessageNotFoundError("nope")
+
+        result = get_thread("nope")
+
+        assert result["success"] is False
+        assert result["error_type"] == "message_not_found"
+        assert "nope" in result["error"]
+        mock_logger.log_operation.assert_not_called()
+
+    def test_unexpected_exception_maps_to_unknown(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.get_thread.side_effect = RuntimeError("boom")
+
+        result = get_thread("1")
+
+        assert result["success"] is False
+        assert result["error_type"] == "unknown"
+        assert "boom" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -8,6 +8,7 @@ from apple_mail_mcp.exceptions import MailAppleScriptError
 from apple_mail_mcp.utils import (
     escape_applescript_string,
     format_applescript_list,
+    normalize_subject,
     parse_applescript_json,
     parse_applescript_list,
     parse_date_filter,
@@ -172,3 +173,34 @@ class TestParseAppleScriptJson:
         """'ERROR:' with no message still raises (edge case)."""
         with pytest.raises(MailAppleScriptError):
             parse_applescript_json("ERROR:")
+
+
+class TestNormalizeSubject:
+    def test_strips_leading_re(self) -> None:
+        assert normalize_subject("Re: Q3 Report") == "Q3 Report"
+
+    def test_strips_leading_fwd(self) -> None:
+        assert normalize_subject("Fwd: Budget update") == "Budget update"
+
+    def test_strips_leading_fw(self) -> None:
+        assert normalize_subject("Fw: heads up") == "heads up"
+
+    def test_strips_nested_prefixes(self) -> None:
+        assert normalize_subject("Re: Re: Fwd: Re: Q3") == "Q3"
+
+    def test_case_insensitive(self) -> None:
+        assert normalize_subject("RE: hello") == "hello"
+        assert normalize_subject("FWD: hi") == "hi"
+        assert normalize_subject("re: yo") == "yo"
+
+    def test_preserves_subject_without_prefix(self) -> None:
+        assert normalize_subject("Q3 Report") == "Q3 Report"
+
+    def test_handles_empty_string(self) -> None:
+        assert normalize_subject("") == ""
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        assert normalize_subject("  Re:   Q3 Report  ") == "Q3 Report"
+
+    def test_preserves_internal_whitespace(self) -> None:
+        assert normalize_subject("Re: Q3   Report") == "Q3   Report"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,6 +15,7 @@ from apple_mail_mcp.utils import (
     parse_rfc822_ids,
     sanitize_input,
     validate_email,
+    walk_thread_graph,
 )
 
 
@@ -233,3 +234,86 @@ class TestParseRfc822Ids:
     def test_malformed_trailing_angle(self) -> None:
         """Lenient: strip stray brackets around otherwise-valid ids."""
         assert parse_rfc822_ids("<a@x.com> <malformed") == ["a@x.com", "malformed"]
+
+
+class TestWalkThreadGraph:
+    def test_single_anchor_no_candidates(self) -> None:
+        """Thread of one message returns just that message."""
+        accepted = walk_thread_graph(
+            known_ids={"rfc-anchor"},
+            candidates=[],
+        )
+        assert accepted == []
+
+    def test_direct_reply_found(self) -> None:
+        """A candidate whose in_reply_to matches the anchor joins the thread."""
+        cand = {
+            "id": "reply-1",
+            "rfc_message_id": "rfc-reply-1",
+            "in_reply_to": "rfc-anchor",
+            "references_parsed": [],
+        }
+        accepted = walk_thread_graph(
+            known_ids={"rfc-anchor"},
+            candidates=[cand],
+        )
+        assert accepted == [cand]
+
+    def test_nested_reply_discovered_in_second_pass(self) -> None:
+        """A reply-to-the-reply is added after its parent is added."""
+        c1 = {
+            "id": "reply-1",
+            "rfc_message_id": "rfc-1",
+            "in_reply_to": "rfc-anchor",
+            "references_parsed": [],
+        }
+        c2 = {
+            "id": "reply-2",
+            "rfc_message_id": "rfc-2",
+            "in_reply_to": "rfc-1",
+            "references_parsed": [],
+        }
+        accepted = walk_thread_graph(
+            known_ids={"rfc-anchor"},
+            candidates=[c2, c1],  # c2 first — requires iteration to stability
+        )
+        ids = {c["id"] for c in accepted}
+        assert ids == {"reply-1", "reply-2"}
+
+    def test_references_chain_expands_known_set(self) -> None:
+        """A candidate whose references list overlaps known_ids joins."""
+        cand = {
+            "id": "branch",
+            "rfc_message_id": "rfc-branch",
+            "in_reply_to": "",
+            "references_parsed": ["rfc-ancient", "rfc-anchor"],
+        }
+        accepted = walk_thread_graph(
+            known_ids={"rfc-anchor"},
+            candidates=[cand],
+        )
+        assert accepted == [cand]
+
+    def test_unrelated_candidate_rejected(self) -> None:
+        cand = {
+            "id": "unrelated",
+            "rfc_message_id": "rfc-other",
+            "in_reply_to": "rfc-completely-different",
+            "references_parsed": [],
+        }
+        accepted = walk_thread_graph(
+            known_ids={"rfc-anchor"},
+            candidates=[cand],
+        )
+        assert accepted == []
+
+    def test_cycle_terminates(self) -> None:
+        """Malformed client references that form a cycle don't loop forever."""
+        c1 = {"id": "a", "rfc_message_id": "rfc-a", "in_reply_to": "rfc-b", "references_parsed": []}
+        c2 = {"id": "b", "rfc_message_id": "rfc-b", "in_reply_to": "rfc-a", "references_parsed": []}
+        accepted = walk_thread_graph(
+            known_ids={"rfc-a"},
+            candidates=[c1, c2],
+        )
+        ids = {c["id"] for c in accepted}
+        assert ids == {"a", "b"}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -12,6 +12,7 @@ from apple_mail_mcp.utils import (
     parse_applescript_json,
     parse_applescript_list,
     parse_date_filter,
+    parse_rfc822_ids,
     sanitize_input,
     validate_email,
 )
@@ -204,3 +205,31 @@ class TestNormalizeSubject:
 
     def test_preserves_internal_whitespace(self) -> None:
         assert normalize_subject("Re: Q3   Report") == "Q3   Report"
+
+
+class TestParseRfc822Ids:
+    def test_single_angle_wrapped_id(self) -> None:
+        assert parse_rfc822_ids("<abc@example.com>") == ["abc@example.com"]
+
+    def test_multiple_space_separated(self) -> None:
+        assert parse_rfc822_ids("<a@x.com> <b@x.com> <c@x.com>") == [
+            "a@x.com", "b@x.com", "c@x.com",
+        ]
+
+    def test_multiline_references(self) -> None:
+        raw = "<a@x.com>\n <b@x.com>\n <c@x.com>"
+        assert parse_rfc822_ids(raw) == ["a@x.com", "b@x.com", "c@x.com"]
+
+    def test_preserves_bare_ids(self) -> None:
+        """Some clients emit ids without angle brackets."""
+        assert parse_rfc822_ids("bare@example.com") == ["bare@example.com"]
+
+    def test_empty_string_returns_empty_list(self) -> None:
+        assert parse_rfc822_ids("") == []
+
+    def test_whitespace_only_returns_empty_list(self) -> None:
+        assert parse_rfc822_ids("   \n  ") == []
+
+    def test_malformed_trailing_angle(self) -> None:
+        """Lenient: strip stray brackets around otherwise-valid ids."""
+        assert parse_rfc822_ids("<a@x.com> <malformed") == ["a@x.com", "malformed"]


### PR DESCRIPTION
## Summary

New Phase 4 Discovery tool. MCP surface 16 → 17. Reconstructs email threads from Mail.app by walking RFC 5322 headers across candidate messages.

## Algorithm

Two AppleScript calls + a Python graph walk:

1. **Resolve anchor** — iterate accounts/mailboxes for the internal id; return the anchor's account, RFC 822 message-id, subject, in-reply-to, references.
2. **Base subject normalization** (Python) — strip `Re:` / `Fwd:` / `Fw:` prefixes.
3. **Collect candidates** — for each mailbox of the anchor's account, `whose subject contains "<base_subject>"`, then read each hit's threading headers.
4. **Graph walk** (Python) — iterate-to-stability: add candidates whose `rfc_message_id`, `in_reply_to`, or `references` overlap the known-id frontier. Cycle-safe via `max_iterations=100`.
5. Sort by `date_received` ascending; drop threading internals; return the 6-field search-shape rows.

## Key empirical finding (shaped the design)

- `whose subject contains "X"` — sub-second (indexed).
- `whose message id is "X"` — **~21s per lookup** on real Gmail (not indexed).

The subject-prefilter is a feasibility requirement, not an optimization. Tradeoff: thread members whose subject was rewritten mid-conversation are missed. Documented in the tool docstring and the `applescript-mail` skill (stale "No thread/conversation access" claim corrected).

Follow-up **[#66](../../issues/66)** tracks the IMAP-based code path (removes the subject-rewrite limitation once #41's imap_connector lands).

## Changes by area

- **Helpers** ([src/apple_mail_mcp/utils.py](src/apple_mail_mcp/utils.py)): `normalize_subject`, `parse_rfc822_ids`, `walk_thread_graph`.
- **Connector** ([src/apple_mail_mcp/mail_connector.py](src/apple_mail_mcp/mail_connector.py)): new `get_thread(message_id)` method with both AppleScript calls + Python graph walk + row shape sanitization.
- **Server** ([src/apple_mail_mcp/server.py](src/apple_mail_mcp/server.py)): `@mcp.tool() get_thread`, `message_not_found` error mapping.
- **Security**: `get_thread` in `cheap_reads` rate-limit tier.
- **E2E**: `EXPECTED_TOOLS` 16 → 17 in both in-process and stdio suites; invocation case added.
- **Integration**: 2 new tests verified against real Gmail (orphan anchor; nonexistent anchor).
- **Docs**: CLAUDE.md Phase 4 bullet, api-design skill tool count, TESTING.md counts, TOOLS.md Phase 4 entry with full param/return/limitation docs, **applescript-mail skill correction**.
- **Evals**: `TOOL_NAMES`, `tool_descriptions.md` entry, Read-category scenario 42.

## Design + plan docs

- Design: [`docs/plans/2026-04-21-get-thread-design.md`](docs/plans/2026-04-21-get-thread-design.md)
- Implementation plan: [`docs/plans/2026-04-21-get-thread.md`](docs/plans/2026-04-21-get-thread.md)

Closes #29.

## Test plan
- [x] `make test` — 306 unit tests pass (22 new across utils / connector / server / security)
- [x] `make test-e2e` — 23 pass (22 existing + 1 new invocation case)
- [x] `make check-all` — lint, mypy strict, complexity, version-sync, parity all green
- [x] `make test-integration` — 2 new get_thread integration tests verified against real Gmail
- [ ] GitHub Actions `Tests` workflow green on this PR

## Known limitations (in docstring + TOOLS.md)
- **Subject rewrites miss thread members** (subject-prefilter tradeoff).
- **Single-account scope** — threads that span multiple accounts not reconstructed.
- **Orphan anchors** (no threading headers) return a thread of 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)