### PR TITLE
Document keychain spike findings (#39)

### DIFF
--- a/docs/research/imap-hybrid-approach.md
+++ b/docs/research/imap-hybrid-approach.md
@@ -1,8 +1,8 @@
 # IMAP Hybrid Approach — Research Findings
 
-**Status:** Research complete, not yet implemented
-**Related issues:** #15 (closed), #39, #40, #41
-**Date:** 2026-04
+**Status:** Keychain-retrieval assumption **falsified 2026-04-22** — see [Spike Findings (#39)](#spike-findings-39-2026-04-22) below. Further IMAP work is blocked on a follow-up research issue that evaluates auth alternatives. The "Authentication: macOS Keychain" section of this document is superseded and kept only as historical context.
+**Related issues:** #15 (closed), #39 (closed — negative result), #40, #41, #66 (all blocked on #68), #68 (new — evaluate auth options)
+**Date:** 2026-04 (original); findings appended 2026-04-22
 
 ## Question
 
@@ -120,6 +120,8 @@ imap.store(msg_id, '+FLAGS', '\\Deleted')
 
 ## Authentication: macOS Keychain
 
+> **Superseded 2026-04-22 — this section's premise was falsified by spike #39. See [Spike Findings](#spike-findings-39-2026-04-22). Retained for historical context; do not act on the claims below without re-validating.**
+
 The key insight is that **Mail.app already stores IMAP credentials in the Keychain** when the user sets up an account. Python can retrieve them without prompting:
 
 ```bash
@@ -204,3 +206,69 @@ Follow-up issues #39, #40, #41 are on v0.5.0 as spikes.
 - [RFC 5256: IMAP SORT and THREAD](https://www.rfc-editor.org/rfc/rfc5256.html)
 - [macOS security(1) man page](x-man-page://1/security) — for `find-internet-password`
 - [email-oauth2-proxy](https://github.com/simonrob/email-oauth2-proxy) — OAuth2 shim if needed
+
+## Spike Findings (#39, 2026-04-22)
+
+### Context
+
+Issue #39 was scoped as a proof-of-concept for the auth path described in the superseded section above: retrieve IMAP credentials from macOS Keychain via `security find-internet-password -s imap.<provider>.com`, connect via IMAPClient, fetch a single message. On first probing, the central assumption failed immediately — Mail.app on modern macOS (tested on macOS 26.3.1 / Darwin 25.3.0) does not store its IMAP credentials anywhere the `security` CLI can reach.
+
+### Reproduction
+
+Run [`scripts/probe_keychain_for_imap.sh`](../../scripts/probe_keychain_for_imap.sh). It enumerates both the login and System keychains, searches for items by IMAP protocol and by common provider hostnames, counts OAuth-token items, and tests whether the Internet Accounts DB is readable.
+
+### Observed results (2026-04-22)
+
+Machine: macOS 26.3.1 (Darwin 25.3.0). Mail.app has 5 configured accounts: Gmail, Yahoo, iCloud, MobileMe (iCloud), Pitt (disabled).
+
+```
+--- Check 1: items with ptcl=imap or ptcl=imps ---
+  /Users/Morgan/Library/Keychains/login.keychain-db: 0 items
+  /Library/Keychains/System.keychain: 0 items
+  TOTAL: 0
+
+--- Check 2: items matching common IMAP server hostnames ---
+  imap.gmail.com: not found
+  imap.mail.me.com: not found
+  imap.mail.yahoo.com: not found
+  outlook.office365.com: not found
+  imap-mail.outlook.com: not found
+  imap.fastmail.com: not found
+  imap.aol.com: not found
+  TOTAL MATCHES: 0 / 7
+
+--- Check 3: OAuth tokens (Gmail/Google) ---
+  Items with gena="Google OAuth": 2
+
+--- Check 4: Accounts framework DB readability (TCC) ---
+  /Users/Morgan/Library/Accounts: NOT readable (TCC-protected — grant Full Disk Access to test)
+```
+
+### Interpretation
+
+On modern macOS:
+
+- **No IMAP-protocol internet-password items exist** in either user-accessible keychain for any of the configured accounts. The original assumption (that `security find-internet-password -s imap.gmail.com` would return usable creds) is wrong.
+- **Gmail auth is OAuth, not a stored password** — refresh tokens are present as generic-password items with `gena="Google OAuth"`, but they are not directly usable for IMAP LOGIN; they require XOAUTH2 plus token-refresh handling.
+- **The Internet Accounts framework DB** (`~/Library/Accounts/Accounts4.sqlite`), where Apple consolidates account metadata on recent macOS, is protected by TCC. Reading it requires the user to grant Full Disk Access to whatever binary is performing the read — inappropriate for an MCP server that runs as the user.
+- **iCloud accounts** (visible to Mail.app as `account type = iCloud`, not `imap`) go through Apple's Internet Accounts path entirely, not IMAP.
+
+The conclusion is cheap and definitive: the spike's hypothesis is falsified on this configuration. Further validation on other machines is welcome but not load-bearing — the mechanism is system-level, not account-specific.
+
+### Auth alternatives (to be evaluated in follow-up)
+
+| # | Option | Trade-off |
+|---|--------|-----------|
+| a | User-supplied Keychain item under a known service name (e.g. `apple-mail-mcp.<account>`) populated via a setup script | Simplest; works with app passwords across all providers; requires one-time user setup |
+| b | Extract Google OAuth refresh tokens from Keychain and speak XOAUTH2 | Gmail/Google only; must handle token refresh; brittle against Google OAuth changes |
+| c | Read the Accounts framework DB via a TCC-entitled helper | Requires user to grant Full Disk Access; entitlement distribution issues; heavyweight |
+| d | Plain env vars / config file for IMAP credentials | Trivial to implement; no Keychain integration; worst UX and worst security story |
+| e | Abandon IMAP; stay on AppleScript for all operations | Deletes the whole IMAP arc (#40, #41, #66); concedes the perf and threading wins of the hybrid design |
+
+### Status of related issues
+
+- **#39** — closed as a completed spike with negative result (this document is the deliverable).
+- **#40** (IMAPClient integration for `search_messages`) — blocked. The IMAP perf prototype is meaningful only once auth is settled.
+- **#41** (design `imap_connector.py` alongside `mail_connector.py`) — blocked. The delegation design assumed a working Keychain auth path.
+- **#66** (IMAP-based thread reconstruction) — blocked, same reason.
+- **#68** — new research issue to evaluate the five options above and recommend one.

--- a/scripts/probe_keychain_for_imap.sh
+++ b/scripts/probe_keychain_for_imap.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Probe whether Mail.app's IMAP credentials are retrievable from the macOS Keychain.
+#
+# Background: docs/research/imap-hybrid-approach.md proposed retrieving IMAP
+# credentials via `security find-internet-password -s imap.<provider>.com`.
+# This script tests that assumption on the running machine. See issue #39
+# and the "Spike Findings" section of imap-hybrid-approach.md for context.
+#
+# Exits 0 regardless of findings — this is a diagnostic, not a gate.
+set -uo pipefail
+
+echo "=================================================================="
+echo "Keychain / IMAP credential probe"
+echo "macOS: $(sw_vers -productName) $(sw_vers -productVersion) (Darwin $(uname -r))"
+echo "Date:  $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "=================================================================="
+echo ""
+
+KEYCHAINS=$(security list-keychains | tr -d '"' | xargs)
+
+echo "--- Keychains in search list ---"
+echo "$KEYCHAINS" | tr ' ' '\n' | sed 's/^/  /'
+echo ""
+
+echo "--- Check 1: items with ptcl=imap or ptcl=imps ---"
+IMAP_PROTO_COUNT=0
+for kc in $KEYCHAINS; do
+    count=$(security dump-keychain "$kc" 2>/dev/null \
+        | grep -cE '"ptcl"<uint32>="(imap|imps)"' || true)
+    echo "  $kc: $count items"
+    IMAP_PROTO_COUNT=$((IMAP_PROTO_COUNT + count))
+done
+echo "  TOTAL: $IMAP_PROTO_COUNT"
+echo ""
+
+echo "--- Check 2: items matching common IMAP server hostnames ---"
+SERVERS=(
+    "imap.gmail.com"
+    "imap.mail.me.com"
+    "imap.mail.yahoo.com"
+    "outlook.office365.com"
+    "imap-mail.outlook.com"
+    "imap.fastmail.com"
+    "imap.aol.com"
+)
+SERVER_MATCH_COUNT=0
+for srv in "${SERVERS[@]}"; do
+    out=$(security find-internet-password -s "$srv" 2>&1 || true)
+    if echo "$out" | grep -q "could not be found"; then
+        echo "  $srv: not found"
+    else
+        echo "  $srv: FOUND"
+        SERVER_MATCH_COUNT=$((SERVER_MATCH_COUNT + 1))
+    fi
+done
+echo "  TOTAL MATCHES: $SERVER_MATCH_COUNT / ${#SERVERS[@]}"
+echo ""
+
+echo "--- Check 3: OAuth tokens (Gmail/Google) ---"
+GOOGLE_OAUTH_COUNT=$(security dump-keychain 2>/dev/null \
+    | grep -cE '"gena"<blob>="Google OAuth"' || true)
+echo "  Items with gena=\"Google OAuth\": $GOOGLE_OAUTH_COUNT"
+echo ""
+
+echo "--- Check 4: Accounts framework DB readability (TCC) ---"
+ACCOUNTS_DIR="$HOME/Library/Accounts"
+if ls "$ACCOUNTS_DIR" >/dev/null 2>&1; then
+    echo "  $ACCOUNTS_DIR: readable"
+    if [ -f "$ACCOUNTS_DIR/Accounts4.sqlite" ] \
+        && sqlite3 "$ACCOUNTS_DIR/Accounts4.sqlite" ".tables" >/dev/null 2>&1; then
+        echo "  Accounts4.sqlite: readable"
+    else
+        echo "  Accounts4.sqlite: NOT readable (likely TCC-protected)"
+    fi
+else
+    echo "  $ACCOUNTS_DIR: NOT readable (TCC-protected — grant Full Disk Access to test)"
+fi
+echo ""
+
+echo "--- Check 5: Mail.app account inventory (for reference) ---"
+osascript <<'APPLESCRIPT' 2>&1 || echo "  (unable to query Mail.app — may not be running or automation not authorized)"
+tell application "Mail"
+    set out to ""
+    repeat with a in every account
+        set out to out & "  " & (name of a) & " [" & (account type of a as string) & "]" & linefeed
+    end repeat
+    return out
+end tell
+APPLESCRIPT
+echo ""
+
+echo "=================================================================="
+echo "SUMMARY"
+echo "=================================================================="
+echo "  IMAP-protocol Keychain items:     $IMAP_PROTO_COUNT"
+echo "  Common IMAP hostnames matched:    $SERVER_MATCH_COUNT / ${#SERVERS[@]}"
+echo "  Google OAuth items in Keychain:   $GOOGLE_OAUTH_COUNT"
+echo ""
+if [ "$IMAP_PROTO_COUNT" -eq 0 ] && [ "$SERVER_MATCH_COUNT" -eq 0 ]; then
+    echo "  VERDICT: Mail.app's IMAP credentials are NOT retrievable via the"
+    echo "  login/System keychain on this machine. The assumption in"
+    echo "  docs/research/imap-hybrid-approach.md is falsified here."
+else
+    echo "  VERDICT: Some IMAP credentials appear retrievable. Inspect the"
+    echo "  matching items above to determine whether they are usable."
+fi
+echo "=================================================================="


### PR DESCRIPTION
## Summary

- Closes spike #39 with a negative result: Mail.app's IMAP credentials are **not** retrievable from the macOS Keychain via `security find-internet-password` on modern macOS (tested on 26.3.1 / Darwin 25.3.0). The central assumption in `docs/research/imap-hybrid-approach.md` is falsified.
- Adds `scripts/probe_keychain_for_imap.sh` to reproduce the finding on any machine.
- Updates the research doc with a status banner, a superseded note on the old Authentication section, and a new `Spike Findings (#39, 2026-04-22)` section cataloging five auth alternatives.
- Files #68 to evaluate those alternatives. #40, #41, #66 are labeled `blocked` on #68 and remain on v0.5.0.

## What the probe found

```
IMAP-protocol Keychain items:     0
Common IMAP hostnames matched:    0 / 7
Google OAuth items in Keychain:   2
~/Library/Accounts/Accounts4.sqlite: NOT readable (TCC-protected)
```

Mail.app account inventory on the test machine includes Gmail, Yahoo, and iCloud — none of which have standard IMAP credentials in either keychain.

## Auth alternatives catalogued in the findings

| # | Option | Trade-off |
|---|--------|-----------|
| a | User-supplied Keychain item under a known service name | Simplest; works with app passwords across providers |
| b | Extract Google OAuth tokens + XOAUTH2 | Gmail only; refresh complexity |
| c | Read Accounts framework DB via TCC-entitled helper | Requires Full Disk Access |
| d | Env-var / config-file credentials | Worst UX, no Keychain |
| e | Abandon IMAP | Kills the hybrid arc |

Evaluation tracked in #68.

## Test plan

- [x] `make lint` — passes
- [x] `make test` (unit) — 306 passed (ran automatically via pre-push hook)
- [x] `bash scripts/probe_keychain_for_imap.sh` — reproduces the documented findings
- [ ] Reviewer sanity-reads the findings section of `imap-hybrid-approach.md` and confirms the status banner is prominent

## Notes

- No Python source, dependencies, or user-facing tool behavior changes in this PR.
- #39 will be closed with a summary comment **after** this PR merges, not auto-closed by the PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)