### PR TITLE
Fix bulk-ops cubic-loop perf bug with source_mailbox parameter (#103)

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -118,6 +118,76 @@ def _wrap_as_json_script(body: str) -> str:
     )
 
 
+def _bulk_repeat_block(
+    *,
+    account: str | None,
+    source_mailbox: str | None,
+    inner: str,
+    counter_var: str,
+) -> str:
+    """Emit the AppleScript repeat block for a bulk-mutation operation.
+
+    When `account` and `source_mailbox` are both provided, emits a narrow
+    O(N) loop scoped to a single mailbox. When both are None, falls back
+    to the legacy O(N × accounts × mailboxes) cross-scan for backwards
+    compatibility. Any partial-pair raises ValueError — a mailbox name
+    without an account is ambiguous (the same name can exist across
+    multiple accounts).
+
+    Args:
+        account: Account name or UUID, or None.
+        source_mailbox: Source mailbox name, or None.
+        inner: AppleScript statement(s) to run inside the loop AFTER
+            `set msg to first message of mb whose id is msgId`. Must NOT
+            include the counter increment — that's appended automatically.
+        counter_var: Name of the AppleScript counter variable (e.g.
+            "updateCount", "moveCount") that gets incremented per success.
+
+    Returns:
+        AppleScript fragment ready to interpolate into a `tell application
+        "Mail"` block. Indented for readability when embedded.
+
+    Raises:
+        ValueError: If exactly one of `account`/`source_mailbox` is given.
+    """
+    if (account is None) != (source_mailbox is None):
+        missing = "source_mailbox" if account is not None else "account"
+        raise ValueError(
+            f"account and source_mailbox must be provided together; "
+            f"missing {missing}"
+        )
+
+    if account is not None and source_mailbox is not None:
+        # Narrow path: single mailbox, single loop. O(N).
+        account_clause = applescript_account_clause(account)
+        mb_safe = escape_applescript_string(sanitize_input(source_mailbox))
+        return (
+            f'            set sourceMb to mailbox "{mb_safe}" of {account_clause}\n'
+            f"            repeat with msgId in idList\n"
+            f"                try\n"
+            f"                    set msg to first message of sourceMb whose id is msgId\n"
+            f"                    {inner}\n"
+            f"                    set {counter_var} to {counter_var} + 1\n"
+            f"                end try\n"
+            f"            end repeat"
+        )
+
+    # Cross-scan path (legacy / backwards compat). O(N × M × K).
+    return (
+        f"            repeat with msgId in idList\n"
+        f"                repeat with acc in accounts\n"
+        f"                    repeat with mb in mailboxes of acc\n"
+        f"                        try\n"
+        f"                            set msg to first message of mb whose id is msgId\n"
+        f"                            {inner}\n"
+        f"                            set {counter_var} to {counter_var} + 1\n"
+        f"                        end try\n"
+        f"                    end repeat\n"
+        f"                end repeat\n"
+        f"            end repeat"
+    )
+
+
 class AppleMailConnector:
     """Interface to Apple Mail via AppleScript."""
 
@@ -1140,24 +1210,42 @@ class AppleMailConnector:
         result = self._run_applescript(script)
         return result == "sent"
 
-    def mark_as_read(self, message_ids: list[str], read: bool = True) -> int:
+    def mark_as_read(
+        self,
+        message_ids: list[str],
+        read: bool = True,
+        *,
+        account: str | None = None,
+        source_mailbox: str | None = None,
+    ) -> int:
         """
         Mark messages as read or unread.
 
         Args:
             message_ids: List of message IDs
             read: True for read, False for unread
+            account: Optional account name (or UUID) the messages live in.
+                Must be provided together with `source_mailbox`. When both
+                are given, the AppleScript narrows the scan to that single
+                mailbox — O(N) instead of the default cross-scan O(N × M × K).
+            source_mailbox: Optional source mailbox name; see `account`.
 
         Returns:
             Number of messages updated
 
         Raises:
+            ValueError: If exactly one of `account`/`source_mailbox` is given.
             MailAppleScriptError: If operation fails
         """
         if not message_ids:
             return 0
 
