### PR TITLE
Surface untriaged contributor issues in /merge-and-status (#104)

### DIFF
--- a/.claude/commands/merge-and-status.md
+++ b/.claude/commands/merge-and-status.md
@@ -1,4 +1,4 @@
-Merge the current PR, pull main, surface any open contributor PRs, and show open milestone issues.
+Merge the current PR, pull main, surface any open contributor PRs and untriaged contributor issues, and show open milestone issues.
 
 ## Steps
 
@@ -35,17 +35,30 @@ Merge the current PR, pull main, surface any open contributor PRs, and show open
    - Dependabot PRs count as contributor PRs for visibility purposes (they need rebase nudges or merges too).
    - If zero rows, say "No open contributor PRs" so the user gets positive confirmation rather than ambiguity.
 
-6. **Determine the current milestone.** Look at the most recent closed PR's milestone, or find the earliest open milestone:
+6. **Surface untriaged contributor issues** (open issues filed by anyone other than the current GitHub user that are NOT assigned to a milestone). The reasoning for the no-milestone filter: assigned issues have already been triaged and are visible elsewhere — the truly invisible ones are the unassigned ones.
+   ```bash
+   GIT_USER=$(gh api user --jq .login)
+   gh issue list --state open --limit 50 --json number,title,author,createdAt,milestone \
+     --jq "map(select(.author.login != \"$GIT_USER\")) | map(select(.milestone == null)) | .[] | \"#\(.number)|\(.author.login)|\(.title)|\(.createdAt[:10])\""
+   ```
+   Behavioral rules (mirror the contributor-PR step):
+   - Render as a table with columns: issue #, author, title, opened-on date.
+   - If any rows appear, **call them out at the top of the final response** alongside (or below) the contributor-PR call-out — e.g., "⚠️ N untriaged contributor issue(s) need attention."
+   - If the same author appears multiple times, group them together in the table.
+   - If zero rows, say "No untriaged contributor issues" for positive confirmation.
+
+7. **Determine the current milestone.** Look at the most recent closed PR's milestone, or find the earliest open milestone:
    ```bash
    gh api repos/:owner/:repo/milestones --jq 'sort_by(.due_on // .title) | map(select(.state == "open")) | .[0].title'
    ```
 
-7. **List open issues** on that milestone:
+8. **List open issues** on that milestone:
    ```bash
    gh issue list --milestone "<milestone>" --state open
    ```
 
-8. **Display results** in this order:
+9. **Display results** in this order:
    - Merge confirmation (which PR landed, what was authored by whom)
-   - Contributor-PR section from step 5 — with the call-out if any exist, or the "No open contributor PRs" line if zero
+   - Contributor-PR section from step 5 — call-out if any exist, or "No open contributor PRs"
+   - Untriaged contributor issues section from step 6 — call-out if any exist, or "No untriaged contributor issues"
    - Current milestone + its open issues as a formatted table (issue #, title, labels)


### PR DESCRIPTION
Closes #104.

## Summary

Mirrors the contributor-PR surface (#90 / PR #94) for issues — adds a step that lists open issues authored by anyone other than the current GitHub user that are NOT assigned to a milestone.

The no-milestone filter is intentional: assigned issues have already been triaged and are visible on their milestone listings; the truly invisible ones are the unassigned ones — same blind spot the contributor-PR surface closed for PRs.

## What surfaces today

Running this query against the repo right now returns **5 untriaged external-filed issues**, the oldest from December 2025:
- #1 (joel-alturaeducation, 2025-12-05) — \`search_messages\` -1726
- #6 (AlessandroB1989, 2026-01-15) — same -1726 bug
- #8 (jc-cp, 2026-02-19) — \"v0.2 coming out?\"
- #9, #10 (haocn-ops, 2026-03-11) — leased-inbox demo posts

The first two are fixed by PR #59 (v0.4.1) and just need closing. The rest need actual triage. The next \`/merge-and-status\` after this lands will show all of them.

## Test plan
- [x] \`make check-all\` passes (no source changes)
- [x] Slash-command registry picked up the updated description (\"...untriaged contributor issue...\") immediately after edit
- [ ] Real test is the next \`/merge-and-status\` run after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)