### PR TITLE
IMAP-based thread reconstruction in get_thread (#66)

### DIFF
--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -12,13 +12,17 @@ See ``docs/plans/2026-04-23-imap-connector-design.md``.
 
 from __future__ import annotations
 
+import logging
 import re
 from datetime import date as _date
 from datetime import timedelta as _timedelta
 from typing import Any
 
 from imapclient import IMAPClient
+from imapclient.exceptions import IMAPClientError
 from imapclient.response_types import Envelope
+
+logger = logging.getLogger(__name__)
 
 # Strict ISO 8601 YYYY-MM-DD. Duplicated from mail_connector to break an
 # otherwise-circular import: mail_connector.search_messages delegates to
@@ -261,5 +265,107 @@ class ImapConnector:
                     _envelope_to_dict(entry[b"ENVELOPE"], tuple(entry[b"FLAGS"]))
                 )
             return results
+        finally:
+            client.logout()
+
+    def find_thread_members(
+        self,
+        anchor_rfc_message_id: str,
+        anchor_references: list[str],
+    ) -> list[dict[str, Any]]:
+        """Return all messages in the anchor's thread across the account.
+
+        Iterates every mailbox on the server. For each mailbox, searches
+        for any message whose Message-ID, In-Reply-To, or References
+        header matches any of the known thread IDs (the anchor plus its
+        known ancestors from the anchor's References header). Collects
+        matches, dedupes by Message-ID, sorts chronologically.
+
+        A single pass suffices because well-formed replies copy the entire
+        References chain of their parent — so searching on the anchor's
+        Message-ID against the References header captures all descendants
+        regardless of tree depth.
+
+        Args:
+            anchor_rfc_message_id: RFC 5322 Message-ID of the thread anchor,
+                bracketless (as returned by _strip_brackets).
+            anchor_references: List of Message-IDs from the anchor's
+                References header, bracketless, order preserved.
+
+        Returns:
+            List of message dicts in the same shape as search_messages
+            (``id``, ``subject``, ``sender``, ``date_received``,
+            ``read_status``, ``flagged``), deduped by Message-ID, sorted
+            chronologically ascending.
+        """
+        known_ids: set[str] = {anchor_rfc_message_id} | set(anchor_references)
+
+        client = IMAPClient(
+            self._host, port=self._port, ssl=True, timeout=self._connect_timeout
+        )
+        try:
+            client.login(self._email, self._password)
+            mailboxes = client.list_folders()
+            collected: dict[str, dict[str, Any]] = {}
+
+            for entry in mailboxes:
+                # list_folders yields (flags, delimiter, name) tuples.
+                mailbox_name = entry[2] if len(entry) >= 3 else entry[-1]
+                if isinstance(mailbox_name, bytes):
+                    mailbox_name = mailbox_name.decode("utf-8", errors="replace")
+
+                try:
+                    client.select_folder(mailbox_name, readonly=True)
+                except IMAPClientError as exc:
+                    # Some mailboxes (e.g. Gmail smart labels) reject SELECT.
+                    # Matches the AppleScript path's precedent of skipping
+                    # them silently.
+                    logger.debug(
+                        "find_thread_members: skipping mailbox %s: %s",
+                        mailbox_name, exc,
+                    )
+                    continue
+
+                # Search for each known id across three header types. IMAP
+                # returns UIDs whose specified header contains the given
+                # substring; each search is server-side and indexed.
+                uids_found: set[int] = set()
+                for id_ in known_ids:
+                    id_quoted = f"<{id_}>"
+                    for header in ("Message-ID", "In-Reply-To", "References"):
+                        try:
+                            uids = client.search(["HEADER", header, id_quoted])
+                        except IMAPClientError as exc:
+                            logger.debug(
+                                "find_thread_members: search failed in %s for "
+                                "%s=%s: %s",
+                                mailbox_name, header, id_quoted, exc,
+                            )
+                            continue
+                        uids_found.update(uids)
+
+                if not uids_found:
+                    continue
+
+                fetched = client.fetch(
+                    list(uids_found), [b"ENVELOPE", b"FLAGS"]
+                )
+                for fetch_entry in fetched.values():
+                    envelope = fetch_entry.get(b"ENVELOPE")
+                    if envelope is None:
+                        continue
+                    raw_msgid = getattr(envelope, "message_id", None)
+                    if not raw_msgid:
+                        continue
+                    clean_msgid = _strip_brackets(_decode(raw_msgid))
+                    if clean_msgid in collected:
+                        continue
+                    flags = tuple(fetch_entry.get(b"FLAGS", ()) or ())
+                    collected[clean_msgid] = _envelope_to_dict(envelope, flags)
+
+            return sorted(
+                collected.values(),
+                key=lambda m: m.get("date_received") or "",
+            )
         finally:
             client.logout()

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -865,6 +865,33 @@ class AppleMailConnector:
         """
         return self._get_thread_applescript(message_id)
 
+    def _imap_get_thread(
+        self, anchor: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """IMAP path for get_thread.
+
+        Takes the anchor dict produced by _resolve_thread_anchor_applescript
+        and delegates thread-member collection to ImapConnector. Propagates
+        all fallback-triggering exceptions unchanged — the caller
+        (get_thread) is responsible for catching and falling back.
+
+        Raises:
+            MailKeychainEntryNotFoundError: No opt-in (benign).
+            MailKeychainAccessDeniedError: Keychain ACL refused.
+            OSError (incl. socket.timeout): Network / connection failure.
+            imapclient.exceptions.LoginError: Credentials rejected.
+            imapclient.exceptions.IMAPClientError: Protocol or session error.
+            MailAccountNotFoundError: Mail.app doesn't know this account.
+        """
+        account = cast(str, anchor["account"])
+        host, port, email = self._resolve_imap_config(account)
+        password = get_imap_password(account, email)
+        imap = ImapConnector(host, port, email, password)
+        return imap.find_thread_members(
+            anchor_rfc_message_id=cast(str, anchor["rfc_message_id"]),
+            anchor_references=cast(list[str], anchor.get("references") or []),
+        )
+
     def _get_thread_applescript(self, message_id: str) -> list[dict[str, Any]]:
         """AppleScript path for get_thread (the universal baseline).
 

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -845,6 +845,13 @@ class AppleMailConnector:
     def get_thread(self, message_id: str) -> list[dict[str, Any]]:
         """Return all messages in the thread containing ``message_id``.
 
+        Tries the IMAP path first (server-side header search, no subject-
+        prefilter dependency). Falls back to AppleScript on any IMAP
+        failure per the graceful-degradation invariants in
+        docs/research/imap-auth-options-decision.md — so a user with no
+        Keychain entry, a revoked password, or a dropped network still
+        gets working threading via AppleScript.
+
         Args:
             message_id: Internal Mail.app id of any message in the thread
                 (the anchor). Typically obtained from search_messages or
@@ -858,12 +865,14 @@ class AppleMailConnector:
 
         Raises:
             MailMessageNotFoundError: If no message with the given id exists.
-
-        Will grow IMAP delegation in a subsequent commit of #66; for now
-        this is a passthrough to the AppleScript implementation so the
-        MCP tool surface keeps working during the refactor.
         """