-        status = "true" if read else "false"
+        repeat_block = _bulk_repeat_block(
+            account=account,
+            source_mailbox=source_mailbox,
+            inner=f"set read status of msg to {'true' if read else 'false'}",
+            counter_var="updateCount",
+        )
 
         # Build list of IDs (sanitize and escape each)
         id_list = ", ".join(
@@ -1170,17 +1258,7 @@ class AppleMailConnector:
             set idList to {{{id_list}}}
             set updateCount to 0
 
-            repeat with msgId in idList
-                repeat with acc in accounts
-                    repeat with mb in mailboxes of acc
-                        try
-                            set msg to first message of mb whose id is msgId
-                            set read status of msg to {status}
-                            set updateCount to updateCount + 1
-                        end try
-                    end repeat
-                end repeat
-            end repeat
+{repeat_block}
 
             return updateCount
         end tell

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -1756,6 +1756,8 @@ class AppleMailConnector:
         destination_mailbox: str,
         account: str,
         gmail_mode: bool = False,
+        *,
+        source_mailbox: str | None = None,
     ) -> int:
         """
         Move messages to a different mailbox.
@@ -1763,8 +1765,14 @@ class AppleMailConnector:
         Args:
             message_ids: List of message IDs to move
             destination_mailbox: Name of destination mailbox
-            account: Account name
+            account: Account name (or UUID) hosting the destination mailbox
             gmail_mode: Use Gmail-specific handling (copy + delete)
+            source_mailbox: Optional source mailbox name to narrow the
+                AppleScript scan to one mailbox (O(N) instead of O(N × M × K)).
+                When provided, source is assumed to be in the same `account`
+                as the destination — the common case. To move across
+                accounts, omit `source_mailbox` to fall back to the
+                cross-scan path.
 
         Returns:
             Number of messages moved
@@ -1786,54 +1794,33 @@ class AppleMailConnector:
         )
 
         if gmail_mode:
-            # Gmail requires copy + delete approach to properly handle labels
-            script = f"""
-            tell application "Mail"
-                set accountRef to {account_clause}
-                set destMailbox to mailbox "{mailbox_safe}" of accountRef
-                set idList to {{{id_list}}}
-                set moveCount to 0
-
-                repeat with msgId in idList
-                    repeat with acc in accounts
-                        repeat with mb in mailboxes of acc
-                            try
-                                set msg to first message of mb whose id is msgId
-                                duplicate msg to destMailbox
-                                delete msg
-                                set moveCount to moveCount + 1
-                            end try
-                        end repeat
-                    end repeat
-                end repeat
-
-                return moveCount
-            end tell
-            """
+            inner = "duplicate msg to destMailbox\n                    delete msg"
         else:
-            # Standard IMAP move
-            script = f"""
-            tell application "Mail"
-                set accountRef to {account_clause}
-                set destMailbox to mailbox "{mailbox_safe}" of accountRef
-                set idList to {{{id_list}}}
-                set moveCount to 0
+            inner = "set mailbox of msg to destMailbox"
 
-                repeat with msgId in idList
-                    repeat with acc in accounts
-                        repeat with mb in mailboxes of acc
-                            try
-                                set msg to first message of mb whose id is msgId
-                                set mailbox of msg to destMailbox
-                                set moveCount to moveCount + 1
-                            end try
-                        end repeat
-                    end repeat
-                end repeat
+        # `account` is required by this method (it's where the destination
+        # lives), so source_mailbox is the only "optional" half here. Pass
+        # account through only when the caller explicitly wants the narrow
+        # source-scan path.
+        repeat_block = _bulk_repeat_block(
+            account=account if source_mailbox is not None else None,
+            source_mailbox=source_mailbox,
+            inner=inner,
+            counter_var="moveCount",
+        )
 
-                return moveCount
-            end tell
-            """
+        script = f"""
+        tell application "Mail"
+            set accountRef to {account_clause}
+            set destMailbox to mailbox "{mailbox_safe}" of accountRef
+            set idList to {{{id_list}}}
+            set moveCount to 0
+
+{repeat_block}
+
+            return moveCount
+        end tell
+        """
 
         result = self._run_applescript(script)
         return int(result) if result.isdigit() else 0

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -122,7 +122,7 @@ def _bulk_repeat_block(
     *,
     account: str | None,
     source_mailbox: str | None,
-    inner: str,
+    actions: list[str],
     counter_var: str,
 ) -> str:
     """Emit the AppleScript repeat block for a bulk-mutation operation.
