### PR TITLE
Surface open contributor PRs in /merge-and-status (#90)

### DIFF
--- a/.claude/commands/merge-and-status.md
+++ b/.claude/commands/merge-and-status.md
@@ -1,4 +1,4 @@
-Merge the current PR, pull main, and show open milestone issues.
+Merge the current PR, pull main, surface any open contributor PRs, and show open milestone issues.
 
 ## Steps
 
@@ -22,14 +22,30 @@ Merge the current PR, pull main, and show open milestone issues.
    git checkout main && git pull
    ```
 
-5. **Determine the current milestone.** Look at the most recent closed PR's milestone, or find the earliest open milestone:
+5. **Surface open contributor PRs** (any PR the current GitHub user did not author). This is the catch-net for external contributions that might otherwise sit unreviewed for weeks:
+   ```bash
+   GIT_USER=$(gh api user --jq .login)
+   gh pr list --state open --json number,title,author,createdAt \
+     --jq "map(select(.author.login != \"$GIT_USER\")) | .[] | \"#\(.number)|\(.author.login)|\(.title)|\(.createdAt[:10])\""
+   ```
+   Behavioral rules for displaying the result:
+   - Render as a table with columns: PR #, author, title, opened-on date.
+   - If any rows appear, **call them out at the top of the final response** — e.g., "⚠️ N contributor PR(s) need attention." Don't bury this below the milestone-issues list.
+   - If the same author appears multiple times, group them together in the table.
+   - Dependabot PRs count as contributor PRs for visibility purposes (they need rebase nudges or merges too).
+   - If zero rows, say "No open contributor PRs" so the user gets positive confirmation rather than ambiguity.
+
+6. **Determine the current milestone.** Look at the most recent closed PR's milestone, or find the earliest open milestone:
    ```bash
    gh api repos/:owner/:repo/milestones --jq 'sort_by(.due_on // .title) | map(select(.state == "open")) | .[0].title'
    ```
 
-6. **List open issues** on that milestone:
+7. **List open issues** on that milestone:
    ```bash
    gh issue list --milestone "<milestone>" --state open
    ```
 
-7. **Display results** as a formatted table with issue number, title, and labels.
+8. **Display results** in this order:
+   - Merge confirmation (which PR landed, what was authored by whom)
+   - Contributor-PR section from step 5 — with the call-out if any exist, or the "No open contributor PRs" line if zero
+   - Current milestone + its open issues as a formatted table (issue #, title, labels)


### PR DESCRIPTION
Closes #90.

## Summary

Extends \`/merge-and-status\` with a step between \"pull main\" and \"list milestone issues\" that surfaces open PRs from any author other than the current GitHub user. This is the catch-net for the failure mode that surfaced earlier this milestone — six contributor PRs sat unreviewed for weeks because nothing in the post-merge workflow nudged them to attention.

The behavioral rules match what I've been running manually for the past several \`/merge-and-status\` invocations during this session, so the design is empirically validated:

- Render as a table (PR #, author, title, opened-on date)
- Call out at the top of the response if any rows exist
- Group repeated authors together
- Include dependabot — those need rebase nudges too
- Say \"No open contributor PRs\" when zero, for positive confirmation

## Test plan
- [x] \`make check-all\` passes (no source changes)
- [x] Slash-command file parses — Claude Code's skill registry picked up the new description (\"surface any open contributor PRs\") immediately after the edit
- [ ] Real test is the next \`/merge-and-status\` invocation — should run the new step automatically without me manually calling \`gh pr list\`

## Out of scope

- Auto-rebasing or auto-merging contributor PRs (the maintainer still drives those decisions)
- Watching for newly-opened PRs in real time (use GitHub watch settings for that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)