### PR TITLE
release: v0.5.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Mail via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.4.1 | **Tests:** 254 unit / 21 e2e | **Coverage:** 95%
+**Version:** v0.5.0 | **Tests:** 571 unit / 23 e2e | **Coverage:** 92%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-26
+
+Major minor release. Fifteen new MCP tools across four feature areas (account discovery, rule management, email templates, IMAP-backed performance), several long-standing AppleScript-injection bugs closed, and contributor-experience tightening prompted by an honest look at how earlier external PRs got handled. The README, CONTRIBUTING.md, and `.github/PULL_REQUEST_TEMPLATE.md` were all reworked to make the project safer and more welcoming to contribute to.
+
+### Added
+
+**Rule CRUD (#63):** `set_rule_enabled`, `create_rule`, `update_rule`, `delete_rule`. Addresses rules by 1-based positional index (rules have no stable id in Mail.app's AppleScript interface). Medium-tier schema: 6 condition fields × 5 operators, AND/OR match logic, 7 actions. Full-replacement semantics for `actions`; condition-replacement is refused with a typed error due to a recursion bug in Mail.app on macOS Tahoe (`-[MFMessageRule(Applescript) removeFromCriteriaAtIndex:]`) that crashes Mail on any condition-deletion path. (#84)
+
+**Email templates (#30):** `list_templates`, `get_template`, `save_template`, `delete_template`, `render_template`. File-per-template storage at `~/.apple_mail_mcp/templates/<name>.md` (overridable via `APPLE_MAIL_MCP_HOME`). Simple `{placeholder}` substitution with reply-context auto-fills (`recipient_name`, `recipient_email`, `original_subject`, `today`). Render-only API — caller passes the result to existing `reply_to_message`/`forward_message`/`send_email`. First persistent-state feature in the project; the `~/.apple_mail_mcp/` convention is documented in CLAUDE.md. (#85)
+
+**Discovery & threads:**
+- `list_accounts` returns each account's id (UUID), display name, email addresses, type, and enabled state (#62, closes #26)
+- `list_rules` lists Mail.app rules with index, name, and enabled state (#64, closes #27)
+- `get_thread` reconstructs conversations using IMAP THREAD when available, falling back to AppleScript header-based reconstruction (#67, #81; closes #29 and #66)
+- `search_messages` gains 4 new filters: `is_flagged`, `date_from`, `date_to`, `has_attachment` (#65, closes #28)
+
+**IMAP-backed performance:**
+- New `imap_connector.py` and `keychain.py` modules. When a Keychain entry exists for an account, search and thread tools transparently use IMAP for server-side execution (~1s vs 1-5s); on any IMAP failure they silently fall back to AppleScript with no functional loss. (#78, #79; closes #40 and #41)
+- IMAP graceful-degradation invariants documented (#71)
+- IMAP auth path decision documented after Keychain-spike findings (#69, #70; closes #39 and #68)
+
+**Account-id (UUID) acceptance:** Account-gated tools now accept either the display name or the stable account UUID (returned by `list_accounts`). Names remain valid for convenience; UUIDs survive renames. (#82, closes #61)
+
+**Documentation & contributor experience:**
+- `docs/guides/SECURITY_CHECKLIST.md` unifies security guidance previously scattered across CLAUDE.md (#93, closes #87)
+- CONTRIBUTING.md adds an acknowledgment to early contributors whose PRs were closed without comment, plus issue-first workflow guidance and granular test requirements (#93, closes #87)
+- PR template surfaces linked-issue and tests-added checks as explicit fields (#95, closes #88)
+- README adds a pre-1.0 warning recommending version pinning (#96, closes #89)
+- Tools count in README and CLAUDE.md brought current (14 → 26)
+
+**Tooling:**
+- `/merge-and-status` slash command now surfaces open PRs from external contributors so they don't sit unreviewed (#94, closes #90)
+
+### Fixed
+
+- **AppleScript injection in 6 connector methods.** `mark_as_read`, `move_messages`, `flag_message`, `delete_messages`, `reply_to_message`, and `forward_message` interpolated raw message IDs into AppleScript without escaping. Each ID is now individually sanitized + escaped + quoted. Original report by [@martparve](https://github.com/martparve) in #34, with regression test guards added in this release.
+- **Crashes on UUID-style message IDs.** `get_message`, `get_attachments`, `_resolve_thread_anchor_applescript`, and `save_attachments` interpolated escaped IDs without surrounding quotes; AppleScript then parsed dashes/dots/`@` in iCloud-format IDs as syntax tokens and errored. Wrapped the escaped value in literal quotes everywhere. (#34, closes #86)
+- Pyright false positives for `imapclient` calls (#83)
+
+### Changed
+
+- GitHub Actions: `actions/checkout` 4 → 6, `astral-sh/setup-uv` 6 → 7 (#13, #14)
+- Coverage now 92% (was 95% in v0.4.1); new connector and template code accounts for the small drop. Floor remains 90%.
+
 ## [0.4.1] - 2026-04-19
 
 Patch release: dep hygiene and v0.4.0 follow-ups. Four connector bugs that unit tests couldn't catch were surfaced by running the three new integration tests against real Mail.app.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ An MCP server that provides programmatic access to Apple Mail, enabling AI assis
 
 > ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.5.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading. The aim is to reach 1.0 once the v0.6.0 polish work lands.
 
-## Tools (14)
+## Tools (26)
 
 **Core:** list_mailboxes, search_messages, get_message, send_email, mark_as_read
 **Attachments & Management:** send_email_with_attachments, get_attachments, save_attachments, move_messages, flag_message, create_mailbox, delete_messages
 **Reply/Forward:** reply_to_message, forward_message
+**Discovery & Rules:** list_accounts, list_rules, get_thread, set_rule_enabled, create_rule, update_rule, delete_rule
+**Templates:** list_templates, get_template, save_template, delete_template, render_template
+
+See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for full parameter and return-shape documentation.
 
 ## Prerequisites
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-mail-mcp"
-version = "0.4.1"
+version = "0.5.0"
 description = "MCP server for Apple Mail integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_mail_mcp/__init__.py
+++ b/src/apple_mail_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Mail MCP Server
 A Model Context Protocol server for Apple Mail integration.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -22,23 +22,37 @@ from apple_mail_mcp import server
 pytestmark = pytest.mark.e2e
 
 EXPECTED_TOOLS = {
+    # Discovery
     "list_accounts",
-    "list_rules",
     "list_mailboxes",
+    "list_rules",
     "search_messages",
     "get_message",
     "get_thread",
-    "send_email",
-    "mark_as_read",
-    "send_email_with_attachments",
     "get_attachments",
+    # Send / reply / forward
+    "send_email",
+    "send_email_with_attachments",
+    "reply_to_message",
+    "forward_message",
+    # Mutations
+    "mark_as_read",
     "save_attachments",
     "move_messages",
     "flag_message",
     "create_mailbox",
     "delete_messages",
-    "reply_to_message",
-    "forward_message",
+    # Rule CRUD (#63)
+    "set_rule_enabled",
+    "create_rule",
+    "update_rule",
+    "delete_rule",
+    # Templates (#30)
+    "list_templates",
+    "get_template",
+    "save_template",
+    "delete_template",
+    "render_template",
 }
 
 

--- a/tests/e2e/test_stdio_transport.py
+++ b/tests/e2e/test_stdio_transport.py
@@ -25,23 +25,37 @@ from mcp.client.stdio import stdio_client
 pytestmark = pytest.mark.e2e
 
 EXPECTED_TOOLS = {
+    # Discovery
     "list_accounts",
-    "list_rules",
     "list_mailboxes",
+    "list_rules",
     "search_messages",
     "get_message",
     "get_thread",
-    "send_email",
-    "mark_as_read",
-    "send_email_with_attachments",
     "get_attachments",
+    # Send / reply / forward
+    "send_email",
+    "send_email_with_attachments",
+    "reply_to_message",
+    "forward_message",
+    # Mutations
+    "mark_as_read",
     "save_attachments",
     "move_messages",
     "flag_message",
     "create_mailbox",
     "delete_messages",
-    "reply_to_message",
-    "forward_message",
+    # Rule CRUD (#63)
+    "set_rule_enabled",
+    "create_rule",
+    "update_rule",
+    "delete_rule",
+    # Templates (#30)
+    "list_templates",
+    "get_template",
+    "save_template",
+    "delete_template",
+    "render_template",
 }
 
 # Per #50 acceptance: test must complete within 15 seconds.

--- a/uv.lock
+++ b/uv.lock
@@ -39,7 +39,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-mcp"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Release PR for **v0.5.0**. Closes the v0.5.0 milestone (21 issues / 24 PRs since v0.4.1 on Apr 19).

Headline content per CHANGELOG:
- **Rule CRUD** (#63 / #84) — 4 tools
- **Email templates** (#30 / #85) — 5 tools
- **Account discovery, threads, advanced filters** — list_accounts, list_rules, get_thread, 4 search filters (#26, #27, #28, #29)
- **IMAP-backed performance** for search and threads with graceful AppleScript fallback (#40, #41, #66)
- **AppleScript injection fixes** in 6 connector methods, originally reported by @martparve (#34) plus quoting fixes for UUID-style message IDs (#86)
- **Contributor experience tightening** — issue-first guidance, externalized SECURITY_CHECKLIST.md, updated PR template, README pre-1.0 warning, /merge-and-status surfaces contributor PRs (#87, #88, #89, #90)

## Release-prep changes in this PR

| File | Change |
|------|--------|
| pyproject.toml, __init__.py | 0.4.1 → 0.5.0 |
| CLAUDE.md | Version, test counts (254 → 571), coverage (95% → 92%) |
| README.md | Tools section refreshed (14 → 26), missing Discovery+Rules and Templates groups added |
| CHANGELOG.md | New v0.5.0 entry |
| tests/e2e/{test_mcp_tools.py, test_stdio_transport.py} | EXPECTED_TOOLS hardcoded set updated to include the 9 new tools (was failing on main) |

## Validation
- [x] \`./scripts/check_version_sync.sh\` — all 4 files at 0.5.0
- [x] \`./scripts/check_client_server_parity.sh\` — all connector methods exposed (modulo intentional internal helpers)
- [x] \`./scripts/check_complexity.sh\` — all functions within threshold
- [x] \`./scripts/check_applescript_safety.sh\` — passed
- [x] \`./scripts/check_readme_claims.sh\` — README counts match server.py
- [x] \`make test\` — 571 unit tests passing (18 skipped, 30 deselected)
- [x] \`make check-all\` — all checks pass
- [x] e2e tests passing (23 / 23) after EXPECTED_TOOLS update
- [x] Coverage: 92.17% (above 90% floor)
- [⚠️] \`./scripts/check_dependencies.sh\` has a script bug (calls bare \`pip-audit\` instead of \`uv run pip-audit\`); worked around manually. Real audit shows only \`pip 26.0.1\` CVE in the build env (no fix available, not a runtime dep). Filed #97 for the script fix.

## Code review

Skipped the \`superpowers:code-reviewer\` agent for the cumulative diff (12k+ lines / 49 files) given that each PR was reviewed individually at merge time and the integration surface is exercised by 23 passing e2e tests + 92% coverage. Diff was skimmed for red flags (TODOs, type-ignore, prints) — none found. If you want a deeper second look before merging, let me know and I'll run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)