### PR TITLE
Update PR template: surface linked-issue + tests-added checks (#88)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,19 @@
+## Linked issue
+<!-- Required. "Closes #N", "Fixes #N", or "Related to #N" if this PR doesn't close the issue. -->
+
 ## Summary
-<!-- References issues with "Closes #N" -->
+<!-- What does this PR do? Why is it needed? -->
 
 ## Test plan
-- [ ] Unit tests (`make test`)
-- [ ] Integration tests (`make test-integration`) — if AppleScript was modified
-- [ ] `make check-all` passes
-- [ ] Manual verification
+- [ ] Unit tests cover the new code paths (happy path + error branches)
+- [ ] Bug fixes include a regression test (fails before the fix, passes after)
+- [ ] Integration tests added/updated if AppleScript was modified
+- [ ] `make check-all` passes locally
+- [ ] Manual verification (describe what you tested and how)
 
 ## Checklist
-- [ ] Tests cover new code
-- [ ] Documentation updated (TOOLS.md, README if user-visible)
-- [ ] Security checklist reviewed (if applicable)
-- [ ] No new linting or type errors
+- [ ] Linked to an issue (above)
+- [ ] Documentation updated (TOOLS.md / README) if user-visible
+- [ ] Security checklist reviewed (see [`docs/guides/SECURITY_CHECKLIST.md`](docs/guides/SECURITY_CHECKLIST.md))
+- [ ] Branch follows `{type}/issue-{num}-{description}` convention
+- [ ] No new lint or type errors


### PR DESCRIPTION
Closes #88.

## Summary

The previous PR template hid the issue-linkage expectation in an HTML comment that most contributors skip past. This PR surfaces five existing expectations (issue link, granular test bullets, security checklist link, branch convention, manual-verification description) as explicit fields and checkboxes.

Five changes:
- **Linked issue** is now its own top-level section, not a buried comment hint
- **Test plan** splits the vague \"Tests cover new code\" into three granular bullets matching CONTRIBUTING.md (#87): happy/error paths for new features, regression tests for bug fixes, integration tests for AppleScript changes
- **Security checklist** bullet links to the new \`docs/guides/SECURITY_CHECKLIST.md\` added in #87 instead of pointing into internal AI-tooling files
- **Branch-name convention** is surfaced as a checkbox so contributors catch naming issues during PR creation rather than after a rename request
- **Manual verification** bullet explicitly asks contributors to describe what they tested and how

## Notes for reviewers

- The security-checklist link uses a repo-root-relative path (\`docs/guides/SECURITY_CHECKLIST.md\`) because GitHub's PR description rendering resolves markdown links against the repo root, not the template file's location. This means the link works in PR descriptions (the high-traffic surface) but won't resolve when viewing the template file directly in \`.github/\`. That's the right tradeoff.

## Test plan
- [x] \`make check-all\` passes (no source changes)
- [ ] Real test is the next PR opened against this repo — should land with the new template fields

## Out of scope (separate PR)
- #89 — README pre-1.0 warning (last v0.5.0 issue after this lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)