### PR TITLE
Tighten CONTRIBUTING.md + add SECURITY_CHECKLIST.md (#87)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,7 +37,7 @@ make coverage              # Coverage report
 - **Backend + frontend together** — Every feature touches `mail_connector.py` AND `server.py`. Verify with `check_client_server_parity.sh`.
 - **Sanitize everything twice** — All user input: `sanitize_input()` then `escape_applescript_string()` before AppleScript.
 - **Structured responses** — Every tool returns `{"success": bool, ...}`. Errors include `error` and `error_type`.
-- **Security checklist per feature** — Input validation, escaping, path traversal, rate limiting, audit logging.
+- **Security checklist per feature** — see [`docs/guides/SECURITY_CHECKLIST.md`](../docs/guides/SECURITY_CHECKLIST.md) for the canonical reference (5 concerns: input sanitization, AppleScript escaping, path-traversal-safe name validation, rate limiting, audit logging). Don't duplicate guidance here; link out instead.
 - **If you touched AppleScript, write integration tests** — Unit tests mock `_run_applescript()` and CANNOT catch AppleScript bugs.
 
 ## AppleScript Gotchas

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing to Apple Mail MCP
 
+## A note on early contributor PRs
+
+Between December 2025 and April 2026, several PRs from external contributors — including @ericboehs, @kemotaha, @tylew, and @jpgrosen — were closed without comment or merge. The honest explanation is that Claude Code, running on my behalf, was aggressively closing PRs without surfacing them for my review, and I didn't have a workflow that would catch them. That's a process failure I own. Several of those PRs correctly diagnosed bugs that were re-fixed independently on `main` weeks later than they could have been.
+
+To everyone whose work got that treatment: I'm sorry. The project is healthier because you flagged these issues, even when the credit didn't follow.
+
+The process changes shipping in this milestone (#87, #88, #90) — issue-first guidance below, an updated PR template, and a post-merge workflow that surfaces open contributor PRs — are aimed at making sure future PRs get a real evaluation: merged, redirected, or closed with clear reasoning. Never silently.
+
 ## Setup
 
 ```bash
@@ -11,6 +19,7 @@ uv sync --dev
 
 ## Development Workflow
 
+0. **Before you start coding,** open an issue (or comment on an existing one) describing what you plan to fix or build. This lets us flag duplicate or in-flight work and saves you from rebases or wasted effort.
 1. Create a branch: `git checkout -b feature/issue-N-description`
 2. Write tests first (TDD): RED -> GREEN -> REFACTOR
 3. Implement backend (`mail_connector.py`) and frontend (`server.py`) together
@@ -38,10 +47,12 @@ make test-integration  # Real Mail.app tests
 ## Pull Request Process
 
 1. All CI checks pass (`make check-all`)
-2. Tests cover new code (aim for 100% on new features)
-3. If you modified AppleScript, include integration tests
-4. Update `docs/reference/TOOLS.md` if you added/changed a tool
-5. PR description references the issue (`Closes #N`)
+2. Tests for new code:
+   - **New features:** unit tests covering the happy path and error branches.
+   - **Bug fixes:** include a regression test that fails before your fix and passes after.
+   - **AppleScript changes:** an integration test under `tests/integration/`.
+3. Update `docs/reference/TOOLS.md` if you added/changed a tool
+4. PR description references the issue (`Closes #N`)
 
 ## Coding Standards
 
@@ -49,7 +60,7 @@ make test-integration  # Real Mail.app tests
 - **Docstrings** on all public functions (Args, Returns, Raises)
 - **ruff** for linting and formatting (line length: 100)
 - **Structured responses**: `{"success": bool, "error": str, "error_type": str}`
-- **Security checklist** for every new feature (see `.claude/CLAUDE.md`)
+- **Security checklist** for every new feature (see [`docs/guides/SECURITY_CHECKLIST.md`](docs/guides/SECURITY_CHECKLIST.md))
 - **Cyclomatic complexity** ceiling of CC ≤ 20 per function (see [`docs/guides/COMPLEXITY.md`](docs/guides/COMPLEXITY.md))
 
 ## Testing Requirements

--- a/docs/guides/SECURITY_CHECKLIST.md
+++ b/docs/guides/SECURITY_CHECKLIST.md
@@ -1,0 +1,60 @@
+# Security Checklist
+
+Every new feature should be reviewed against the five concerns below before opening a PR. Each section names the canonical implementation in the codebase — reuse it rather than rolling your own. Linked file:line numbers are stable references; if a function moves, update this doc.
+
+## Input sanitization
+
+Any string that originates from an MCP tool argument, an environment variable, or any other external source must pass through [`sanitize_input`](../../src/apple_mail_mcp/utils.py#L156) before further processing. It strips null bytes, truncates oversized strings (currently 10000 chars), and coerces non-strings to strings.
+
+This protects against null-byte injection in shell or AppleScript contexts and bounds memory use for pathological inputs. It does **not** make a string safe for interpolation — see *AppleScript escaping* and *Path-traversal-safe name validation* below.
+
+## AppleScript escaping
+
+Any sanitized string that gets interpolated into AppleScript source must additionally pass through [`escape_applescript_string`](../../src/apple_mail_mcp/utils.py#L44), which escapes backslashes and quotes. The combined idiom is:
+
+```python
+safe = escape_applescript_string(sanitize_input(user_value))
+```
+
+A common mistake is escaping but forgetting the literal AppleScript string quotes around the interpolation site — `whose id is {safe}` parses dashes as subtraction operators on UUID-style ids and crashes. Always wrap in quotes: `whose id is "{safe}"`. See [#86](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/86) for the bug this prevented.
+
+For lists of values (e.g. message-id lists), each element must be individually sanitized + escaped + quoted, then joined:
+
+```python
+id_list = ", ".join(
+    f'"{escape_applescript_string(sanitize_input(mid))}"'
+    for mid in message_ids
+)
+```
+
+## Path-traversal-safe name validation
+
+Any user-supplied string used as a filename stem must pass a strict regex *before* being handed to `Path()`. The canonical example is [`_validate_name`](../../src/apple_mail_mcp/templates.py#L180) in the templates module:
+
+```python
+_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+```
+
+This rejects `..`, slashes, dots, spaces, control characters, and oversized lengths — anything that could let a name escape its intended directory. Validate before any filesystem work; never `Path(user_input)` first and check existence after.
+
+## Rate limiting
+
+Every MCP tool wrapper in [`server.py`](../../src/apple_mail_mcp/server.py) must call [`check_rate_limit`](../../src/apple_mail_mcp/security.py#L180) as its first action and return immediately if the call is rate-limited. The tool name must be registered in [`OPERATION_TIERS`](../../src/apple_mail_mcp/security.py#L122) under one of three tiers:
+
+| Tier | Cap | Use for |
+|------|-----|---------|
+| `cheap_reads` | 60 / 60s | List/get/render operations; local file I/O |
+| `expensive_ops` | 20 / 60s | Search, mutations on Mail.app state, multi-mailbox scans |
+| `sends` | 3 / 60s | Anything that delivers email externally |
+
+There's a unit test in [`test_security.py`](../../tests/unit/test_security.py) (`test_all_operations_have_tier_assigned`) that fails if a registered MCP tool isn't in `OPERATION_TIERS` — adding a new tool without picking a tier breaks the build, by design.
+
+## Audit logging
+
+Every server-side tool wrapper must call [`operation_logger.log_operation`](../../src/apple_mail_mcp/security.py#L25) on its success path with the operation name, the params it received, and a status string. Failure paths log via the per-`error_type` return shape; the audit log captures the successful actions.
+
+This produces a per-process record of what the server actually did — useful for debugging, for confirming that destructive operations were preceded by elicitation, and for users who want to inspect what an LLM caused to happen on their behalf.
+
+## When in doubt
+
+Search for an existing tool wrapper that does something analogous to what you're building (e.g. another mutation tool, another file-I/O tool) and copy its gate sequence. The five concerns above are addressed in roughly the same order in every tool — reusing the established pattern is much safer than reinventing it.


### PR DESCRIPTION
Closes #87.

## Summary

Four targeted changes to make contributor experience better and security guidance findable without reading internal AI-tooling files.

1. **Acknowledgment section at the top of CONTRIBUTING.md.** Names the four contributors (@ericboehs, @kemotaha, @tylew, @jpgrosen) whose PRs were closed without comment between December 2025 and April 2026, takes responsibility for the process gap (Claude Code closing PRs aggressively without surfacing them for review), and points at the in-flight tightening work (#87, #88, #90).
2. **Step 0 in Development Workflow** telling contributors to open or comment on the issue *before* starting work. Aimed at preventing the duplicate-effort pattern (#35, #47).
3. **Three explicit test-requirement bullets** in Pull Request Process replacing the vague "Tests cover new code" line: unit tests for new features, regression tests for bug fixes, integration tests for AppleScript changes.
4. **New `docs/guides/SECURITY_CHECKLIST.md`** unifying security guidance previously scattered across CLAUDE.md (lines 38, 40, 51, 69, 82). Five sections, each pointing at the canonical implementation by file:line: input sanitization, AppleScript escaping, path-traversal-safe name validation, rate limiting, audit logging. CONTRIBUTING.md and CLAUDE.md now both link to it.

## Tone callout for reviewers

The acknowledgment in CONTRIBUTING.md names contributors by GitHub handle. Worth a tone read — it's intended as honest accountability, not theater.

## Test plan
- [x] `make check-all` passes (docs-only change; sanity gate)
- [x] Manual: read CONTRIBUTING.md top-to-bottom — flows naturally without redundancy
- [x] Manual: every file:line link in SECURITY_CHECKLIST.md resolves to the right symbol on this branch
- [x] CLAUDE.md no longer describes the checklist inline; just links out

## Out of scope (separate PRs)
- #88 — PR template updates
- #89 — README pre-1.0 warning
- #90 — `/merge-and-status` extension to surface contributor PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)