### PR TITLE
Fix check_dependencies.sh: invoke pip-audit via `uv run` (#97)

### DIFF
--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -4,17 +4,11 @@ set -euo pipefail
 
 echo "Checking dependencies for vulnerabilities..."
 
-if ! command -v pip-audit &> /dev/null; then
-    if command -v uv &> /dev/null; then
-        echo "Installing pip-audit..."
-        uv pip install pip-audit -q
-    else
-        echo "Error: pip-audit not found. Install with: pip install pip-audit"
-        exit 1
-    fi
-fi
-
-pip-audit 2>&1 || {
+# pip-audit is declared in pyproject.toml's dev dep group, so `uv sync --dev`
+# installs it into .venv. `uv run` resolves it from there — calling bare
+# `pip-audit` (or trying to install it ad-hoc) doesn't work because the
+# .venv bin isn't on the script-runtime PATH.
+uv run pip-audit 2>&1 || {
     echo ""
     echo "WARNING: Vulnerability scan found issues. Review and update dependencies."
     exit 1


### PR DESCRIPTION
Closes #97.

## Summary

The script's old flow was contradictory:

\`\`\`bash
uv pip install pip-audit -q  # installs into .venv/
pip-audit                    # bare invocation — fails, .venv bin isn't on script PATH
\`\`\`

Both lines turned out to be unnecessary. \`pip-audit>=2.7.0\` is already in \`pyproject.toml\`'s dev dep group (lines 39 and 53), so \`uv sync --dev\` installs it. \`uv run pip-audit\` resolves it from \`.venv\` cleanly.

Removes ~13 lines of redundant install logic.

## Test plan
- [x] \`./scripts/check_dependencies.sh\` now produces real audit output (the known \`pip 26.0.1\` CVE-2026-3219 finding surfaces, confirming pip-audit is actually running) instead of \`command not found\`
- [x] \`make check-all\` still passes (it doesn't gate on this script anyway)

## Out of scope

- **The CVE-2026-3219 finding itself.** \`pip 26.0.1\` is a transitive build-env dep with no fix version available. Not a runtime dep of \`apple-mail-mcp\`. Will be handled at v0.6.0 release time — likely with an explicit \`--ignore-vuln\` flag if it's still unfixable then. Filing a separate issue if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)