### PR TITLE
Document graceful-degradation invariants for IMAP path

### DIFF
--- a/docs/research/imap-auth-options-decision.md
+++ b/docs/research/imap-auth-options-decision.md
@@ -8,6 +8,29 @@
 
 Production IMAP authentication will read per-account app-specific passwords from a user-populated Keychain entry, keyed by a project-scoped service name and the Mail.app account's email. A setup helper will hide the raw `security` invocation. No part of the production path will rely on reading Mail.app's own stored credentials, which are not reachable from an unsigned user-scoped process on modern macOS.
 
+## Graceful degradation invariants
+
+IMAP is an optional enhancement, never a prerequisite. The following invariants are binding on the implementation (#41) and on any future work touching the delegation layer. They exist so that a user with no Keychain entry, a user with a revoked app password, and a user working offline all get identical, working tool behavior — just via AppleScript.
+
+1. **AppleScript baseline.** Every MCP tool this server exposes must function when IMAP is not available for any reason. AppleScript + Mail.app is the universal baseline. IMAP is, and will remain, a strictly additive enhancement for read / search operations.
+
+2. **Per-account opt-in.** IMAP is enabled per Mail.app account by the presence of a Keychain entry at `apple-mail-mcp.imap.<mail_app_account_name>`. Accounts without an entry never attempt IMAP; they go straight to AppleScript with no per-call check.
+
+3. **Runtime failure → fallback.** For accounts with IMAP configured, any runtime failure of an IMAP operation falls back to AppleScript for *that operation*. The failure classes that must be caught:
+   - `OSError` / `socket.timeout` — offline, DNS failure, host unreachable, wifi dropped mid-operation.
+   - `imapclient.exceptions.LoginError` — creds rejected (password revoked, app password deleted at the provider, account locked).
+   - `imapclient.exceptions.IMAPClientError` — protocol-level error or server-side error mid-session.
+   - Explicit per-operation timeout.
+   Application-level errors (mailbox does not exist, invalid search criteria, permissions error) are **not** caught; they propagate to the caller because AppleScript would fail identically.
+
+4. **Fail-fast connect timeout.** The IMAP connect timeout is ≤3 seconds. When offline, fallback happens within that budget; the user does not sit through the TCP default of tens of seconds on every operation.
+
+5. **Quiet fallback, audible first failure.** Fallback emits at `DEBUG` log level in the steady state. The *first* IMAP failure per account per server-process lifetime emits a single `WARNING` log entry identifying the account, the failure class, and the fact that subsequent operations on that account will also use AppleScript until the process restarts or the operator intervenes. Subsequent failures for the same account drop back to DEBUG.
+
+6. **Write operations always AppleScript.** `send_email`, `send_email_with_attachments`, `reply_to_message`, `forward_message` always use AppleScript regardless of IMAP state. They are never candidates for delegation. (Repeating the existing hybrid design to forestall confusion.)
+
+7. **No whole-session disable.** We do not introduce a global kill switch that disables IMAP for the whole process after N consecutive failures. Fallback is per-operation; an operation that succeeds later (e.g. user reconnects wifi) re-enables IMAP for that call with no state change. Rationale: a laptop oscillating between offline and online is a common case; a session-wide disable would be user-hostile.
+
 ## Context
 
 Spike #39 tested the architectural assumption from [`imap-hybrid-approach.md`](./imap-hybrid-approach.md) that Mail.app's IMAP credentials could be pulled from the login Keychain via `security find-internet-password`. The assumption was falsified in under a minute: zero items with `ptcl=imap`/`imps` exist in the login or system keychain, and the Internet Accounts framework DB (`~/Library/Accounts/Accounts4.sqlite`) is TCC-protected. See [Spike Findings (#39)](./imap-hybrid-approach.md#spike-findings-39-2026-04-22).

--- a/docs/research/imap-hybrid-approach.md
+++ b/docs/research/imap-hybrid-approach.md
@@ -176,17 +176,26 @@ src/apple_mail_mcp/
 
 **Feature flag:** `MAIL_USE_IMAP=true` for opt-in during development. Default off until stable.
 
-**Delegation logic:**
+**Delegation logic:** see the [graceful-degradation invariants](./imap-auth-options-decision.md#graceful-degradation-invariants) in the decision doc. The sketch below shows the required runtime-fallback shape; the invariants doc is authoritative on exact failure classes and logging behavior.
 
 ```python
+import socket
+from imapclient.exceptions import LoginError, IMAPClientError
+
+IMAP_CONNECT_TIMEOUT_S = 3
+
 class AppleMailConnector:
     def search_messages(self, account, mailbox, ...):
         if self._imap_available(account):
-            return self._imap.search(...)
-        return self._applescript.search(...)
+            try:
+                return self._imap.search(account, mailbox, ...)
+            except (OSError, socket.timeout, LoginError, IMAPClientError) as exc:
+                self._log_imap_fallback(account, exc)
+                # fall through to AppleScript for this operation
+        return self._applescript.search(account, mailbox, ...)
 
     def send_email(self, ...):
-        # Always AppleScript — sending needs compose UI
+        # Always AppleScript — sending needs compose UI. Never delegated.
         return self._applescript.send(...)
 ```
 


### PR DESCRIPTION
## Summary

- The IMAP auth decision in #70 covered config-level fallback (no Keychain entry → AppleScript) but left runtime failures (offline, revoked creds, timeouts, protocol errors) unspecified.
- This PR adds seven explicit invariants to `docs/research/imap-auth-options-decision.md` under a new "Graceful degradation invariants" section, and updates the delegation code sketch in `imap-hybrid-approach.md` to match.
- **Core principle:** every MCP tool must function when IMAP is not available for any reason. AppleScript + Mail.app is the universal baseline; IMAP is always an additive enhancement. A user offline against a local LLM still gets working read/search tools.

## Invariants (summary)

1. AppleScript baseline — universal; every tool works without IMAP.
2. Per-account opt-in via Keychain entry presence.
3. Runtime failure → per-operation fallback (catches `OSError`, `socket.timeout`, `LoginError`, `IMAPClientError`, explicit timeout).
4. ≤3s connect timeout so offline fallback is fast.
5. Quiet fallback at DEBUG; first failure per account emits one WARNING.
6. Write ops (send/reply/forward) always AppleScript.
7. No whole-session disable — per-operation fallback only.

Full text in the decision doc. The `imap-hybrid-approach.md` delegation sketch now shows the try/except pattern and connect-timeout constant, so readers can't miss the runtime-fallback requirement.

## Why now

#41 is the next keystone issue — design of `imap_connector.py` + `keychain.py`. Without these invariants locked in the decision doc, #41 could reasonably produce a version that raises network errors to the MCP caller instead of silently degrading. Post-merge, #41 gets a comment with acceptance criteria derived from these invariants so the principle travels with the implementation.

## Test plan

- [x] `make lint` — passes (no code changes; docs only).
- [x] `make test` — 306 passed (ran via pre-push hook).
- [ ] Reviewer reads the new "Graceful degradation invariants" section in `imap-auth-options-decision.md` and confirms the seven invariants capture the intent.
- [ ] Reviewer confirms the updated delegation code sketch in `imap-hybrid-approach.md` reads as "must catch these exceptions" rather than "might catch these exceptions."

## Post-merge action (user-gated)

After merge, I will — pending your go-ahead — add a comment to #41 with explicit acceptance criteria:

- Delegation layer catches `OSError`, `socket.timeout`, `LoginError`, `IMAPClientError` at every IMAP call site.
- IMAP connect timeout ≤3s.
- First failure per account per process emits WARNING; subsequent DEBUG.
- Unit tests cover: missing Keychain entry, connect-refused, connect-timeout, LoginError, in-session IMAPClientError.
- Integration test covers fallback-when-offline.
- Write ops remain AppleScript-only.

No changes to `src/` or tests in this PR. Production behavior unchanged (no IMAP production code yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)