### PR TITLE
README: add pre-1.0 warning about breaking changes (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 An MCP server that provides programmatic access to Apple Mail, enabling AI assistants like Claude to read, send, search, and manage emails on macOS.
 
+> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.5.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading. The aim is to reach 1.0 once the v0.6.0 polish work lands.
+
 ## Tools (14)
 
 **Core:** list_mailboxes, search_messages, get_message, send_email, mark_as_read


### PR DESCRIPTION
Closes #89.

## Summary

One-paragraph callout right after the project description and before the install instructions, so a first-time reader sees it before deciding how to depend on the project. Recommends version pinning, points at the CHANGELOG for upgrade-time review, and signals when the API will stabilize (1.0 after v0.6.0 polish work).

## Final wording

> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, \`apple-mail-mcp==0.5.0\`) and review the [CHANGELOG](CHANGELOG.md) before upgrading. The aim is to reach 1.0 once the v0.6.0 polish work lands.

Tone is informational, not scary. The example pin uses \`0.5.0\` because that's the upcoming release this PR is part of.

## Test plan
- [x] \`make check-all\` passes (no source changes)
- [x] Manual: re-read the README top-to-bottom and confirm the warning sits naturally between the description and the Tools section without breaking flow

## Out of scope (worth a follow-up issue, but not this PR)

The README's Tools section is **stale**: it says \`## Tools (14)\` and lists only the Core / Attachments & Management / Reply/Forward groups (5 + 7 + 2 = 14). Since v0.4.0 we've added 12 more tools (Discovery + Rules CRUD + Templates), bringing the actual count to 26. CLAUDE.md and TOOLS.md are accurate; just the README hasn't been refreshed. Recommend filing a separate issue for v0.6.0 to bring the README's tool listing into alignment.

## After this lands

v0.5.0 has zero open issues — ready to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)