-        return self._get_thread_applescript(message_id)
+        anchor = self._resolve_thread_anchor_applescript(message_id)
+        try:
+            return self._imap_get_thread(anchor)
+        except _IMAP_FALLBACK_EXCS as exc:
+            self._log_imap_fallback(cast(str, anchor["account"]), exc)
+            # fall through to AppleScript
+        return self._collect_thread_applescript(anchor)
 
     def _imap_get_thread(
         self, anchor: dict[str, Any],

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -845,12 +845,6 @@ class AppleMailConnector:
     def get_thread(self, message_id: str) -> list[dict[str, Any]]:
         """Return all messages in the thread containing ``message_id``.
 
-        Uses Mail.app's indexed ``whose subject contains "..."`` filter as a
-        pre-filter, then reconstructs the thread by walking RFC 5322
-        Message-ID / In-Reply-To / References headers across the candidate
-        set. Members whose subject was rewritten mid-thread are not found
-        (documented limitation).
-
         Args:
             message_id: Internal Mail.app id of any message in the thread
                 (the anchor). Typically obtained from search_messages or
@@ -864,16 +858,52 @@ class AppleMailConnector:
 
         Raises:
             MailMessageNotFoundError: If no message with the given id exists.
+
+        Will grow IMAP delegation in a subsequent commit of #66; for now
+        this is a passthrough to the AppleScript implementation so the
+        MCP tool surface keeps working during the refactor.
         """
-        from .utils import (
-            normalize_subject,
-            parse_rfc822_ids,
-            walk_thread_graph,
-        )
+        return self._get_thread_applescript(message_id)
+
+    def _get_thread_applescript(self, message_id: str) -> list[dict[str, Any]]:
+        """AppleScript path for get_thread (the universal baseline).
+
+        Composes _resolve_thread_anchor_applescript (call 1) and
+        _collect_thread_applescript (call 2 + Python graph walk). Called
+        directly when IMAP is not configured for the account, or as a
+        fallback when the IMAP path fails for any reason.
+
+        Uses Mail.app's indexed ``whose subject contains "..."`` filter as
+        a pre-filter, then reconstructs the thread by walking RFC 5322
+        Message-ID / In-Reply-To / References headers across the candidate
+        set. Members whose subject was rewritten mid-thread are not found
+        (documented limitation of this path; fixed by the IMAP path).
+        """
+        anchor = self._resolve_thread_anchor_applescript(message_id)
+        return self._collect_thread_applescript(anchor)
+
+    def _resolve_thread_anchor_applescript(
+        self, message_id: str,
+    ) -> dict[str, Any]:
+        """AppleScript call 1: resolve Mail.app internal ID to thread anchor.
+
+        Returns a dict with keys:
+            internal_id: str — the Mail.app internal id the caller passed in
+                (echoed back so downstream code can use it without threading
+                it separately).
+            account: str — Mail.app account name the message lives in.
+            rfc_message_id: str — RFC 5322 Message-ID (no angle brackets).
+            subject: str — message subject.
+            in_reply_to: str | None — parent's Message-ID if present.
+            references: list[str] — parsed References header (bracketless,
+                order preserved, duplicates removed).
+
+        Raises:
+            MailMessageNotFoundError: If no message with the given id exists.
+        """
+        from .utils import parse_rfc822_ids
 
         message_id_safe = escape_applescript_string(sanitize_input(message_id))
-
-        # ---- Call 1: resolve anchor ----
         anchor_body = f'''
         tell application "Mail"
             set anchorResult to missing value
@@ -906,12 +936,33 @@ class AppleMailConnector:
 
         anchor_script = _wrap_as_json_script(anchor_body)
         anchor_raw = self._run_applescript(anchor_script)
-        anchor = cast(dict[str, Any], parse_applescript_json(anchor_raw))
+        raw = cast(dict[str, Any], parse_applescript_json(anchor_raw))
 
-        # ---- Call 2: collect subject-prefiltered candidates across the
-        # anchor's account (all mailboxes) with their threading headers ----
-        account_name = anchor["account"]
-        base_subject = normalize_subject(anchor["subject"])
+        in_reply_to_raw = raw.get("in_reply_to") or ""
+        references_raw = raw.get("references_raw") or ""
+        return {
+            "internal_id": message_id,
+            "account": cast(str, raw["account"]),
+            "rfc_message_id": cast(str, raw["rfc_message_id"]),
+            "subject": cast(str, raw["subject"]),
+            "in_reply_to": in_reply_to_raw or None,
+            "references": parse_rfc822_ids(references_raw),
+        }
+
+    def _collect_thread_applescript(
+        self, anchor: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """AppleScript call 2 + Python graph walk.
+
+        Takes the anchor dict produced by _resolve_thread_anchor_applescript,
+        fetches subject-prefiltered candidates across all mailboxes of the
+        anchor's account, and walks the reference graph to assemble the
+        thread. Returns the final sorted search-shape list.
+        """
+        from .utils import normalize_subject, parse_rfc822_ids, walk_thread_graph
+
+        account_name = cast(str, anchor["account"])
+        base_subject = normalize_subject(cast(str, anchor["subject"]))
         account_safe = escape_applescript_string(sanitize_input(account_name))
         subject_safe = escape_applescript_string(sanitize_input(base_subject))
 
@@ -956,11 +1007,12 @@ class AppleMailConnector:
             )
 
         # Seed the known-id frontier: anchor + its own references.
-        anchor_rfc = anchor["rfc_message_id"]
+        anchor_rfc = cast(str, anchor["rfc_message_id"])
         known_ids: set[str] = {anchor_rfc}
-        if anchor["in_reply_to"]:
-            known_ids.add(anchor["in_reply_to"])
-        known_ids.update(parse_rfc822_ids(anchor["references_raw"]))
+        in_reply_to = cast("str | None", anchor.get("in_reply_to"))
+        if in_reply_to:
+            known_ids.add(in_reply_to)
+        known_ids.update(cast(list[str], anchor.get("references") or []))
 
         # Separate the anchor's own candidate row (when present) from the
         # rest. The graph walk operates on the non-anchor candidates; the
@@ -990,7 +1042,7 @@ class AppleMailConnector:
                 anchor_rfc,
             )
             thread.append({
-                "id": message_id,
+                "id": cast(str, anchor.get("internal_id") or ""),
                 "subject": anchor["subject"],
                 "sender": "",
                 "date_received": "",

--- a/tests/integration/test_imap_delegation.py
+++ b/tests/integration/test_imap_delegation.py
@@ -140,3 +140,98 @@ class TestIMAPDelegation:
         )
         msg = warnings[0].getMessage()
         assert ICLOUD_ACCOUNT_NAME in msg
+
+    def test_get_thread_uses_imap_when_keychain_entry_present(
+        self,
+        connector: AppleMailConnector,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Positive path: real iCloud, IMAP path resolves a thread.
+
+        Discovers a real message ID at runtime (via Mail.app — iCloud's
+        INBOX is empty for this user, so we look in Sent Messages where
+        we know there are some). Skips if no messages anywhere.
+        """
+        host, port, email = connector._resolve_imap_config(ICLOUD_ACCOUNT_NAME)
+        if not _keychain_entry_exists(ICLOUD_ACCOUNT_NAME, email):
+            pytest.skip(
+                f"No Keychain entry under "
+                f"apple-mail-mcp.imap.{ICLOUD_ACCOUNT_NAME} for {email}."
+            )
+
+        # Find any iCloud message to use as anchor.
+        anchor_finder = subprocess.run(
+            [
+                "/usr/bin/osascript", "-e",
+                'tell application "Mail" to return id of '
+                '(first message of mailbox "Sent Messages" of account "iCloud")',
+            ],
+            capture_output=True, text=True, check=False,
+        )
+        if anchor_finder.returncode != 0:
+            pytest.skip(
+                f"No anchor message available in iCloud Sent Messages: "
+                f"{anchor_finder.stderr.strip()}"
+            )
+        anchor_id = anchor_finder.stdout.strip()
+        assert anchor_id, "Anchor finder returned empty stdout"
+
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp"):
+            result = connector.get_thread(message_id=anchor_id)
+
+        assert isinstance(result, list)
+        # IMAP path must have succeeded silently — no fallback WARNING for
+        # this account.
+        assert ICLOUD_ACCOUNT_NAME not in connector._imap_failures
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings == [], (
+            f"Expected IMAP path to succeed silently, but got warnings: "
+            f"{[r.getMessage() for r in warnings]}"
+        )
+
+    def test_get_thread_falls_back_when_imap_host_unroutable(
+        self,
+        connector: AppleMailConnector,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Negative path for get_thread: IMAP fails, AppleScript path runs.
+
+        Same monkey-patch trick as the search_messages negative test —
+        force the IMAP connect to fail by pointing at an unroutable host,
+        and stub the Keychain lookup so we don't short-circuit on the
+        benign not-found path.
+        """
+        # Find an anchor first (anchor resolution stays AppleScript).
+        anchor_finder = subprocess.run(
+            [
+                "/usr/bin/osascript", "-e",
+                'tell application "Mail" to return id of '
+                '(first message of mailbox "Sent Messages" of account "iCloud")',
+            ],
+            capture_output=True, text=True, check=False,
+        )
+        if anchor_finder.returncode != 0:
+            pytest.skip(f"No anchor message available: {anchor_finder.stderr.strip()}")
+        anchor_id = anchor_finder.stdout.strip()
+
+        def fake_config(_account: str) -> tuple[str, int, str]:
+            return ("10.255.255.1", 993, "fake@example.com")
+
+        monkeypatch.setattr(connector, "_resolve_imap_config", fake_config)
+        monkeypatch.setattr(
+            "apple_mail_mcp.mail_connector.get_imap_password",
+            lambda _account, _email: "fake-password",
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp"):
+            result = connector.get_thread(message_id=anchor_id)
+
+        # AppleScript fallback ran and returned the thread (at least the
+        # anchor itself).
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        assert ICLOUD_ACCOUNT_NAME in connector._imap_failures
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert ICLOUD_ACCOUNT_NAME in warnings[0].getMessage()

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -498,3 +498,174 @@ class TestEnvelopeTranslation:
         }
         [msg] = ImapConnector("h", 993, "u@e.com", "pw").search_messages()
         assert msg["subject"] == "héllo ✓"
+
+
+class TestFindThreadMembers:
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_returns_empty_when_no_search_hits(self, mock_cls):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.list_folders.return_value = [((b"\\HasNoChildren",), b"/", "INBOX")]
+        mock_client.search.return_value = []
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@x",
+            anchor_references=[],
+        )
+        assert result == []
+        mock_client.logout.assert_called_once()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_returns_anchor_and_reply_sorted_chronologically(self, mock_cls):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.list_folders.return_value = [((b"\\HasNoChildren",), b"/", "INBOX")]
+        # Every search returns the same UIDs — dedup by Message-ID in fetch.
+        mock_client.search.return_value = [1, 2]
+        mock_client.fetch.return_value = {
+            1: {
+                b"ENVELOPE": _fake_envelope(
+                    message_id=b"<anchor@x>",
+                    subject=b"Original",
+                    date=datetime(2026, 4, 20, 10, 0, 0),
+                ),
+                b"FLAGS": (),
+            },
+            2: {
+                b"ENVELOPE": _fake_envelope(
+                    message_id=b"<reply@x>",
+                    subject=b"Re: Original",
+                    date=datetime(2026, 4, 21, 10, 0, 0),
+                ),
+                b"FLAGS": (),
+            },
+        }
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@x",
+            anchor_references=[],
+        )
+
+        assert len(result) == 2
+        assert [m["id"] for m in result] == ["anchor@x", "reply@x"]
+        # Chronological sort
+        assert result[0]["date_received"] < result[1]["date_received"]
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_iterates_all_mailboxes_in_account(self, mock_cls):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.list_folders.return_value = [
+            ((), b"/", "INBOX"),
+            ((), b"/", "Archive"),
+            ((), b"/", "Sent"),
+        ]
+        mock_client.search.return_value = []
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="a@x",
+            anchor_references=[],
+        )
+
+        selected_folders = [
+            call.args[0] for call in mock_client.select_folder.call_args_list
+        ]
+        assert selected_folders == ["INBOX", "Archive", "Sent"]
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_dedups_messages_found_in_multiple_mailboxes(self, mock_cls):
+        """A Gmail-like account may surface the same message in INBOX and
+        All Mail. Output must not duplicate it."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.list_folders.return_value = [
+            ((), b"/", "INBOX"),
+            ((), b"/", "All Mail"),
+        ]
+        mock_client.search.return_value = [1]
+        mock_client.fetch.return_value = {
+            1: {
+                b"ENVELOPE": _fake_envelope(
+                    message_id=b"<anchor@x>", subject=b"Original"
+                ),
+                b"FLAGS": (),
+            }
+        }
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@x",
+            anchor_references=[],
+        )
+        assert len(result) == 1
+        assert result[0]["id"] == "anchor@x"
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_skips_mailbox_that_fails_to_select(self, mock_cls):
+        from imapclient.exceptions import IMAPClientError
+
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.list_folders.return_value = [
+            ((), b"/", "INBOX"),
+            ((), b"/", "[Gmail]/Smart Label"),
+        ]
+
+        def select_side_effect(name, readonly=False):
+            if "Smart Label" in name:
+                raise IMAPClientError("cannot select this mailbox")
+
+        mock_client.select_folder.side_effect = select_side_effect
+        mock_client.search.return_value = [1]
+        mock_client.fetch.return_value = {
+            1: {
+                b"ENVELOPE": _fake_envelope(message_id=b"<anchor@x>"),
+                b"FLAGS": (),
+            }
+        }
+
+        # No exception — Smart Label skipped, INBOX still processed.
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@x",
+            anchor_references=[],
+        )
+        assert len(result) == 1
+        mock_client.logout.assert_called_once()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_searches_for_each_known_id(self, mock_cls):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.list_folders.return_value = [((), b"/", "INBOX")]
+        mock_client.search.return_value = []
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@x",
+            anchor_references=["parent@x", "grandparent@x"],
+        )
+
+        # Collect all search criteria across all calls.
+        searched_ids: set[str] = set()
+        for call in mock_client.search.call_args_list:
+            crit = call.args[0]
+            # Last element is the header value, e.g. "<anchor@x>"
+            val = crit[-1]
+            if isinstance(val, str) and val.startswith("<") and val.endswith(">"):
+                searched_ids.add(val.strip("<>"))
+
+        assert "anchor@x" in searched_ids
+        assert "parent@x" in searched_ids
+        assert "grandparent@x" in searched_ids
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_logout_called_on_exception(self, mock_cls):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.list_folders.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+                anchor_rfc_message_id="a@x",
+                anchor_references=[],
+            )
+
+        mock_client.logout.assert_called_once()

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -606,6 +606,135 @@ class TestAppleMailConnector:
         with pytest.raises(LoginError):
             connector._imap_get_thread(anchor)
 
+    # --- get_thread delegation -------------------------------------------
+
+    @patch.object(AppleMailConnector, "_collect_thread_applescript")
+    @patch.object(AppleMailConnector, "_imap_get_thread")
+    @patch.object(AppleMailConnector, "_resolve_thread_anchor_applescript")
+    def test_get_thread_uses_imap_on_success(
+        self,
+        mock_anchor: MagicMock,
+        mock_imap: MagicMock,
+        mock_collect: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_anchor.return_value = {
+            "internal_id": "500",
+            "account": "iCloud",
+            "rfc_message_id": "anchor@x",
+            "subject": "S",
+            "in_reply_to": None,
+            "references": [],
+        }
+        mock_imap.return_value = [{"id": "anchor@x", "subject": "from imap"}]
+        result = connector.get_thread("500")
+        assert result == [{"id": "anchor@x", "subject": "from imap"}]
+        mock_collect.assert_not_called()
+
+    @patch.object(AppleMailConnector, "_collect_thread_applescript")
+    @patch.object(AppleMailConnector, "_imap_get_thread")
+    @patch.object(AppleMailConnector, "_resolve_thread_anchor_applescript")
+    def test_get_thread_falls_back_on_keychain_missing(
+        self,
+        mock_anchor: MagicMock,
+        mock_imap: MagicMock,
+        mock_collect: MagicMock,
+        connector: AppleMailConnector,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_anchor.return_value = {
+            "internal_id": "500",
+            "account": "iCloud",
+            "rfc_message_id": "anchor@x",
+            "subject": "S",
+            "in_reply_to": None,
+            "references": [],
+        }
+        mock_imap.side_effect = MailKeychainEntryNotFoundError("no entry")
+        mock_collect.return_value = [{"id": "500", "subject": "from applescript"}]
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp.mail_connector"):
+            result = connector.get_thread("500")
+        assert result == [{"id": "500", "subject": "from applescript"}]
+        mock_collect.assert_called_once()
+        # Missing-entry = silent (no WARNING).
+        warning_records = [
+            r for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert warning_records == []
+        assert "iCloud" not in connector._imap_failures
+
+    @patch.object(AppleMailConnector, "_collect_thread_applescript")
+    @patch.object(AppleMailConnector, "_imap_get_thread")
+    @patch.object(AppleMailConnector, "_resolve_thread_anchor_applescript")
+    def test_get_thread_falls_back_on_oserror_with_warning(
+        self,
+        mock_anchor: MagicMock,
+        mock_imap: MagicMock,
+        mock_collect: MagicMock,
+        connector: AppleMailConnector,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_anchor.return_value = {
+            "internal_id": "500",
+            "account": "iCloud",
+            "rfc_message_id": "anchor@x",
+            "subject": "S",
+            "in_reply_to": None,
+            "references": [],
+        }
+        mock_imap.side_effect = OSError("unreachable")
+        mock_collect.return_value = [{"id": "500"}]
+        with caplog.at_level(logging.DEBUG, logger="apple_mail_mcp.mail_connector"):
+            result = connector.get_thread("500")
+        assert result == [{"id": "500"}]
+        mock_collect.assert_called_once()
+        warning_records = [
+            r for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert len(warning_records) == 1
+        assert "iCloud" in connector._imap_failures
+
+    @patch.object(AppleMailConnector, "_collect_thread_applescript")
+    @patch.object(AppleMailConnector, "_imap_get_thread")
+    @patch.object(AppleMailConnector, "_resolve_thread_anchor_applescript")
+    def test_get_thread_falls_back_on_login_error(
+        self,
+        mock_anchor: MagicMock,
+        mock_imap: MagicMock,
+        mock_collect: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        from imapclient.exceptions import LoginError
+
+        mock_anchor.return_value = {
+            "internal_id": "500", "account": "iCloud",
+            "rfc_message_id": "anchor@x", "subject": "S",
+            "in_reply_to": None, "references": [],
+        }
+        mock_imap.side_effect = LoginError("rejected")
+        mock_collect.return_value = [{"id": "500"}]
+        result = connector.get_thread("500")
+        assert result == [{"id": "500"}]
+        mock_collect.assert_called_once()
+
+    @patch.object(AppleMailConnector, "_collect_thread_applescript")
+    @patch.object(AppleMailConnector, "_imap_get_thread")
+    @patch.object(AppleMailConnector, "_resolve_thread_anchor_applescript")
+    def test_get_thread_anchor_not_found_propagates(
+        self,
+        mock_anchor: MagicMock,
+        mock_imap: MagicMock,
+        mock_collect: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """MailMessageNotFoundError from anchor resolution must propagate,
+        not fall back — the message just doesn't exist anywhere."""
+        mock_anchor.side_effect = MailMessageNotFoundError("Can't get message")
+        with pytest.raises(MailMessageNotFoundError):
+            connector.get_thread("nonexistent")
+        mock_imap.assert_not_called()
+        mock_collect.assert_not_called()
+
     # --- search_messages delegation --------------------------------------
 
     @patch.object(AppleMailConnector, "_search_messages_applescript")
@@ -1121,7 +1250,7 @@ class TestAppleMailConnector:
             '"in_reply_to":"","references_raw":""}',
             "[]",
         ]
-        connector.get_thread("12345")
+        connector._get_thread_applescript("12345")
         anchor_script = mock_run.call_args_list[0][0][0]
         # All record keys must be |quoted| per the v0.4.1 selector-collision rule.
         assert "|rfc_message_id|:(message id of msg)" in anchor_script
@@ -1136,7 +1265,7 @@ class TestAppleMailConnector:
         """Anchor lookup failure propagates MailMessageNotFoundError."""
         mock_run.side_effect = MailMessageNotFoundError("Can't get message")
         with pytest.raises(MailMessageNotFoundError):
-            connector.get_thread("99999")
+            connector._get_thread_applescript("99999")
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_get_thread_returns_anchor_plus_replies_sorted(
@@ -1158,7 +1287,7 @@ class TestAppleMailConnector:
             '"date_received":"Wed Jan 3 2024","read_status":false,"flagged":false}'
             ']'
         ]
-        result = connector.get_thread("100")
+        result = connector._get_thread_applescript("100")
         assert len(result) == 3
         assert [m["id"] for m in result] == ["100", "101", "102"]
         # Response rows match search_messages shape (6 fields).
@@ -1179,7 +1308,7 @@ class TestAppleMailConnector:
             '"references_raw":"","subject":"Q3","sender":"a@x",'
             '"date_received":"Mon","read_status":false,"flagged":false}]'
         ]
-        result = connector.get_thread("100")
+        result = connector._get_thread_applescript("100")
         for m in result:
             assert "rfc_message_id" not in m
             assert "in_reply_to" not in m
@@ -1198,7 +1327,7 @@ class TestAppleMailConnector:
             '"references_raw":"","subject":"Standalone","sender":"a@x",'
             '"date_received":"Mon","read_status":false,"flagged":false}]'
         ]
-        result = connector.get_thread("500")
+        result = connector._get_thread_applescript("500")
         assert len(result) == 1
         assert result[0]["id"] == "500"
 
@@ -1212,7 +1341,7 @@ class TestAppleMailConnector:
             '"subject":"Re: Re: Q3 Report","in_reply_to":"","references_raw":""}',
             '[]',
         ]
-        connector.get_thread("1")
+        connector._get_thread_applescript("1")
         candidate_script = mock_run.call_args_list[1][0][0]
         assert 'account "Gmail"' in candidate_script
         # Base subject strips all Re: prefixes.

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -516,6 +516,96 @@ class TestAppleMailConnector:
         with pytest.raises(OSError, match="unreachable"):
             connector._imap_search("iCloud", "INBOX")
 
+    # --- _imap_get_thread helper -----------------------------------------
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_imap_get_thread_happy_path(
+        self,
+        mock_resolve: MagicMock,
+        mock_keychain: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_resolve.return_value = ("imap.mail.me.com", 993, "user@icloud.com")
+        mock_keychain.return_value = "app-password"
+        mock_imap = MagicMock()
+        mock_imap_cls.return_value = mock_imap
+        mock_imap.find_thread_members.return_value = [
+            {"id": "anchor@x", "subject": "S"},
+        ]
+
+        anchor = {
+            "internal_id": "500",
+            "account": "iCloud",
+            "rfc_message_id": "anchor@x",
+            "subject": "Hello",
+            "in_reply_to": None,
+            "references": ["parent@x"],
+        }
+        result = connector._imap_get_thread(anchor)
+
+        mock_resolve.assert_called_once_with("iCloud")
+        mock_keychain.assert_called_once_with("iCloud", "user@icloud.com")
+        mock_imap_cls.assert_called_once_with(
+            "imap.mail.me.com", 993, "user@icloud.com", "app-password"
+        )
+        mock_imap.find_thread_members.assert_called_once_with(
+            anchor_rfc_message_id="anchor@x",
+            anchor_references=["parent@x"],
+        )
+        assert result == [{"id": "anchor@x", "subject": "S"}]
+
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_imap_get_thread_keychain_missing_propagates(
+        self,
+        mock_resolve: MagicMock,
+        mock_keychain: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_resolve.return_value = ("imap.mail.me.com", 993, "user@icloud.com")
+        mock_keychain.side_effect = MailKeychainEntryNotFoundError("no entry")
+        anchor = {
+            "internal_id": "500",
+            "account": "iCloud",
+            "rfc_message_id": "anchor@x",
+            "subject": "Hello",
+            "in_reply_to": None,
+            "references": [],
+        }
+        with pytest.raises(MailKeychainEntryNotFoundError):
+            connector._imap_get_thread(anchor)
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_imap_get_thread_login_error_propagates(
+        self,
+        mock_resolve: MagicMock,
+        mock_keychain: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        from imapclient.exceptions import LoginError
+
+        mock_resolve.return_value = ("imap.mail.me.com", 993, "user@icloud.com")
+        mock_keychain.return_value = "pw"
+        mock_imap = MagicMock()
+        mock_imap_cls.return_value = mock_imap
+        mock_imap.find_thread_members.side_effect = LoginError("rejected")
+        anchor = {
+            "internal_id": "500",
+            "account": "iCloud",
+            "rfc_message_id": "anchor@x",
+            "subject": "Hello",
+            "in_reply_to": None,
+            "references": [],
+        }
+        with pytest.raises(LoginError):
+            connector._imap_get_thread(anchor)
+
     # --- search_messages delegation --------------------------------------
 
     @patch.object(AppleMailConnector, "_search_messages_applescript")


### PR DESCRIPTION
## Summary

- Wires \`get_thread\` to try IMAP first and fall back to AppleScript, completing the third IMAP delegation path (after \`search_messages\` in #40).
- Replaces the subject-prefilter dependency on the IMAP side — which fixes the known AppleScript limitation where thread members with rewritten subjects were missed.
- Adds \`ImapConnector.find_thread_members\` — header-search BFS across all mailboxes of the account, deduped, chronologically sorted.
- Files #80 as the follow-up research issue for server-side alternatives (RFC 5256 \`THREAD REFERENCES\` + Gmail \`X-GM-THRID\`).

## Design decisions locked in (two brainstorming Q&A)

1. **Threading approach:** IMAP header search across all mailboxes of the anchor's account. Server-side \`THREAD REFERENCES\` and Gmail \`X-GM-THRID\` are queued in #80.
2. **Mailbox scope:** all mailboxes of the anchor's account — preserves cross-mailbox coverage of the current AppleScript path.

## Key insight: one-pass search suffices

Well-formed replies copy the entire References chain from their parent. So searching \`HEADER References <anchor_id>\` on any mailbox returns **every descendant** regardless of tree depth. Combined with \`HEADER Message-ID <id>\` for each known ancestor id (from the anchor's References header) and \`HEADER In-Reply-To <id>\` for broken-References clients, one iteration captures the whole connected component of the reference graph — no BFS needed, no repeated rounds.

## Architecture changes

- **Refactor:** \`get_thread\` body split into \`_resolve_thread_anchor_applescript\` (call 1) + \`_collect_thread_applescript\` (call 2 + Python graph walk). A combined \`_get_thread_applescript\` preserves the old full-path flow for tests.
- **New:** \`ImapConnector.find_thread_members(anchor_rfc_message_id, anchor_references)\` — stateless, same per-call lifecycle as \`search_messages\`.
- **New:** \`AppleMailConnector._imap_get_thread(anchor)\` — same shape as \`_imap_search\` from #40.
- **Rewired:** public \`get_thread\` does anchor resolution once, then tries \`_imap_get_thread\`, catches \`_IMAP_FALLBACK_EXCS\` (unchanged from #40), logs via \`_log_imap_fallback\`, falls through to \`_collect_thread_applescript\`.

Anchor resolution stays AppleScript because the MCP tool surface accepts Mail.app's internal ID, which IMAP doesn't understand. Tool surface is unchanged.

## Test coverage

- **Unit tests:** 16 new across \`test_imap_connector.py\` (7 on \`find_thread_members\`) and \`test_mail_connector.py\` (3 on \`_imap_get_thread\`, 5 on \`get_thread\` delegation, 1 on anchor-not-found propagation). Covers BFS via one-pass search, per-mailbox iteration, cross-mailbox dedup, SELECT-failure skip, each fallback exception class, anchor-not-found propagation.
- **Integration tests:** 2 new against real iCloud using a runtime-discovered anchor from Sent Messages. Positive asserts IMAP path succeeds silently; negative monkey-patches unroutable host + stubbed Keychain and asserts AppleScript fallback + WARNING.
- **Pre-existing tests:** 6 AppleScript-path tests for \`get_thread\` updated to call \`_get_thread_applescript\` directly (same pattern as #40).

## Performance note

Integration-test runtime was ~3.5 min (positive get_thread alone took ~90s). Root cause: per-mailbox × per-known-id × 3 header types = many round-trips. The algorithm is correct but unoptimized. Optimization paths (OR-chain searches; RFC 5256 \`THREAD\` command) are tracked in #80.

## Test plan

- [x] \`make lint\` — passes.
- [x] \`make typecheck\` — passes (mypy strict).
- [x] \`make test\` — 390 passed.
- [x] \`make check-all\` — all 6 checks green.
- [x] \`MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=iCloud uv run pytest tests/integration/ -v\` — 5/5 pass (2 from #41, 2 from #40, 1 new + 1 new for this PR).
- [ ] Reviewer reads the new \`find_thread_members\` implementation in \`imap_connector.py\` and confirms the one-pass-search reasoning holds.
- [ ] Reviewer confirms \`src/apple_mail_mcp/server.py\` diff is empty.

## Post-merge actions (user-gated)

1. Close #66 with a comment linking to the PR and noting delegation is live.
2. Confirm #80 is on v0.6.0 with \`research\` + \`enhancement\` labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)