### PR TITLE
Wire IMAP delegation into search_messages (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,54 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 On first run, macOS will prompt for Automation access. Grant permission in:
 **System Settings > Privacy & Security > Automation > Terminal (or your IDE)**
 
+## Optional: faster search via IMAP
+
+`search_messages` works out of the box via AppleScript. For large mailboxes (thousands of messages), AppleScript's `whose` clause can take 1–5 seconds per query. If you want faster server-side search, you can enable IMAP delegation per account by adding a Keychain entry.
+
+**How it works.** If a Keychain entry exists for an account, the server uses IMAP (fast, server-side SEARCH). Otherwise — or on any IMAP failure (offline, wrong password, timeout) — it silently falls back to AppleScript. You never lose functionality; you only gain speed when IMAP is configured and reachable. No config flags, no environment variables; the Keychain entry's presence is the opt-in.
+
+**One-time setup per account.**
+
+1. Generate an app-specific password at your provider. The procedure varies:
+   - **iCloud:** [appleid.apple.com/account/manage](https://appleid.apple.com/account/manage) → App-Specific Passwords. Requires 2FA on your Apple ID (default).
+   - **Gmail:** [myaccount.google.com/apppasswords](https://myaccount.google.com/apppasswords). Requires 2-Step Verification on your Google account.
+   - **Yahoo / Fastmail / AOL:** generate an app password in the provider's account-security settings.
+
+2. Look up the account's primary email address as Mail.app knows it. The easiest way:
+   ```bash
+   osascript -e 'tell application "Mail" to return email addresses of account "iCloud"'
+   ```
+   (Substitute your account's name — whatever it's labeled in Mail.app.) Use the first email address returned.
+
+3. Store the app password in Keychain under a project-scoped service name:
+   ```bash
+   security add-generic-password \
+       -s "apple-mail-mcp.imap.<ACCOUNT_NAME>" \
+       -a "<email-from-step-2>" \
+       -w "<app-password>" \
+       -T "" -U
+   ```
+   Replace `<ACCOUNT_NAME>` with the Mail.app account name *exactly* (e.g. `iCloud`, `Gmail`, `"Yahoo!"`). The `-T ""` flag clears the ACL so macOS will prompt for Keychain access on first read (click "Always Allow" to persist).
+
+4. The next time you use a search tool, it will go through IMAP. On first access, you may see a one-time "security wants to use the 'login' keychain" prompt — click **Always Allow**.
+
+**Verifying the setup.** Run:
+```bash
+uv run python -c "from apple_mail_mcp.mail_connector import AppleMailConnector; \
+    print(AppleMailConnector().search_messages(account='<ACCOUNT_NAME>', limit=1))"
+```
+If IMAP is working, the call returns in ~1 second. If it logs a WARNING about falling back (visible with `--log-level=DEBUG`), check that the account name matches Mail.app's account name exactly and that the email in your Keychain entry matches what `email addresses of account` returns.
+
+**Known provider quirks.**
+
+- **iCloud:** the IMAP server accepts `@icloud.com` / `@me.com` aliases as LOGIN username, not the Apple ID email. This server reads `email addresses of account` from Mail.app for that reason.
+- **Yahoo:** app passwords have been progressively deprecated; the option may not be available for all accounts. If Yahoo's account-security page doesn't show the option, IMAP setup isn't possible for that account and AppleScript is the only path.
+- **Gmail:** requires 2-Step Verification enabled. If your Google Workspace admin has disabled app passwords at the tenant level, IMAP setup isn't possible for that account.
+
+**Write operations** (`send_email`, `reply_to_message`, `forward_message`) always use AppleScript regardless of IMAP configuration — these need Mail.app's compose UI.
+
+A user-friendly `apple-mail-mcp setup-imap` CLI subcommand that wraps the `security add-generic-password` call (including validation and a test connection) is tracked in [#76](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/76).
+
 ## Development
 
 ```bash

--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -12,6 +12,7 @@ See ``docs/plans/2026-04-23-imap-connector-design.md``.
 
 from __future__ import annotations
 
+import re
 from datetime import date as _date
 from datetime import timedelta as _timedelta
 from typing import Any
@@ -19,7 +20,12 @@ from typing import Any
 from imapclient import IMAPClient
 from imapclient.response_types import Envelope
 
-from apple_mail_mcp.mail_connector import _ISO_DATE_RE
+# Strict ISO 8601 YYYY-MM-DD. Duplicated from mail_connector to break an
+# otherwise-circular import: mail_connector.search_messages delegates to
+# this module, so mail_connector has to import from imap_connector, and a
+# reverse dependency would deadlock. The regex is trivial; duplication is
+# preferable to reshuffling the module layout.
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 CONNECT_TIMEOUT_S: float = 3.0
 """Per invariant 4 in imap-auth-options-decision.md: ≤3s so offline

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -278,8 +278,17 @@ class AppleMailConnector:
             account: Mail.app account name (e.g. "iCloud", "Gmail").
 
         Returns:
-            Tuple of (host, port, email). `email` is Mail.app's `user name`
-            property — the canonical login identifier, not an alias.
+            Tuple of (host, port, email). `email` is the first entry of
+            Mail.app's `email addresses` list if non-empty, else falls back
+            to the `user name` property.
+
+            For iCloud specifically, `user name` is the Apple ID login
+            identifier — which may be any email (e.g. a Gmail address) —
+            while the IMAP server only accepts @icloud.com / @me.com aliases
+            as LOGIN username. `email addresses` reliably contains the
+            alias iCloud's IMAP server expects. For Gmail / Yahoo / generic
+            IMAP accounts, the first email address typically equals
+            `user name`, so the behavior is equivalent there.
 
         Raises:
             MailAccountNotFoundError: If the account doesn't exist.
@@ -288,16 +297,20 @@ class AppleMailConnector:
         tell_body = f'''
         tell application "Mail"
             set acctRef to account "{account_safe}"
-            set resultData to {{|host|:(server name of acctRef), |port|:(port of acctRef), |email|:(user name of acctRef)}}
+            set acctEmails to email addresses of acctRef
+            if acctEmails is missing value then set acctEmails to {{}}
+            set resultData to {{|host|:(server name of acctRef), |port|:(port of acctRef), |user_name|:(user name of acctRef), |email_addresses|:acctEmails}}
         end tell
         '''
         script = _wrap_as_json_script(tell_body)
         raw = self._run_applescript(script)
         parsed = cast(dict[str, Any], parse_applescript_json(raw))
+        email_addresses = cast(list[str], parsed.get("email_addresses") or [])
+        email = email_addresses[0] if email_addresses else cast(str, parsed["user_name"])
         return (
             cast(str, parsed["host"]),
             cast(int, parsed["port"]),
-            cast(str, parsed["email"]),
+            email,
         )
 
     def _imap_search(

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -235,7 +235,7 @@ class AppleMailConnector:
         tell_body = f'''
         tell application "Mail"
             set acctRef to account "{account_safe}"
-            set result to {{|host|:(server name of acctRef), |port|:(port of acctRef), |email|:(user name of acctRef)}}
+            set resultData to {{|host|:(server name of acctRef), |port|:(port of acctRef), |email|:(user name of acctRef)}}
         end tell
         '''
         script = _wrap_as_json_script(tell_body)

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 from .exceptions import (
     MailAccountNotFoundError,
     MailAppleScriptError,
+    MailKeychainEntryNotFoundError,
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
 )
@@ -74,6 +75,40 @@ class AppleMailConnector:
             timeout: Timeout in seconds for AppleScript operations
         """
         self.timeout = timeout
+        # Accounts for which we've already logged a WARNING about IMAP failure.
+        # Subsequent failures for the same account are demoted to DEBUG per
+        # invariant 5 in docs/research/imap-auth-options-decision.md.
+        self._imap_failures: set[str] = set()
+
+    def _log_imap_fallback(self, account: str, exc: Exception) -> None:
+        """Log an IMAP fallback event at the level specified by the invariants.
+
+        MailKeychainEntryNotFoundError is a benign opt-out signal — always DEBUG,
+        never tracked. For any other failure, the first per-account occurrence
+        logs WARNING; subsequent occurrences for the same account log DEBUG.
+        """
+        if isinstance(exc, MailKeychainEntryNotFoundError):
+            logger.debug(
+                "IMAP not configured for %s (no Keychain entry); using AppleScript",
+                account,
+            )
+            return
+        if account not in self._imap_failures:
+            self._imap_failures.add(account)
+            logger.warning(
+                "IMAP failed for %s (%s: %s), falling back to AppleScript; "
+                "subsequent failures for this account will log at DEBUG",
+                account,
+                type(exc).__name__,
+                exc,
+            )
+        else:
+            logger.debug(
+                "IMAP retry failed for %s: %s: %s",
+                account,
+                type(exc).__name__,
+                exc,
+            )
 
     def _run_applescript(self, script: str) -> str:
         """

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -17,6 +17,8 @@ from .exceptions import (
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
 )
+from .imap_connector import ImapConnector
+from .keychain import get_imap_password
 from .utils import escape_applescript_string, parse_applescript_json, sanitize_input
 
 logger = logging.getLogger(__name__)
@@ -280,6 +282,49 @@ class AppleMailConnector:
             cast(str, parsed["host"]),
             cast(int, parsed["port"]),
             cast(str, parsed["email"]),
+        )
+
+    def _imap_search(
+        self,
+        account: str,
+        mailbox: str = "INBOX",
+        sender_contains: str | None = None,
+        subject_contains: str | None = None,
+        read_status: bool | None = None,
+        is_flagged: bool | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        has_attachment: bool | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Run search_messages through the IMAP path.
+
+        Resolves host/port/email via AppleScript, fetches the password from
+        Keychain, and delegates to ImapConnector. Propagates all fallback-
+        triggering exceptions unchanged — the caller (search_messages) is
+        responsible for catching and falling back.
+
+        Raises:
+            MailKeychainEntryNotFoundError: No opt-in (benign).
+            MailKeychainAccessDeniedError: Keychain ACL refused.
+            OSError (incl. socket.timeout): Network / connection failure.
+            imapclient.exceptions.LoginError: Credentials rejected.
+            imapclient.exceptions.IMAPClientError: Protocol or session error.
+            MailAccountNotFoundError: Mail.app doesn't know this account.
+        """
+        host, port, email = self._resolve_imap_config(account)
+        password = get_imap_password(account, email)
+        imap = ImapConnector(host, port, email, password)
+        return imap.search_messages(
+            mailbox=mailbox,
+            sender_contains=sender_contains,
+            subject_contains=subject_contains,
+            read_status=read_status,
+            is_flagged=is_flagged,
+            date_from=date_from,
+            date_to=date_to,
+            has_attachment=has_attachment,
+            limit=limit,
         )
 
     def search_messages(

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -231,8 +231,43 @@ class AppleMailConnector:
         has_attachment: bool | None = None,
         limit: int | None = None,
     ) -> list[dict[str, Any]]:
+        """Search messages via AppleScript.
+
+        Will grow IMAP delegation in a subsequent commit of #40; for now this
+        is a passthrough to the AppleScript implementation so the MCP tool
+        surface keeps working during the refactor.
         """
-        Search for messages matching criteria.
+        return self._search_messages_applescript(
+            account,
+            mailbox,
+            sender_contains,
+            subject_contains,
+            read_status,
+            is_flagged,
+            date_from,
+            date_to,
+            has_attachment,
+            limit,
+        )
+
+    def _search_messages_applescript(
+        self,
+        account: str,
+        mailbox: str = "INBOX",
+        sender_contains: str | None = None,
+        subject_contains: str | None = None,
+        read_status: bool | None = None,
+        is_flagged: bool | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        has_attachment: bool | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """AppleScript path for search_messages (the universal baseline).
+
+        Called directly when IMAP is not configured for the account, or as a
+        fallback when the IMAP path fails for any reason (see the graceful-
+        degradation invariants in docs/research/imap-auth-options-decision.md).
 
         Args:
             account: Account name.

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -10,9 +10,12 @@ from datetime import timedelta as _timedelta
 from pathlib import Path
 from typing import Any, cast
 
+from imapclient.exceptions import IMAPClientError, LoginError
+
 from .exceptions import (
     MailAccountNotFoundError,
     MailAppleScriptError,
+    MailKeychainAccessDeniedError,
     MailKeychainEntryNotFoundError,
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
@@ -20,6 +23,19 @@ from .exceptions import (
 from .imap_connector import ImapConnector
 from .keychain import get_imap_password
 from .utils import escape_applescript_string, parse_applescript_json, sanitize_input
+
+# Exception classes that trigger AppleScript fallback per the graceful-
+# degradation invariants (docs/research/imap-auth-options-decision.md).
+# OSError covers socket.timeout too. ValueError and MailAccountNotFoundError
+# are deliberately NOT in this tuple — they indicate caller/config errors
+# and must surface, not be papered over by fallback.
+_IMAP_FALLBACK_EXCS: tuple[type[Exception], ...] = (
+    MailKeychainEntryNotFoundError,
+    MailKeychainAccessDeniedError,
+    OSError,
+    LoginError,
+    IMAPClientError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -340,12 +356,30 @@ class AppleMailConnector:
         has_attachment: bool | None = None,
         limit: int | None = None,
     ) -> list[dict[str, Any]]:
-        """Search messages via AppleScript.
+        """Search for messages matching criteria.
 
-        Will grow IMAP delegation in a subsequent commit of #40; for now this
-        is a passthrough to the AppleScript implementation so the MCP tool
-        surface keeps working during the refactor.
+        Tries the IMAP path first (fast, server-side SEARCH). Falls back to
+        AppleScript on any IMAP failure per the graceful-degradation invariants
+        in docs/research/imap-auth-options-decision.md — so a user with no
+        Keychain entry, a revoked password, or a dropped network still gets
+        working search via AppleScript.
         """
+        try:
+            return self._imap_search(
+                account,
+                mailbox,
+                sender_contains,
+                subject_contains,
+                read_status,
+                is_flagged,
+                date_from,
+                date_to,
+                has_attachment,
+                limit,
+            )
+        except _IMAP_FALLBACK_EXCS as exc:
+            self._log_imap_fallback(account, exc)
+            # fall through to AppleScript
         return self._search_messages_applescript(
             account,
             mailbox,

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -218,6 +218,35 @@ class AppleMailConnector:
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
+    def _resolve_imap_config(self, account: str) -> tuple[str, int, str]:
+        """Query Mail.app for the IMAP connection details of an account.
+
+        Args:
+            account: Mail.app account name (e.g. "iCloud", "Gmail").
+
+        Returns:
+            Tuple of (host, port, email). `email` is Mail.app's `user name`
+            property — the canonical login identifier, not an alias.
+
+        Raises:
+            MailAccountNotFoundError: If the account doesn't exist.
+        """
+        account_safe = escape_applescript_string(sanitize_input(account))
+        tell_body = f'''
+        tell application "Mail"
+            set acctRef to account "{account_safe}"
+            set result to {{|host|:(server name of acctRef), |port|:(port of acctRef), |email|:(user name of acctRef)}}
+        end tell
+        '''
+        script = _wrap_as_json_script(tell_body)
+        raw = self._run_applescript(script)
+        parsed = cast(dict[str, Any], parse_applescript_json(raw))
+        return (
+            cast(str, parsed["host"]),
+            cast(int, parsed["port"]),
+            cast(str, parsed["email"]),
+        )
+
     def search_messages(
         self,
         account: str,

--- a/tests/integration/test_imap_delegation.py
+++ b/tests/integration/test_imap_delegation.py
@@ -1,0 +1,142 @@
+"""Integration tests for search_messages IMAP delegation against real iCloud.
+
+Guarded by ``MAIL_TEST_MODE=true``. The positive test requires a Keychain
+entry keyed to the Apple ID email (what Mail.app returns for `user name`),
+not an @icloud.com alias::
+
+    security add-generic-password \\
+        -s "apple-mail-mcp.imap.iCloud" \\
+        -a "<apple-id-email>" \\
+        -w "<APP_PASSWORD>" \\
+        -T "" -U
+
+Run:
+
+    MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=iCloud \\
+        uv run pytest tests/integration/test_imap_delegation.py -v
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+
+import pytest
+
+from apple_mail_mcp.mail_connector import AppleMailConnector
+
+ICLOUD_ACCOUNT_NAME = "iCloud"
+
+
+def _test_mode_enabled() -> bool:
+    return os.getenv("MAIL_TEST_MODE") == "true"
+
+
+def _keychain_entry_exists(account_name: str, email: str) -> bool:
+    service = f"apple-mail-mcp.imap.{account_name}"
+    result = subprocess.run(
+        ["security", "find-generic-password", "-s", service, "-a", email],
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+@pytest.fixture
+def connector() -> AppleMailConnector:
+    return AppleMailConnector()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _test_mode_enabled(), reason="MAIL_TEST_MODE != 'true'")
+class TestIMAPDelegation:
+    def test_search_messages_uses_imap_when_keychain_entry_present(
+        self, connector: AppleMailConnector, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Positive path: real iCloud, Keychain entry present, search goes via IMAP.
+
+        Skipped if the user hasn't set up the Apple-ID-keyed Keychain entry
+        — this test requires an entry keyed to Mail.app's 'user name'
+        property (the Apple ID), not an alias.
+        """
+        host, port, email = connector._resolve_imap_config(ICLOUD_ACCOUNT_NAME)
+        if not _keychain_entry_exists(ICLOUD_ACCOUNT_NAME, email):
+            pytest.skip(
+                f"No Keychain entry under "
+                f"apple-mail-mcp.imap.{ICLOUD_ACCOUNT_NAME} for {email}. "
+                f"See the test file's module docstring for setup."
+            )
+
+        # If IMAP succeeds, _imap_failures stays empty. If anything falls back,
+        # the set will contain iCloud. We assert the IMAP path executed.
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp"):
+            result = connector.search_messages(
+                account=ICLOUD_ACCOUNT_NAME, limit=5
+            )
+
+        assert isinstance(result, list)
+        # Search may be empty (iCloud inbox often is for this user), but the
+        # IMAP path must have been used — which means the failures set is empty
+        # AND we did not emit any WARNING about falling back.
+        assert ICLOUD_ACCOUNT_NAME not in connector._imap_failures
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings == [], (
+            f"Expected IMAP path to succeed silently, but got warnings: "
+            f"{[r.getMessage() for r in warnings]}"
+        )
+
+        # Any messages returned must have the standard keys. (iCloud may
+        # legitimately return [] — that's a successful IMAP search.)
+        expected_keys = {
+            "id", "subject", "sender", "date_received",
+            "read_status", "flagged",
+        }
+        for msg in result:
+            assert set(msg.keys()) == expected_keys
+
+    def test_search_messages_falls_back_when_imap_host_unroutable(
+        self,
+        connector: AppleMailConnector,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Negative path: IMAP connect times out, AppleScript path runs.
+
+        Monkey-patches _resolve_imap_config to return an unroutable host
+        (10.255.255.1:993 — TEST-NET-1-adjacent; guaranteed to not route).
+        Also stubs get_imap_password so the Keychain lookup doesn't short-
+        circuit the test with a benign MailKeychainEntryNotFoundError —
+        we want the 3s IMAP connect timeout to fire, OSError to propagate,
+        and the first-failure WARNING path to execute.
+        """
+        def fake_config(_account: str) -> tuple[str, int, str]:
+            return ("10.255.255.1", 993, "fake@example.com")
+
+        monkeypatch.setattr(connector, "_resolve_imap_config", fake_config)
+        monkeypatch.setattr(
+            "apple_mail_mcp.mail_connector.get_imap_password",
+            lambda _account, _email: "fake-password",
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp"):
+            result = connector.search_messages(
+                account=ICLOUD_ACCOUNT_NAME, limit=5
+            )
+
+        # AppleScript path succeeded despite IMAP failure. iCloud may return
+        # an empty inbox; the key assertion is that we got a list back at all
+        # (i.e. search_messages didn't raise).
+        assert isinstance(result, list)
+
+        # The failures set must contain iCloud.
+        assert ICLOUD_ACCOUNT_NAME in connector._imap_failures
+
+        # First failure should log at WARNING.
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, (
+            f"Expected exactly one WARNING, got {len(warnings)}: "
+            f"{[r.getMessage() for r in warnings]}"
+        )
+        msg = warnings[0].getMessage()
+        assert ICLOUD_ACCOUNT_NAME in msg

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -263,16 +263,36 @@ class TestAppleMailConnector:
     # --- _resolve_imap_config --------------------------------------------
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_resolve_imap_config_returns_tuple(
+    def test_resolve_imap_config_prefers_first_email_address(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
+        """Primary path: first email_addresses entry wins over user_name.
+
+        iCloud's IMAP server rejects the Apple-ID user_name as LOGIN
+        but accepts the aliases in email_addresses.
+        """
         mock_run.return_value = (
             '{"host":"imap.mail.me.com",'
             '"port":993,'
-            '"email":"s_morgan_jeffries@yahoo.com"}'
+            '"user_name":"apple.id@gmail.com",'
+            '"email_addresses":["user@icloud.com","user@me.com"]}'
         )
         result = connector._resolve_imap_config("iCloud")
-        assert result == ("imap.mail.me.com", 993, "s_morgan_jeffries@yahoo.com")
+        assert result == ("imap.mail.me.com", 993, "user@icloud.com")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_falls_back_to_user_name_when_emails_empty(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Fallback path: empty email_addresses → use user_name."""
+        mock_run.return_value = (
+            '{"host":"imap.gmail.com",'
+            '"port":993,'
+            '"user_name":"me@gmail.com",'
+            '"email_addresses":[]}'
+        )
+        result = connector._resolve_imap_config("Gmail")
+        assert result == ("imap.gmail.com", 993, "me@gmail.com")
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_resolve_imap_config_propagates_account_not_found(
@@ -290,13 +310,15 @@ class TestAppleMailConnector:
     ) -> None:
         """NSJSONSerialization requires |key| form for record keys."""
         mock_run.return_value = (
-            '{"host":"h","port":993,"email":"e@e.com"}'
+            '{"host":"h","port":993,'
+            '"user_name":"u@e.com","email_addresses":["u@e.com"]}'
         )
         connector._resolve_imap_config("iCloud")
         script = mock_run.call_args[0][0]
         assert "|host|:(server name of acctRef)" in script
         assert "|port|:(port of acctRef)" in script
-        assert "|email|:(user name of acctRef)" in script
+        assert "|user_name|:(user name of acctRef)" in script
+        assert "|email_addresses|:acctEmails" in script
         # Must assign to resultData for _wrap_as_json_script to serialize.
         assert "set resultData to" in script
 
@@ -305,7 +327,8 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         mock_run.return_value = (
-            '{"host":"h","port":993,"email":"e@e.com"}'
+            '{"host":"h","port":993,'
+            '"user_name":"u@e.com","email_addresses":["u@e.com"]}'
         )
         connector._resolve_imap_config('Weird "Name" Acct')
         script = mock_run.call_args[0][0]

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1,5 +1,6 @@
 """Unit tests for mail connector."""
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,6 +8,8 @@ import pytest
 from apple_mail_mcp.exceptions import (
     MailAccountNotFoundError,
     MailAppleScriptError,
+    MailKeychainAccessDeniedError,
+    MailKeychainEntryNotFoundError,
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
 )
@@ -308,6 +311,95 @@ class TestAppleMailConnector:
         script = mock_run.call_args[0][0]
         # The quote must be escaped; raw quotes would break the script.
         assert 'Weird \\"Name\\" Acct' in script
+
+    # --- _imap_failures state + _log_imap_fallback -----------------------
+
+    def test_imap_failures_starts_empty(
+        self, connector: AppleMailConnector
+    ) -> None:
+        assert connector._imap_failures == set()
+
+    def test_log_imap_fallback_keychain_entry_not_found_is_silent(
+        self, connector: AppleMailConnector, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Missing Keychain entry is a benign opt-out signal — DEBUG only."""
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp.mail_connector"):
+            connector._log_imap_fallback(
+                "iCloud", MailKeychainEntryNotFoundError("missing")
+            )
+        # Not in the failures set — benign signals don't count as failures.
+        assert "iCloud" not in connector._imap_failures
+        # Should log at DEBUG, never WARNING.
+        warning_records = [
+            r for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert warning_records == []
+        debug_records = [
+            r for r in caplog.records if r.levelno == logging.DEBUG
+        ]
+        assert len(debug_records) == 1
+        assert "iCloud" in debug_records[0].getMessage()
+
+    def test_log_imap_fallback_first_failure_logs_warning(
+        self, connector: AppleMailConnector, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp.mail_connector"):
+            connector._log_imap_fallback("iCloud", OSError("network down"))
+        assert "iCloud" in connector._imap_failures
+        warning_records = [
+            r for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert len(warning_records) == 1
+        msg = warning_records[0].getMessage()
+        assert "iCloud" in msg
+        assert "OSError" in msg
+
+    def test_log_imap_fallback_subsequent_failure_same_account_is_debug(
+        self, connector: AppleMailConnector, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Seed: first failure.
+        connector._log_imap_fallback("iCloud", OSError("first"))
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp.mail_connector"):
+            connector._log_imap_fallback("iCloud", OSError("second"))
+        # Set unchanged (already contains iCloud).
+        assert connector._imap_failures == {"iCloud"}
+        warning_records = [
+            r for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert warning_records == []
+        debug_records = [
+            r for r in caplog.records if r.levelno == logging.DEBUG
+        ]
+        assert len(debug_records) == 1
+
+    def test_log_imap_fallback_failure_new_account_logs_warning(
+        self, connector: AppleMailConnector, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        connector._log_imap_fallback("iCloud", OSError("iCloud first"))
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp.mail_connector"):
+            connector._log_imap_fallback("Gmail", OSError("Gmail first"))
+        assert connector._imap_failures == {"iCloud", "Gmail"}
+        warning_records = [
+            r for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert len(warning_records) == 1
+        assert "Gmail" in warning_records[0].getMessage()
+
+    def test_log_imap_fallback_access_denied_counts_as_failure(
+        self, connector: AppleMailConnector, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Access denied is a misconfiguration worth surfacing, unlike missing entry."""
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp.mail_connector"):
+            connector._log_imap_fallback(
+                "iCloud", MailKeychainAccessDeniedError("ACL refused")
+            )
+        assert "iCloud" in connector._imap_failures
+        warning_records = [
+            r for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert len(warning_records) == 1
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_basic(

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -493,6 +493,159 @@ class TestAppleMailConnector:
         with pytest.raises(OSError, match="unreachable"):
             connector._imap_search("iCloud", "INBOX")
 
+    # --- search_messages delegation --------------------------------------
+
+    @patch.object(AppleMailConnector, "_search_messages_applescript")
+    @patch.object(AppleMailConnector, "_imap_search")
+    def test_search_messages_uses_imap_on_success(
+        self,
+        mock_imap_search: MagicMock,
+        mock_as_search: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_imap_search.return_value = [{"id": "1", "subject": "from imap"}]
+        result = connector.search_messages(account="iCloud", mailbox="INBOX")
+        assert result == [{"id": "1", "subject": "from imap"}]
+        mock_as_search.assert_not_called()
+
+    @patch.object(AppleMailConnector, "_search_messages_applescript")
+    @patch.object(AppleMailConnector, "_imap_search")
+    def test_search_messages_falls_back_on_keychain_missing(
+        self,
+        mock_imap_search: MagicMock,
+        mock_as_search: MagicMock,
+        connector: AppleMailConnector,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_imap_search.side_effect = MailKeychainEntryNotFoundError("no entry")
+        mock_as_search.return_value = [{"id": "1", "subject": "from applescript"}]
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp.mail_connector"):
+            result = connector.search_messages(account="iCloud")
+        assert result == [{"id": "1", "subject": "from applescript"}]
+        mock_as_search.assert_called_once()
+        # Missing-entry = silent (no WARNING).
+        warning_records = [
+            r for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert warning_records == []
+        # Account not tracked as a failure.
+        assert "iCloud" not in connector._imap_failures
+
+    @patch.object(AppleMailConnector, "_search_messages_applescript")
+    @patch.object(AppleMailConnector, "_imap_search")
+    def test_search_messages_falls_back_on_oserror_with_warning(
+        self,
+        mock_imap_search: MagicMock,
+        mock_as_search: MagicMock,
+        connector: AppleMailConnector,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_imap_search.side_effect = OSError("unreachable")
+        mock_as_search.return_value = [{"id": "1"}]
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp.mail_connector"):
+            result = connector.search_messages(account="iCloud")
+        assert result == [{"id": "1"}]
+        mock_as_search.assert_called_once()
+        warning_records = [
+            r for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert len(warning_records) == 1
+        assert "iCloud" in connector._imap_failures
+
+    @patch.object(AppleMailConnector, "_search_messages_applescript")
+    @patch.object(AppleMailConnector, "_imap_search")
+    def test_search_messages_falls_back_on_login_error(
+        self,
+        mock_imap_search: MagicMock,
+        mock_as_search: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        from imapclient.exceptions import LoginError
+
+        mock_imap_search.side_effect = LoginError("rejected")
+        mock_as_search.return_value = [{"id": "1"}]
+        result = connector.search_messages(account="iCloud")
+        assert result == [{"id": "1"}]
+        mock_as_search.assert_called_once()
+
+    @patch.object(AppleMailConnector, "_search_messages_applescript")
+    @patch.object(AppleMailConnector, "_imap_search")
+    def test_search_messages_falls_back_on_imap_protocol_error(
+        self,
+        mock_imap_search: MagicMock,
+        mock_as_search: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        from imapclient.exceptions import IMAPClientError
+
+        mock_imap_search.side_effect = IMAPClientError("bad thing")
+        mock_as_search.return_value = [{"id": "1"}]
+        result = connector.search_messages(account="iCloud")
+        assert result == [{"id": "1"}]
+        mock_as_search.assert_called_once()
+
+    @patch.object(AppleMailConnector, "_search_messages_applescript")
+    @patch.object(AppleMailConnector, "_imap_search")
+    def test_search_messages_forwards_all_parameters(
+        self,
+        mock_imap_search: MagicMock,
+        mock_as_search: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_imap_search.return_value = []
+        connector.search_messages(
+            account="iCloud",
+            mailbox="Sent",
+            sender_contains="alice",
+            subject_contains="invoice",
+            read_status=True,
+            is_flagged=False,
+            date_from="2026-04-01",
+            date_to="2026-04-22",
+            has_attachment=True,
+            limit=10,
+        )
+        mock_imap_search.assert_called_once_with(
+            "iCloud",
+            "Sent",
+            "alice",
+            "invoice",
+            True,
+            False,
+            "2026-04-01",
+            "2026-04-22",
+            True,
+            10,
+        )
+
+    @patch.object(AppleMailConnector, "_search_messages_applescript")
+    @patch.object(AppleMailConnector, "_imap_search")
+    def test_search_messages_does_not_catch_value_error(
+        self,
+        mock_imap_search: MagicMock,
+        mock_as_search: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """Invalid-input errors must propagate to the caller, not silently fall back."""
+        mock_imap_search.side_effect = ValueError("bad date")
+        with pytest.raises(ValueError, match="bad date"):
+            connector.search_messages(account="iCloud", date_from="not-a-date")
+        mock_as_search.assert_not_called()
+
+    @patch.object(AppleMailConnector, "_search_messages_applescript")
+    @patch.object(AppleMailConnector, "_imap_search")
+    def test_search_messages_does_not_catch_mailaccountnotfound(
+        self,
+        mock_imap_search: MagicMock,
+        mock_as_search: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """A truly-missing account must surface, not be papered over by fallback."""
+        mock_imap_search.side_effect = MailAccountNotFoundError("No such account")
+        with pytest.raises(MailAccountNotFoundError):
+            connector.search_messages(account="Ghost")
+        mock_as_search.assert_not_called()
+
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_basic(
         self, mock_run: MagicMock, connector: AppleMailConnector
@@ -504,7 +657,7 @@ class TestAppleMailConnector:
             '"read_status":false}]'
         )
 
-        result = connector.search_messages("Gmail", "INBOX")
+        result = connector._search_messages_applescript("Gmail", "INBOX")
 
         assert len(result) == 1
         assert result[0]["id"] == "12345"
@@ -525,7 +678,7 @@ class TestAppleMailConnector:
             '"sender":"boss@example.com","date_received":"Wed Feb 5 2025",'
             '"read_status":true}]'
         )
-        result = connector.search_messages("Gmail", "INBOX")
+        result = connector._search_messages_applescript("Gmail", "INBOX")
         assert len(result) == 1
         assert result[0]["subject"] == "Q3 Report | Draft"
 
@@ -540,7 +693,7 @@ class TestAppleMailConnector:
         """
         mock_run.side_effect = MailAccountNotFoundError("Can't get account \"NoSuch\".")
         with pytest.raises(MailAccountNotFoundError):
-            connector.search_messages("NoSuch", "INBOX")
+            connector._search_messages_applescript("NoSuch", "INBOX")
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_propagates_mailbox_not_found(
@@ -549,7 +702,7 @@ class TestAppleMailConnector:
         """Similar regression guard for MailMailboxNotFoundError."""
         mock_run.side_effect = MailMailboxNotFoundError("Can't get mailbox \"NoSuch\".")
         with pytest.raises(MailMailboxNotFoundError):
-            connector.search_messages("Gmail", "NoSuch")
+            connector._search_messages_applescript("Gmail", "NoSuch")
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_with_filters(
@@ -558,7 +711,7 @@ class TestAppleMailConnector:
         """Test message search with filters."""
         mock_run.return_value = "[]"
 
-        connector.search_messages(
+        connector._search_messages_applescript(
             "Gmail",
             "INBOX",
             sender_contains="john@example.com",
@@ -588,7 +741,7 @@ class TestAppleMailConnector:
         rejects with `Illegal comparison or logical (-1726)`.
         """
         mock_run.return_value = "[]"
-        connector.search_messages("Gmail", "INBOX")
+        connector._search_messages_applescript("Gmail", "INBOX")
         script = mock_run.call_args[0][0]
         assert "whose true" not in script
         # With NO filters, the generated source must reference `mailboxRef`
@@ -605,7 +758,7 @@ class TestAppleMailConnector:
         by slicing the live message collection reference.
         """
         mock_run.return_value = "[]"
-        connector.search_messages("Gmail", "INBOX", limit=5)
+        connector._search_messages_applescript("Gmail", "INBOX", limit=5)
         script = mock_run.call_args[0][0]
         assert "items 1 thru" not in script
         assert "if (count of resultData) >= 5 then exit repeat" in script
@@ -615,11 +768,11 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         mock_run.return_value = "[]"
-        connector.search_messages("Gmail", "INBOX", is_flagged=True)
+        connector._search_messages_applescript("Gmail", "INBOX", is_flagged=True)
         script = mock_run.call_args[0][0]
         assert "flagged status is true" in script
 
-        connector.search_messages("Gmail", "INBOX", is_flagged=False)
+        connector._search_messages_applescript("Gmail", "INBOX", is_flagged=False)
         script = mock_run.call_args[0][0]
         assert "flagged status is false" in script
 
@@ -628,7 +781,7 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         mock_run.return_value = "[]"
-        connector.search_messages(
+        connector._search_messages_applescript(
             "Gmail", "INBOX", date_from="2026-04-01", date_to="2026-04-15"
         )
         script = mock_run.call_args[0][0]
@@ -645,7 +798,7 @@ class TestAppleMailConnector:
         Prevents AppleScript injection via unescaped date strings.
         """
         with pytest.raises(ValueError, match="date_from"):
-            connector.search_messages(
+            connector._search_messages_applescript(
                 "Gmail", "INBOX",
                 date_from='2024-01-01", delete mailbox',
             )
@@ -656,7 +809,7 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         with pytest.raises(ValueError, match="date_to"):
-            connector.search_messages("Gmail", "INBOX", date_to="not-a-date")
+            connector._search_messages_applescript("Gmail", "INBOX", date_to="not-a-date")
         mock_run.assert_not_called()
 
     @patch.object(AppleMailConnector, "_run_applescript")
@@ -667,7 +820,7 @@ class TestAppleMailConnector:
         mock_run.return_value = "[]"
         # Combine with a read_status filter so the whose clause exists and the
         # "count attachments not in whose" assertion is meaningful.
-        connector.search_messages(
+        connector._search_messages_applescript(
             "Gmail", "INBOX", read_status=True, has_attachment=True
         )
         script = mock_run.call_args[0][0]
@@ -687,7 +840,7 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         mock_run.return_value = "[]"
-        connector.search_messages("Gmail", "INBOX", has_attachment=False)
+        connector._search_messages_applescript("Gmail", "INBOX", has_attachment=False)
         script = mock_run.call_args[0][0]
         assert (
             "if (count of mail attachments of msg) > 0 then set includeThis to false"
@@ -700,7 +853,7 @@ class TestAppleMailConnector:
     ) -> None:
         """When has_attachment is None, no attachment post-filter code appears."""
         mock_run.return_value = "[]"
-        connector.search_messages("Gmail", "INBOX")
+        connector._search_messages_applescript("Gmail", "INBOX")
         script = mock_run.call_args[0][0]
         assert "mail attachments of msg" not in script
 
@@ -713,7 +866,7 @@ class TestAppleMailConnector:
             '[{"id":"1","subject":"s","sender":"a@b.c",'
             '"date_received":"Mon","read_status":false,"flagged":true}]'
         )
-        result = connector.search_messages("Gmail", "INBOX")
+        result = connector._search_messages_applescript("Gmail", "INBOX")
         assert result[0]["flagged"] is True
 
     @patch.object(AppleMailConnector, "_run_applescript")
@@ -726,7 +879,7 @@ class TestAppleMailConnector:
         gets stripped during NSDictionary conversion. Must be quoted as `|id|:`.
         """
         mock_run.return_value = "[]"
-        connector.search_messages("Gmail", "INBOX")
+        connector._search_messages_applescript("Gmail", "INBOX")
         script = mock_run.call_args[0][0]
         assert "|id|:(id of msg as text)" in script
         # The bare form must not appear in the msgRecord literal — it would collide.

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -294,6 +294,8 @@ class TestAppleMailConnector:
         assert "|host|:(server name of acctRef)" in script
         assert "|port|:(port of acctRef)" in script
         assert "|email|:(user name of acctRef)" in script
+        # Must assign to resultData for _wrap_as_json_script to serialize.
+        assert "set resultData to" in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_resolve_imap_config_escapes_account_name(

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -401,6 +401,98 @@ class TestAppleMailConnector:
         ]
         assert len(warning_records) == 1
 
+    # --- _imap_search helper ---------------------------------------------
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_imap_search_happy_path(
+        self,
+        mock_resolve: MagicMock,
+        mock_keychain: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_resolve.return_value = ("imap.mail.me.com", 993, "user@icloud.com")
+        mock_keychain.return_value = "app-password"
+        mock_imap = MagicMock()
+        mock_imap_cls.return_value = mock_imap
+        mock_imap.search_messages.return_value = [{"id": "1", "subject": "S"}]
+
+        result = connector._imap_search("iCloud", "INBOX", limit=5)
+
+        mock_resolve.assert_called_once_with("iCloud")
+        mock_keychain.assert_called_once_with("iCloud", "user@icloud.com")
+        mock_imap_cls.assert_called_once_with(
+            "imap.mail.me.com", 993, "user@icloud.com", "app-password"
+        )
+        # Parameters forwarded 1:1 to the IMAP connector (minus `account`).
+        mock_imap.search_messages.assert_called_once_with(
+            mailbox="INBOX",
+            sender_contains=None,
+            subject_contains=None,
+            read_status=None,
+            is_flagged=None,
+            date_from=None,
+            date_to=None,
+            has_attachment=None,
+            limit=5,
+        )
+        assert result == [{"id": "1", "subject": "S"}]
+
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_imap_search_keychain_missing_propagates(
+        self,
+        mock_resolve: MagicMock,
+        mock_keychain: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_resolve.return_value = ("imap.mail.me.com", 993, "user@icloud.com")
+        mock_keychain.side_effect = MailKeychainEntryNotFoundError("no entry")
+        with pytest.raises(MailKeychainEntryNotFoundError):
+            connector._imap_search("iCloud", "INBOX")
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_imap_search_login_error_propagates(
+        self,
+        mock_resolve: MagicMock,
+        mock_keychain: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        from imapclient.exceptions import LoginError
+
+        mock_resolve.return_value = ("imap.mail.me.com", 993, "user@icloud.com")
+        mock_keychain.return_value = "wrong-password"
+        mock_imap = MagicMock()
+        mock_imap_cls.return_value = mock_imap
+        mock_imap.search_messages.side_effect = LoginError("rejected")
+
+        with pytest.raises(LoginError):
+            connector._imap_search("iCloud", "INBOX")
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_imap_search_oserror_propagates(
+        self,
+        mock_resolve: MagicMock,
+        mock_keychain: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_resolve.return_value = ("imap.mail.me.com", 993, "user@icloud.com")
+        mock_keychain.return_value = "pw"
+        mock_imap = MagicMock()
+        mock_imap_cls.return_value = mock_imap
+        mock_imap.search_messages.side_effect = OSError("unreachable")
+
+        with pytest.raises(OSError, match="unreachable"):
+            connector._imap_search("iCloud", "INBOX")
+
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_basic(
         self, mock_run: MagicMock, connector: AppleMailConnector

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -257,6 +257,56 @@ class TestAppleMailConnector:
         script = mock_run.call_args[0][0]
         assert "|name|:(name of mb)" in script
 
+    # --- _resolve_imap_config --------------------------------------------
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_returns_tuple(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = (
+            '{"host":"imap.mail.me.com",'
+            '"port":993,'
+            '"email":"s_morgan_jeffries@yahoo.com"}'
+        )
+        result = connector._resolve_imap_config("iCloud")
+        assert result == ("imap.mail.me.com", 993, "s_morgan_jeffries@yahoo.com")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_propagates_account_not_found(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.side_effect = MailAccountNotFoundError(
+            "Can't get account \"NoSuch\"."
+        )
+        with pytest.raises(MailAccountNotFoundError):
+            connector._resolve_imap_config("NoSuch")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_script_has_quoted_keys(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """NSJSONSerialization requires |key| form for record keys."""
+        mock_run.return_value = (
+            '{"host":"h","port":993,"email":"e@e.com"}'
+        )
+        connector._resolve_imap_config("iCloud")
+        script = mock_run.call_args[0][0]
+        assert "|host|:(server name of acctRef)" in script
+        assert "|port|:(port of acctRef)" in script
+        assert "|email|:(user name of acctRef)" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_escapes_account_name(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = (
+            '{"host":"h","port":993,"email":"e@e.com"}'
+        )
+        connector._resolve_imap_config('Weird "Name" Acct')
+        script = mock_run.call_args[0][0]
+        # The quote must be escaped; raw quotes would break the script.
+        assert 'Weird \\"Name\\" Acct' in script
+
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_basic(
         self, mock_run: MagicMock, connector: AppleMailConnector


### PR DESCRIPTION
## Summary

- Wires `search_messages` to try IMAP first (via #41's `ImapConnector`) and fall back to AppleScript on any graceful-degradation failure. No other tools touched; `server.py` untouched.
- Adds a `_resolve_imap_config` factory that queries Mail.app for `(host, port, email)` per account. Prefers `email_addresses[0]` over `user_name` so iCloud (where Apple ID ≠ IMAP LOGIN username) works correctly.
- Adds per-account failure tracking (`_imap_failures` set) + `_log_imap_fallback` helper implementing invariant 5 (WARNING on first failure, DEBUG thereafter; missing Keychain entry is silent DEBUG only).

## Design decisions locked in (three brainstorming Q&A)

1. **Scope:** delegation only. Benchmark is #32.
2. **Factory placement:** private method on `AppleMailConnector`, using existing `_run_applescript` infra.
3. **Integration tests:** one positive (real iCloud via IMAP) + one negative (unroutable host → real fallback).

## Field finding on iCloud auth

During implementation the positive integration test surfaced that **iCloud IMAP rejects the Apple ID as LOGIN username** when the Apple ID is not an `@icloud.com` / `@me.com` address. Mail.app's `user name` property returns the Apple ID, but iCloud IMAP only accepts the aliases in `email addresses`. The factory now uses `email_addresses[0]` (falling back to `user_name` only if the list is empty), which:

- Fixes iCloud auth.
- Matches Gmail/Yahoo/generic IMAP (where `email_addresses[0] == user_name`).
- Means the original alias-keyed Keychain entry from #70 works unchanged.

Captured in commit `00f60fd` with the test output excerpt from the failed login.

## Test coverage

- **Unit tests:** 22 new across the factory, failure-tracking helper, IMAP-search helper, and the delegation wrapper. Covers: happy paths, all 5 fallback exception classes, WARNING-vs-DEBUG logging rules, the "do not catch" set (`ValueError`, `MailAccountNotFoundError`). Total now: **375 passing**.
- **Integration tests:** `tests/integration/test_imap_delegation.py` — 2 tests passing against real iCloud (~9.4s).
  - Positive: Keychain entry present → IMAP path succeeds silently.
  - Negative: `_resolve_imap_config` monkey-patched to return `10.255.255.1:993`, `get_imap_password` stubbed → real IMAPClient connect fails → fallback runs → WARNING fires.

## Fallback exception tuple

```python
_IMAP_FALLBACK_EXCS = (
    MailKeychainEntryNotFoundError,   # silent — user not opted in
    MailKeychainAccessDeniedError,    # WARNING — misconfiguration
    OSError,                          # includes socket.timeout
    LoginError,                       # creds rejected
    IMAPClientError,                  # protocol/session error
)
```

`ValueError` (bad date string) and `MailAccountNotFoundError` are **deliberately excluded** — those indicate caller/config errors that must surface.

## Test plan

- [x] `make lint` — passes.
- [x] `make typecheck` — passes (mypy strict).
- [x] `make test` — 375 passed.
- [x] `make check-all` — all 6 checks green (lint, typecheck, tests, complexity, version-sync, client-server parity).
- [x] `MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=iCloud uv run pytest tests/integration/test_imap_delegation.py -v` — both pass against real iCloud.
- [ ] Reviewer confirms `src/apple_mail_mcp/server.py` diff is empty (`git diff main -- src/apple_mail_mcp/server.py`).
- [ ] Reviewer reads the graceful-degradation invariants in `docs/research/imap-auth-options-decision.md#graceful-degradation-invariants` and confirms the implementation matches.

## Post-merge actions (user-gated)

After this PR merges, I'll — pending your go-ahead:

1. Close #40 with a comment noting delegation is live.
2. Remove `blocked` label from #66 (IMAP threading). Its blocker was #41; #41 is done; #40 demonstrates the delegation pattern #66 will follow.
3. Leave #72 (`get_message` delegation) and #73 (`get_attachments` delegation) labeled `blocked` — retag comments to reference the pattern rather than #40 specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)