@@ -137,15 +137,15 @@ def _bulk_repeat_block(
     Args:
         account: Account name or UUID, or None.
         source_mailbox: Source mailbox name, or None.
-        inner: AppleScript statement(s) to run inside the loop AFTER
-            `set msg to first message of mb whose id is msgId`. Must NOT
-            include the counter increment — that's appended automatically.
+        actions: One or more AppleScript statements to run inside the
+            loop AFTER `set msg to first message ... whose id is msgId`.
+            The counter increment is appended automatically.
         counter_var: Name of the AppleScript counter variable (e.g.
             "updateCount", "moveCount") that gets incremented per success.
 
     Returns:
         AppleScript fragment ready to interpolate into a `tell application
-        "Mail"` block. Indented for readability when embedded.
+        "Mail"` block.
 
     Raises:
         ValueError: If exactly one of `account`/`source_mailbox` is given.
@@ -159,6 +159,8 @@ def _bulk_repeat_block(
 
     if account is not None and source_mailbox is not None:
         # Narrow path: single mailbox, single loop. O(N).
+        action_indent = " " * 20
+        action_lines = "\n".join(action_indent + a for a in actions)
         account_clause = applescript_account_clause(account)
         mb_safe = escape_applescript_string(sanitize_input(source_mailbox))
         return (
@@ -166,20 +168,22 @@ def _bulk_repeat_block(
             f"            repeat with msgId in idList\n"
             f"                try\n"
             f"                    set msg to first message of sourceMb whose id is msgId\n"
-            f"                    {inner}\n"
+            f"{action_lines}\n"
             f"                    set {counter_var} to {counter_var} + 1\n"
             f"                end try\n"
             f"            end repeat"
         )
 
     # Cross-scan path (legacy / backwards compat). O(N × M × K).
+    action_indent = " " * 28
+    action_lines = "\n".join(action_indent + a for a in actions)
     return (
         f"            repeat with msgId in idList\n"
         f"                repeat with acc in accounts\n"
         f"                    repeat with mb in mailboxes of acc\n"
         f"                        try\n"
         f"                            set msg to first message of mb whose id is msgId\n"
-        f"                            {inner}\n"
+        f"{action_lines}\n"
         f"                            set {counter_var} to {counter_var} + 1\n"
         f"                        end try\n"
         f"                    end repeat\n"
@@ -1243,7 +1247,7 @@ class AppleMailConnector:
         repeat_block = _bulk_repeat_block(
             account=account,
             source_mailbox=source_mailbox,
-            inner=f"set read status of msg to {'true' if read else 'false'}",
+            actions=[f"set read status of msg to {'true' if read else 'false'}"],
             counter_var="updateCount",
         )
 
@@ -1794,9 +1798,9 @@ class AppleMailConnector:
         )
 
         if gmail_mode:
-            inner = "duplicate msg to destMailbox\n                    delete msg"
+            actions = ["duplicate msg to destMailbox", "delete msg"]
         else:
-            inner = "set mailbox of msg to destMailbox"
+            actions = ["set mailbox of msg to destMailbox"]
 
         # `account` is required by this method (it's where the destination
         # lives), so source_mailbox is the only "optional" half here. Pass
@@ -1805,7 +1809,7 @@ class AppleMailConnector:
         repeat_block = _bulk_repeat_block(
             account=account if source_mailbox is not None else None,
             source_mailbox=source_mailbox,
-            inner=inner,
+            actions=actions,
             counter_var="moveCount",
         )
 
@@ -1829,6 +1833,9 @@ class AppleMailConnector:
         self,
         message_ids: list[str],
         flag_color: str,
+        *,
+        account: str | None = None,
+        source_mailbox: str | None = None,
     ) -> int:
         """
         Set flag color on messages.
@@ -1836,12 +1843,18 @@ class AppleMailConnector:
         Args:
             message_ids: List of message IDs to flag
             flag_color: Flag color (none, orange, red, yellow, blue, green, purple, gray)
+            account: Optional account name (or UUID); see `source_mailbox`.
+            source_mailbox: Optional source mailbox name. When provided
+                together with `account`, the AppleScript narrows the scan
+                to that single mailbox — O(N) instead of O(N × M × K).
+                Either alone raises ValueError.
 
         Returns:
             Number of messages flagged
 
         Raises:
-            ValueError: If flag color is invalid
+            ValueError: If flag color is invalid, or if exactly one of
+                `account`/`source_mailbox` is given.
         """
         if not message_ids:
             return 0
@@ -1858,23 +1871,22 @@ class AppleMailConnector:
             for mid in message_ids
         )
 
+        repeat_block = _bulk_repeat_block(
+            account=account,
+            source_mailbox=source_mailbox,
+            actions=[
+                f"set flag index of msg to {flag_index}",
+                f"set flagged status of msg to {flagged_status}",
+            ],
+            counter_var="flagCount",
+        )
+
         script = f"""
         tell application "Mail"
             set idList to {{{id_list}}}
             set flagCount to 0
 
-            repeat with msgId in idList
-                repeat with acc in accounts
-                    repeat with mb in mailboxes of acc
-                        try
-                            set msg to first message of mb whose id is msgId
-                            set flag index of msg to {flag_index}
-                            set flagged status of msg to {flagged_status}
-                            set flagCount to flagCount + 1
-                        end try
-                    end repeat
-                end repeat
-            end repeat
+{repeat_block}
 
             return flagCount
         end tell
@@ -1942,20 +1954,32 @@ class AppleMailConnector:
         message_ids: list[str],
         permanent: bool = False,
         skip_bulk_check: bool = True,
+        *,
+        account: str | None = None,
+        source_mailbox: str | None = None,
     ) -> int:
         """
         Delete messages (move to trash or permanent delete).
 
         Args:
             message_ids: List of message IDs to delete
-            permanent: If True, permanently delete (bypass trash)
+            permanent: If True, permanently delete (bypass trash). NOTE:
+                this flag currently produces identical AppleScript as the
+                non-permanent path; the actual permanent-vs-trash behavior
+                is whatever Mail.app does by default for `delete msg`.
             skip_bulk_check: If False, enforce bulk operation limits
+            account: Optional account name (or UUID); see `source_mailbox`.
+            source_mailbox: Optional source mailbox name. When provided
+                together with `account`, the AppleScript narrows the scan
+                to that single mailbox — O(N) instead of O(N × M × K).
+                Either alone raises ValueError.
 
         Returns:
             Number of messages deleted
 
         Raises:
-            ValueError: If bulk check fails
+            ValueError: If bulk check fails, or if exactly one of
+                `account`/`source_mailbox` is given.
         """
         if not message_ids:
             return 0
@@ -1972,50 +1996,27 @@ class AppleMailConnector:
             for mid in message_ids
         )
 
-        if permanent:
-            # Permanent delete (not recommended, requires extra caution)
-            script = f"""
-            tell application "Mail"
-                set idList to {{{id_list}}}
-                set deleteCount to 0
+        repeat_block = _bulk_repeat_block(
+            account=account,
+            source_mailbox=source_mailbox,
+            actions=["delete msg"],
+            counter_var="deleteCount",
+        )
 
-                repeat with msgId in idList
-                    repeat with acc in accounts
-                        repeat with mb in mailboxes of acc
-                            try
-                                set msg to first message of mb whose id is msgId
-                                delete msg
-                                set deleteCount to deleteCount + 1
-                            end try
-                        end repeat
-                    end repeat
-                end repeat
+        # `permanent` is preserved as a parameter but currently produces
+        # identical AppleScript — Mail.app's `delete msg` semantics handle
+        # both cases the same way today. If permanent-vs-trash needs to
+        # diverge in the future, branch here on `permanent`.
+        script = f"""
+        tell application "Mail"
+            set idList to {{{id_list}}}
+            set deleteCount to 0
 
-                return deleteCount
-            end tell
-            """
-        else:
-            # Move to trash (standard delete)
-            script = f"""
-            tell application "Mail"
-                set idList to {{{id_list}}}
-                set deleteCount to 0
+{repeat_block}
 
-                repeat with msgId in idList
-                    repeat with acc in accounts
-                        repeat with mb in mailboxes of acc
-                            try
-                                set msg to first message of mb whose id is msgId
-                                delete msg
-                                set deleteCount to deleteCount + 1
-                            end try
-                        end repeat
-                    end repeat
-                end repeat
-
-                return deleteCount
-            end tell
-            """
+            return deleteCount
+        end tell
+        """
 
         result = self._run_applescript(script)
         return int(result) if result.isdigit() else 0

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -920,13 +920,24 @@ async def send_email(
 
 
 @mcp.tool()
-def mark_as_read(message_ids: list[str], read: bool = True) -> dict[str, Any]:
+def mark_as_read(
+    message_ids: list[str],
+    read: bool = True,
+    account: str | None = None,
+    source_mailbox: str | None = None,
+) -> dict[str, Any]:
     """
     Mark messages as read or unread.
 
     Args:
         message_ids: List of message IDs to update
         read: True to mark as read, False to mark as unread (default: true)
+        account: Optional account name (or UUID) the messages live in.
+            Must be provided together with `source_mailbox`. When both
+            are given, the operation is much faster — single mailbox
+            scan instead of cross-account search.
+        source_mailbox: Optional source mailbox name (e.g. "INBOX").
+            See `account`.
 
     Returns:
         Dictionary indicating success and number of messages updated
@@ -934,6 +945,8 @@ def mark_as_read(message_ids: list[str], read: bool = True) -> dict[str, Any]:
     Example:
         >>> mark_as_read(["12345", "12346"], read=True)
         {"success": True, "updated": 2}
+        >>> mark_as_read(["12345"], account="Gmail", source_mailbox="INBOX")
+        {"success": True, "updated": 1}
     """
     try:
         rate_err = check_rate_limit("mark_as_read", {"count": len(message_ids)})
@@ -952,7 +965,12 @@ def mark_as_read(message_ids: list[str], read: bool = True) -> dict[str, Any]:
 
         logger.info(f"Marking {len(message_ids)} messages as {'read' if read else 'unread'}")
 
-        count = mail.mark_as_read(message_ids, read=read)
+        count = mail.mark_as_read(
+            message_ids,
+            read=read,
+            account=account,
+            source_mailbox=source_mailbox,
+        )
 
         operation_logger.log_operation(
             "mark_as_read",
@@ -1336,6 +1354,7 @@ def move_messages(
     destination_mailbox: str,
     account: str,
     gmail_mode: bool = False,
+    source_mailbox: str | None = None,
 ) -> dict[str, Any]:
     """
     Move messages to a different mailbox/folder.
@@ -1347,6 +1366,10 @@ def move_messages(
             UUID (from list_accounts) containing the messages. Names are
             convenient but unstable across renames; UUIDs are stable.
         gmail_mode: Use Gmail-specific move handling (copy + delete) for label-based systems
+        source_mailbox: Optional source mailbox name. When provided, the
+            operation is much faster — single mailbox scan instead of
+            cross-account search. Source is assumed to be in the same
+            `account` as the destination.
 
     Returns:
         Dictionary with success status and number of messages moved
@@ -1355,7 +1378,8 @@ def move_messages(
         move_messages(
             message_ids=["12345", "12346"],
             destination_mailbox="Archive",
-            account="Gmail"
+            account="Gmail",
+            source_mailbox="INBOX",
         )
     """
     try:
@@ -1384,6 +1408,7 @@ def move_messages(
             destination_mailbox=destination_mailbox,
             account=account,
             gmail_mode=gmail_mode,
+            source_mailbox=source_mailbox,
         )
 
         return {
@@ -1420,6 +1445,8 @@ def move_messages(
 def flag_message(
     message_ids: list[str],
     flag_color: str,
+    account: str | None = None,
+    source_mailbox: str | None = None,
 ) -> dict[str, Any]:
     """
     Set flag color on messages.
@@ -1427,6 +1454,10 @@ def flag_message(
     Args:
         message_ids: List of message IDs to flag
         flag_color: Flag color name (none, orange, red, yellow, blue, green, purple, gray)
+        account: Optional account name (or UUID) the messages live in.
+            Must be provided together with `source_mailbox`. When both
+            are given, the operation is much faster.
+        source_mailbox: Optional source mailbox name; see `account`.
 
     Returns:
         Dictionary with success status and number of messages flagged
@@ -1434,7 +1465,9 @@ def flag_message(
     Example:
         flag_message(
             message_ids=["12345"],
-            flag_color="red"
+            flag_color="red",
+            account="Gmail",
+            source_mailbox="INBOX",
         )
     """
     try:
@@ -1455,6 +1488,8 @@ def flag_message(
         count = mail.flag_message(
             message_ids=message_ids,
             flag_color=flag_color,
+            account=account,
+            source_mailbox=source_mailbox,
         )
 
         return {
@@ -1578,6 +1613,8 @@ def create_mailbox(
 def delete_messages(
     message_ids: list[str],
     permanent: bool = False,
+    account: str | None = None,
+    source_mailbox: str | None = None,
 ) -> dict[str, Any]:
     """
     Delete messages (move to trash or permanently delete).
@@ -1585,6 +1622,10 @@ def delete_messages(
     Args:
         message_ids: List of message IDs to delete
         permanent: If True, permanently delete; if False, move to Trash (default: False)
+        account: Optional account name (or UUID) the messages live in.
+            Must be provided together with `source_mailbox`. When both
+            are given, the operation is much faster.
+        source_mailbox: Optional source mailbox name; see `account`.
 
     Returns:
         Dictionary with success status and number of messages deleted
@@ -1592,7 +1633,9 @@ def delete_messages(
     Example:
         delete_messages(
             message_ids=["12345"],
-            permanent=False  # Move to trash
+            permanent=False,  # Move to trash
+            account="Gmail",
+            source_mailbox="INBOX",
         )
 
     Note:
@@ -1627,6 +1670,8 @@ def delete_messages(
             message_ids=message_ids,
             permanent=permanent,
             skip_bulk_check=False,  # Enforce limit
+            account=account,
+            source_mailbox=source_mailbox,
         )
 
         return {

--- a/tests/benchmarks/baseline.json
+++ b/tests/benchmarks/baseline.json
@@ -1,5 +1,7 @@
 {
-  "save_attachments_one_file": 0.602,
-  "search_messages_no_filter": 2.123,
+  "mark_as_read_50_msgs": 3.65,
+  "move_messages_50_msgs": 17.167,
+  "save_attachments_one_file": 0.432,
+  "search_messages_no_filter": 1.987,
   "search_messages_with_sender_filter": 59.964
 }

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -290,6 +290,7 @@ def bench_messages(
                     [m["id"] for m in leftover],
                     destination_mailbox=bench_source,
                     account=test_account,
+                    source_mailbox=bench_mailbox,
                 )
             except Exception:
                 # If move fails, break to avoid an infinite loop; the
@@ -313,6 +314,7 @@ def bench_messages(
             [m["id"] for m in source_msgs],
             destination_mailbox=bench_mailbox,
             account=test_account,
+            source_mailbox=bench_source,
         )
     except MailAppleScriptError as e:
         # The bulk-operation cubic-loop bug (#103) makes move_messages

--- a/tests/benchmarks/test_bulk_ops.py
+++ b/tests/benchmarks/test_bulk_ops.py
@@ -26,22 +26,33 @@ from .conftest import (
 
 def test_mark_as_read_50_msgs(
     connector: AppleMailConnector,
+    test_account: str,
+    bench_mailbox: str,
     bench_messages: list[str],
     baselines: dict[str, float],
     capture_mode: bool,
 ) -> None:
     """Baseline: bulk-mark-read against BULK_SIZE messages in the bench
-    mailbox.
+    mailbox, using the narrow-path source_mailbox parameter from #103.
 
     Each iteration toggles read→unread→read on the same message set.
-    Final state of each iteration matches the message's starting state
-    in the bench mailbox.
+    Final state of each iteration matches the message's starting state.
     """
     name = "mark_as_read_50_msgs"
 
     def run() -> None:
-        connector.mark_as_read(bench_messages, read=False)
-        connector.mark_as_read(bench_messages, read=True)
+        connector.mark_as_read(
+            bench_messages,
+            read=False,
+            account=test_account,
+            source_mailbox=bench_mailbox,
+        )
+        connector.mark_as_read(
+            bench_messages,
+            read=True,
+            account=test_account,
+            source_mailbox=bench_mailbox,
+        )
 
     result: BenchmarkResult = measure_median(run, name=name)
     assert_within_baseline(name, result, baselines, capture_mode)
@@ -56,7 +67,8 @@ def test_move_messages_50_msgs(
     baselines: dict[str, float],
     capture_mode: bool,
 ) -> None:
-    """Baseline: bulk-move BULK_SIZE messages.
+    """Baseline: bulk-move BULK_SIZE messages, using narrow-path
+    source_mailbox in both directions.
 
     Each iteration moves bench → source → bench. Two move calls per
     iteration; we measure the round-trip and report it as
@@ -73,11 +85,12 @@ def test_move_messages_50_msgs(
     current_ids = list(bench_messages)
 
     def run() -> None:
-        # Move bench → source
+        # Move bench → source (narrow source-scan)
         connector.move_messages(
             current_ids,
             destination_mailbox=bench_source,
             account=test_account,
+            source_mailbox=bench_mailbox,
         )
         # IDs are now stale. Find the BULK_SIZE most recent in source —
         # those are the ones we just moved.
@@ -86,11 +99,12 @@ def test_move_messages_50_msgs(
         )
         moved_ids = [m["id"] for m in in_source[: len(current_ids)]]
 
-        # Move source → bench
+        # Move source → bench (narrow source-scan)
         connector.move_messages(
             moved_ids,
             destination_mailbox=bench_mailbox,
             account=test_account,
+            source_mailbox=bench_source,
         )
         # Re-fetch bench IDs for the next iteration.
         in_bench = connector.search_messages(
@@ -98,7 +112,6 @@ def test_move_messages_50_msgs(
         )
         current_ids[:] = [m["id"] for m in in_bench[: len(current_ids)]]
 
-    # 3 runs (not 5) — each run is two moves on 50 messages, so the
-    # benchmark is already slow.
+    # 3 runs (not 5) — each run is two moves on 50 messages.
     result: BenchmarkResult = measure_median(run, name=name, runs=3)
     assert_within_baseline(name, result, baselines, capture_mode)

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -2108,6 +2108,62 @@ class TestMessageIdAppleScriptInjection:
         assert 'whose id is "craft\\"ed-id"' in script
 
 
+class TestBulkOpsSourceMailbox:
+    """Regression guards for #103: bulk-mutation methods accept paired
+    `account` + `source_mailbox` parameters that narrow the AppleScript
+    scan from O(N × accounts × mailboxes) to O(N).
+
+    Both params must be provided together (a mailbox name without an
+    account is ambiguous because the same name can exist across accounts).
+    Either alone raises ValueError.
+    """
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    # ------ mark_as_read ------
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_mark_as_read_narrow_path_uses_single_loop(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "2"
+        connector.mark_as_read(
+            ["abc", "def"], account="Gmail", source_mailbox="INBOX"
+        )
+        script = mock_run.call_args[0][0]
+        # Narrow scope: single mailbox of a specific account.
+        assert 'mailbox "INBOX" of' in script
+        assert 'account "Gmail"' in script
+        # Cross-scan loops MUST be gone.
+        assert "repeat with acc in accounts" not in script
+        assert "repeat with mb in mailboxes" not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_mark_as_read_no_params_keeps_cross_scan_path(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "1"
+        connector.mark_as_read(["abc"])
+        script = mock_run.call_args[0][0]
+        # Backwards-compat: existing slow path preserved.
+        assert "repeat with acc in accounts" in script
+        assert "repeat with mb in mailboxes" in script
+
+    def test_mark_as_read_account_without_source_mailbox_raises(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with pytest.raises(ValueError, match="source_mailbox"):
+            connector.mark_as_read(["x"], account="Gmail")
+
+    def test_mark_as_read_source_mailbox_without_account_raises(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with pytest.raises(ValueError, match="account"):
+            connector.mark_as_read(["x"], source_mailbox="INBOX")
+
+
 class TestWhoseIdQuoting:
     """Regression guards for #86: `whose id is X` must wrap X in quotes
     even when X is already escape_applescript_string'd.

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -2218,6 +2218,68 @@ class TestBulkOpsSourceMailbox:
         assert "repeat with acc in accounts" in script
         assert "repeat with mb in mailboxes" in script
 
+    # ------ flag_message ------
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_flag_message_narrow_path_uses_single_loop(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "1"
+        connector.flag_message(
+            ["abc"], "red", account="iCloud", source_mailbox="Archive"
+        )
+        script = mock_run.call_args[0][0]
+        assert 'mailbox "Archive" of' in script
+        assert "set flag index of msg to" in script
+        assert "set flagged status of msg to" in script
+        assert "repeat with acc in accounts" not in script
+
+    def test_flag_message_partial_pair_raises(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with pytest.raises(ValueError, match="source_mailbox"):
+            connector.flag_message(["x"], "red", account="iCloud")
+        with pytest.raises(ValueError, match="account"):
+            connector.flag_message(["x"], "red", source_mailbox="Archive")
+
+    # ------ delete_messages ------
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_delete_messages_narrow_path_uses_single_loop(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "1"
+        connector.delete_messages(
+            ["abc"], account="iCloud", source_mailbox="Trash"
+        )
+        script = mock_run.call_args[0][0]
+        assert 'mailbox "Trash" of' in script
+        assert "delete msg" in script
+        assert "repeat with acc in accounts" not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_delete_messages_permanent_narrow_path(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "1"
+        connector.delete_messages(
+            ["abc"],
+            permanent=True,
+            account="iCloud",
+            source_mailbox="Junk",
+        )
+        script = mock_run.call_args[0][0]
+        assert 'mailbox "Junk" of' in script
+        assert "repeat with acc in accounts" not in script
+
+    def test_delete_messages_partial_pair_raises(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with pytest.raises(ValueError, match="source_mailbox"):
+            connector.delete_messages(["x"], account="iCloud")
+        with pytest.raises(ValueError, match="account"):
+            connector.delete_messages(["x"], source_mailbox="Trash")
+
 
 class TestWhoseIdQuoting:
     """Regression guards for #86: `whose id is X` must wrap X in quotes

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -2163,6 +2163,61 @@ class TestBulkOpsSourceMailbox:
         with pytest.raises(ValueError, match="account"):
             connector.mark_as_read(["x"], source_mailbox="INBOX")
 
+    # ------ move_messages ------
+    # Note: move_messages already has `account` for the DESTINATION account.
+    # `source_mailbox` is independent — it narrows where we LOOK for the
+    # source messages. Both branches (gmail_mode True/False) need the
+    # narrow path.
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_move_messages_narrow_path_standard_branch(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "2"
+        connector.move_messages(
+            ["abc", "def"],
+            destination_mailbox="Archive",
+            account="Gmail",
+            source_mailbox="INBOX",
+        )
+        script = mock_run.call_args[0][0]
+        # Source narrowed to a single mailbox; destination unchanged.
+        assert 'mailbox "INBOX" of' in script
+        assert 'mailbox "Archive" of' in script  # destination still set
+        assert "repeat with acc in accounts" not in script
+        assert "repeat with mb in mailboxes" not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_move_messages_narrow_path_gmail_branch(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "2"
+        connector.move_messages(
+            ["abc", "def"],
+            destination_mailbox="[Gmail]/All Mail",
+            account="Gmail",
+            gmail_mode=True,
+            source_mailbox="INBOX",
+        )
+        script = mock_run.call_args[0][0]
+        assert 'mailbox "INBOX" of' in script
+        # Gmail-mode body: duplicate + delete instead of set mailbox
+        assert "duplicate msg to destMailbox" in script
+        assert "delete msg" in script
+        assert "repeat with acc in accounts" not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_move_messages_no_source_keeps_cross_scan(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "1"
+        connector.move_messages(
+            ["abc"], destination_mailbox="Archive", account="Gmail"
+        )
+        script = mock_run.call_args[0][0]
+        assert "repeat with acc in accounts" in script
+        assert "repeat with mb in mailboxes" in script
+
 
 class TestWhoseIdQuoting:
     """Regression guards for #86: `whose id is X` must wrap X in quotes

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -661,8 +661,20 @@ class TestMarkAsRead:
         assert result["success"] is True
         assert result["updated"] == 3
         assert result["requested"] == 3
-        mock_mail.mark_as_read.assert_called_once_with(["1", "2", "3"], read=True)
+        mock_mail.mark_as_read.assert_called_once_with(
+            ["1", "2", "3"], read=True, account=None, source_mailbox=None
+        )
         mock_logger.log_operation.assert_called_once()
+
+    def test_passes_source_mailbox_through(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """When account+source_mailbox are provided, they reach the connector."""
+        mock_mail.mark_as_read.return_value = 1
+        mark_as_read(["1"], account="Gmail", source_mailbox="INBOX")
+        mock_mail.mark_as_read.assert_called_once_with(
+            ["1"], read=True, account="Gmail", source_mailbox="INBOX"
+        )
 
     def test_empty_list_fails_bulk_validation(
         self, mock_mail: MagicMock, mock_logger: MagicMock
@@ -1023,6 +1035,19 @@ class TestMoveMessages:
             destination_mailbox="Archive",
             account="Gmail",
             gmail_mode=False,
+            source_mailbox=None,
+        )
+
+    def test_passes_source_mailbox_through(self, mock_mail: MagicMock) -> None:
+        """source_mailbox reaches the connector when provided."""
+        mock_mail.move_messages.return_value = 1
+        move_messages(["1"], "Archive", "Gmail", source_mailbox="INBOX")
+        mock_mail.move_messages.assert_called_once_with(
+            message_ids=["1"],
+            destination_mailbox="Archive",
+            account="Gmail",
+            gmail_mode=False,
+            source_mailbox="INBOX",
         )
 
     def test_empty_list_early_exit(self, mock_mail: MagicMock) -> None:
@@ -1072,7 +1097,17 @@ class TestFlagMessage:
         assert result["count"] == 1
         assert result["flag_color"] == "red"
         mock_mail.flag_message.assert_called_once_with(
-            message_ids=["1"], flag_color="red"
+            message_ids=["1"], flag_color="red", account=None, source_mailbox=None
+        )
+
+    def test_passes_source_mailbox_through(self, mock_mail: MagicMock) -> None:
+        mock_mail.flag_message.return_value = 1
+        flag_message(["1"], "red", account="Gmail", source_mailbox="INBOX")
+        mock_mail.flag_message.assert_called_once_with(
+            message_ids=["1"],
+            flag_color="red",
+            account="Gmail",
+            source_mailbox="INBOX",
         )
 
     def test_empty_list_early_exit(self, mock_mail: MagicMock) -> None:
@@ -1194,7 +1229,22 @@ class TestDeleteMessages:
         assert result["count"] == 2
         assert result["permanent"] is False
         mock_mail.delete_messages.assert_called_once_with(
-            message_ids=["1", "2"], permanent=False, skip_bulk_check=False
+            message_ids=["1", "2"],
+            permanent=False,
+            skip_bulk_check=False,
+            account=None,
+            source_mailbox=None,
+        )
+
+    def test_passes_source_mailbox_through(self, mock_mail: MagicMock) -> None:
+        mock_mail.delete_messages.return_value = 1
+        delete_messages(["1"], account="Gmail", source_mailbox="INBOX")
+        mock_mail.delete_messages.assert_called_once_with(
+            message_ids=["1"],
+            permanent=False,
+            skip_bulk_check=False,
+            account="Gmail",
+            source_mailbox="INBOX",
         )
 
     def test_empty_list_early_exit(self, mock_mail: MagicMock) -> None:


### PR DESCRIPTION
Closes #103.

## Summary

All four bulk-mutation methods (\`mark_as_read\`, \`move_messages\`, \`flag_message\`, \`delete_messages\`) emitted AppleScript that scanned every account × every mailbox to find each message ID — O(N × accounts × mailboxes). On the maintainer's machine (4 accounts, 115 total mailboxes), 50-message bulk calls = 5,750 IMAP searches and timed out at 600s. This made bulk benchmarks (#31) impractical and silently slowed real-world usage on multi-account setups.

This PR adds an optional **paired** \`account\` + \`source_mailbox\` parameter to all four methods. When both are provided, the AppleScript narrows the scan to a single mailbox — **O(N) IMAP searches**, one per message ID. Cross-scan path preserved when neither is provided (backwards compatible).

## Measured speedup

Captured live on MobileMe (200+ messages in Sent Messages, 115 total mailboxes across 4 enabled accounts):

| Benchmark | Before | After | Speedup |
|-----------|--------|-------|---------|
| \`mark_as_read_50_msgs\` | 600s+ (timeout) | **3.65s** | ≥165× |
| \`move_messages_50_msgs\` | 600s+ (timeout) | **17.17s** (round-trip) | ≥35× |

The bulk benchmarks (#31) that have been skipping with a pointer to #103 now capture cleanly.

## Design

- **Paired params, all-or-nothing.** Mailbox name without account is ambiguous (\"INBOX\" exists on every IMAP account); either alone raises ValueError.
- **Backwards compatibility preserved.** Existing callers see no behavior change; the cross-scan path runs as before.
- **Shared helper** \`_bulk_repeat_block\` emits the narrow-vs-cross-scan AppleScript fragment, deduplicating the loop structure across all four methods.
- **Server wrappers** thread the new params through unchanged, with docstring examples showing the narrow-path call shape.

## Commits (one per method, plus shared helper, plus server wrappers, plus benchmark integration)

1. \`mark_as_read\` + \`_bulk_repeat_block\` helper
2. \`move_messages\` (both gmail/standard branches)
3. \`flag_message\` + \`delete_messages\`
4. Four MCP tool wrappers in \`server.py\`
5. Bulk benchmark fixture + captured baselines

## Spotted in passing (filed separately)

\`delete_messages(permanent=True)\` produces identical AppleScript to the default branch — the flag has been a no-op. Filed as **#111**. The pre-#103 code already had this issue; this PR collapses both branches behind the shared helper but preserves the parameter and acknowledges the no-op in the docstring.

## Test plan
- [x] \`make test\` — 595 unit tests pass (15 new across TestBulkOpsSourceMailbox + 4 server-level pass-through tests)
- [x] \`make check-all\` — green
- [x] Live capture on MobileMe — bulk benchmarks unblocked, baselines committed
- [x] Backwards compat — existing tests for all four methods (no source_mailbox) still pass

## Out of scope

- **Gmail-specific perf.** \`move_messages\` with \`gmail_mode=True\` shares the helper; Gmail's copy+delete model is its own perf characteristic and tracked in #101 (Gmail benchmarking).
- **Batch coalescing.** Even O(N) at 200ms per IMAP search is 10s for 50 messages. Could potentially batch with \`whose id is in {ids}\` — follow-up if users hit it.
- **\`search_messages_with_sender_filter\` regression.** Hit 60s AppleEvent timeout against MobileMe's large Sent folder during baseline capture — that's a \`search_messages\` issue, tracked in #32.
- **Removing the cross-scan path.** Stays as a fallback for now; deprecation is a post-1.0 decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)