### PR TITLE
fix(#111): deprecate delete_messages(permanent=True); document the gap

### DIFF
--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -782,14 +782,14 @@ create_mailbox(account="Gmail", name="Q2", parent_mailbox="2024")
 
 ### delete_messages
 
-Delete messages (move to trash or permanently delete).
+Delete messages — always moves them to the account's Trash mailbox.
 
 **Parameters:**
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `message_ids` | list[string] | Yes | - | List of message IDs to delete |
-| `permanent` | boolean | No | False | If True, permanently delete; if False, move to Trash |
+| `permanent` | boolean | No | False | Reserved; currently a no-op. Passing `True` emits a `DeprecationWarning`. See [issue #111](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/111). |
 
 **Returns:**
 
@@ -804,24 +804,19 @@ Delete messages (move to trash or permanently delete).
 **Examples:**
 
 ```python
-# Move messages to trash (safe)
+# Move messages to trash
 delete_messages(
     message_ids=["12345", "12346"],
-    permanent=False
-)
-
-# Permanently delete (cannot be undone!)
-delete_messages(
-    message_ids=["12347"],
-    permanent=True
 )
 ```
 
+**Note on `permanent`:**
+
+Mail.app's AppleScript dictionary exposes no path to permanent-delete that bypasses Trash. Calling `delete msg` always moves to the account's Trash; calling `delete` again on a message already in Trash is a no-op, and there is no `empty trash` command. The `permanent` parameter is preserved for API compatibility but currently has no effect; passing `True` raises a `DeprecationWarning` so the gap is visible. Track #111 for status.
+
 **Safety Notes:**
-- **Permanent deletion cannot be undone!**
 - Bulk deletions limited to 100 messages for safety
-- Default behavior moves to trash (recoverable)
-- Use `permanent=True` only when certain
+- All deletes are recoverable from the account's Trash mailbox until that mailbox is emptied (typically by Mail.app's per-account "empty trash" schedule, configurable in Mail's preferences)
 
 ---
 

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -6,6 +6,7 @@ import logging
 import re
 import subprocess
 import time
+import warnings
 from datetime import date as _date
 from datetime import timedelta as _timedelta
 from pathlib import Path
@@ -2011,14 +2012,15 @@ class AppleMailConnector:
         source_mailbox: str | None = None,
     ) -> int:
         """
-        Delete messages (move to trash or permanent delete).
+        Delete messages (always moves to the account's Trash mailbox).
 
         Args:
             message_ids: List of message IDs to delete
-            permanent: If True, permanently delete (bypass trash). NOTE:
-                this flag currently produces identical AppleScript as the
-                non-permanent path; the actual permanent-vs-trash behavior
-                is whatever Mail.app does by default for `delete msg`.
+            permanent: Reserved; currently a no-op. Mail.app's AppleScript
+                dictionary exposes no path to permanent-delete that bypasses
+                Trash — see issue #111. Passing True emits a
+                DeprecationWarning so callers see the discrepancy clearly
+                rather than silently relying on absent behavior.
             skip_bulk_check: If False, enforce bulk operation limits
             account: Optional account name (or UUID); see `source_mailbox`.
             source_mailbox: Optional source mailbox name. When provided
@@ -2027,7 +2029,7 @@ class AppleMailConnector:
                 Either alone raises ValueError.
 
         Returns:
-            Number of messages deleted
+            Number of messages deleted (moved to Trash)
 
         Raises:
             ValueError: If bulk check fails, or if exactly one of
@@ -2035,6 +2037,25 @@ class AppleMailConnector:
         """
         if not message_ids:
             return 0
+
+        # `permanent` was originally meant to bypass Trash, but empirical
+        # probing of Mail.app's AppleScript surface (issue #111) found no
+        # primitive that can permanently-delete:
+        #   - `delete msg` always moves to the account's Trash
+        #   - A second `delete` on a trashed message is a no-op
+        #   - There is no `empty trash` command in the dictionary
+        # Until / unless that changes, the parameter is reserved. Surface
+        # the gap loudly so MCP clients don't quietly trust a ghost knob.
+        if permanent:
+            warnings.warn(
+                "delete_messages(permanent=True) currently behaves "
+                "identically to permanent=False; Mail.app's AppleScript "
+                "dictionary does not expose a way to bypass Trash. "
+                "Messages are moved to the account's Trash mailbox in "
+                "both cases. See issue #111.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Safety check for bulk operations
         if not skip_bulk_check and len(message_ids) > 100:
@@ -2055,10 +2076,6 @@ class AppleMailConnector:
             counter_var="deleteCount",
         )
 
-        # `permanent` is preserved as a parameter but currently produces
-        # identical AppleScript — Mail.app's `delete msg` semantics handle
-        # both cases the same way today. If permanent-vs-trash needs to
-        # diverge in the future, branch here on `permanent`.
         script = f"""
         tell application "Mail"
             set idList to {{{id_list}}}

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -1617,11 +1617,15 @@ def delete_messages(
     source_mailbox: str | None = None,
 ) -> dict[str, Any]:
     """
-    Delete messages (move to trash or permanently delete).
+    Delete messages (always moves to the account's Trash mailbox).
 
     Args:
         message_ids: List of message IDs to delete
-        permanent: If True, permanently delete; if False, move to Trash (default: False)
+        permanent: Reserved; currently a no-op. Mail.app's AppleScript
+            dictionary exposes no path to permanent-delete that bypasses
+            Trash (issue #111). Passing True emits a DeprecationWarning;
+            messages still go to Trash. Recoverable from the account's
+            Trash mailbox until that mailbox is emptied.
         account: Optional account name (or UUID) the messages live in.
             Must be provided together with `source_mailbox`. When both
             are given, the operation is much faster.
@@ -1633,14 +1637,14 @@ def delete_messages(
     Example:
         delete_messages(
             message_ids=["12345"],
-            permanent=False,  # Move to trash
             account="Gmail",
             source_mailbox="INBOX",
         )
 
     Note:
         Bulk deletions are limited to 100 messages for safety.
-        Permanent deletion cannot be undone - use with caution.
+        All deletes are recoverable from Trash; there is currently no
+        AppleScript path to bypass it. See issue #111.
     """
     try:
         if not message_ids:
@@ -1662,8 +1666,7 @@ def delete_messages(
                 "error_type": "validation_error",
             }
 
-        delete_type = "permanently" if permanent else "to trash"
-        logger.info(f"Deleting {len(message_ids)} message(s) {delete_type}")
+        logger.info(f"Deleting {len(message_ids)} message(s) to trash")
 
         # Delete the messages
         count = mail.delete_messages(

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1,6 +1,7 @@
 """Unit tests for mail connector."""
 
 import logging
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -2361,19 +2362,40 @@ class TestBulkOpsSourceMailbox:
         assert "repeat with acc in accounts" not in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_delete_messages_permanent_narrow_path(
+    def test_delete_messages_permanent_emits_deprecation_warning(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
+        """Issue #111: Mail.app exposes no AppleScript path to bypass Trash.
+        `permanent=True` is a no-op; warn so callers don't silently rely on
+        absent behavior."""
         mock_run.return_value = "1"
-        connector.delete_messages(
-            ["abc"],
-            permanent=True,
-            account="iCloud",
-            source_mailbox="Junk",
-        )
+        with pytest.warns(DeprecationWarning, match="#111"):
+            connector.delete_messages(
+                ["abc"],
+                permanent=True,
+                account="iCloud",
+                source_mailbox="Junk",
+            )
+        # Script shape unchanged from the non-permanent path: `delete msg`
+        # always moves to the account's Trash mailbox today.
         script = mock_run.call_args[0][0]
         assert 'mailbox "Junk" of' in script
+        assert "delete msg" in script
         assert "repeat with acc in accounts" not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_delete_messages_default_does_not_warn(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """The default path (permanent=False) must not emit DeprecationWarning."""
+        mock_run.return_value = "1"
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            connector.delete_messages(
+                ["abc"],
+                account="iCloud",
+                source_mailbox="Junk",
+            )
 
     def test_delete_messages_partial_pair_raises(
         self, connector: AppleMailConnector

--- a/tests/unit/test_message_management.py
+++ b/tests/unit/test_message_management.py
@@ -353,19 +353,22 @@ class TestDeleteMessages:
         assert result == 3
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_permanent_delete(
+    def test_permanent_delete_warns_and_still_returns_count(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """Test permanent deletion (bypass trash)."""
+        """Issue #111: permanent=True emits a DeprecationWarning since
+        Mail.app exposes no AppleScript path that actually bypasses Trash.
+        The call still succeeds (messages are moved to Trash like the
+        default path) and returns the count."""
         mock_run.return_value = "1"
 
-        result = connector.delete_messages(
-            message_ids=["12345"],
-            permanent=True
-        )
+        with pytest.warns(DeprecationWarning, match="#111"):
+            result = connector.delete_messages(
+                message_ids=["12345"],
+                permanent=True
+            )
 
         assert result == 1
-        # Permanent delete should have different script
 
     def test_delete_empty_list(self, connector: AppleMailConnector) -> None:
         """Test deleting with empty message list."""

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1285,6 +1285,26 @@ class TestDeleteMessages:
         assert result["success"] is False
         assert result["error_type"] == "unknown"
 
+    def test_permanent_true_threads_through_to_connector(
+        self, mock_mail: MagicMock
+    ) -> None:
+        """Issue #111: the connector emits a DeprecationWarning when
+        permanent=True; the server's job is just to forward the flag
+        unchanged so the warning fires from the user's call frame."""
+        mock_mail.delete_messages.return_value = 1
+        result = delete_messages(["1"], permanent=True)
+        assert result["success"] is True
+        # Server still echoes the (now-meaningless) flag in its response
+        # for backwards compatibility with existing callers.
+        assert result["permanent"] is True
+        mock_mail.delete_messages.assert_called_once_with(
+            message_ids=["1"],
+            permanent=True,
+            skip_bulk_check=False,
+            account=None,
+            source_mailbox=None,
+        )
+
 
 # ---------------------------------------------------------------------------
 # 13. reply_to_message


### PR DESCRIPTION
## Summary

- `delete_messages(permanent=True)` was a silent no-op — emitted identical AppleScript to `permanent=False`.
- Mail.app's AppleScript dictionary exposes **no** path to permanent-delete that bypasses Trash. Verified empirically (probe results below).
- Path chosen: **deprecate honestly**. Surface a `DeprecationWarning`, fix the user-facing docs, keep the parameter for backwards compat.

## Empirical probe

Ran against the MobileMe test account using `osascript`:

| Step | Action | Result |
|------|--------|--------|
| 1 | `delete msg` (msg in regular mailbox) | Moves to per-account "Deleted Messages". ID changes (IMAP UID semantics): 160699 → 160739. |
| 2 | `delete <trashed_msg>` | **No-op.** Trash count unchanged (1 → 1); same id still present after. |
| 3 | `delete (messages of trashMb whose id is X)` | **No-op.** Same result as step 2. |

So the two-step pattern (`delete` → `delete from Trash`) does not work — the second `delete` does nothing on a message already in Trash. There's also no `empty trash` command in the dictionary; only account-level preferences `empty trash frequency` and `empty trash on quit`. ⇒ **No AppleScript-reachable permanent-delete.**

## Changes

### Connector (`src/apple_mail_mcp/mail_connector.py`)

- `delete_messages(permanent=True)` now emits `DeprecationWarning` (with `stacklevel=2` so the warning fires from the caller's frame).
- Parameter preserved unchanged; AppleScript still always emits `delete msg`. Docstring rewritten to be honest about current behavior and reference #111.

### Server tool (`src/apple_mail_mcp/server.py`)

- Docstring rewritten: dropped the false "move to trash or permanently delete" promise. Now: "always moves to the account's Trash mailbox" with a clear pointer to #111.
- `permanent` still threads through to the connector so the warning fires from the user's call site.

### Docs (`docs/reference/TOOLS.md`)

- Replaced the misleading "Permanent deletion cannot be undone" Safety Notes with an honest "Note on `permanent`" explaining the AppleScript limitation.
- Examples updated to drop the now-meaningless `permanent=False` argument.

### Tests

- New `test_delete_messages_permanent_emits_deprecation_warning` + `test_delete_messages_default_does_not_warn` (connector level).
- Rewrote pre-existing `test_permanent_delete` to capture the warning rather than leak it.
- New server-level `test_permanent_true_threads_through_to_connector` confirms the flag still flows through.
- Net: 600 unit tests pass with zero leaked warnings.

## Test plan

- [x] `make test` — 600/600 green
- [x] `make check-all` — green
- [x] Empirical probe captured & non-destructive (test message restored to bench mailbox)
- [ ] Manual smoke: post-merge, call `delete_messages(permanent=True)` from Claude Desktop and verify the deprecation warning surfaces

## Non-goals

- **Not removing the parameter.** That'd be a breaking change for existing MCP clients. v1.0 can revisit.
- **No `empty trash` implementation.** Mail.app doesn't expose it via AppleScript. A future enhancement could explore IMAP `EXPUNGE` for IMAP-delegated accounts (out of scope here).
- **No behavior change to the default path.** `delete_messages()` still moves to Trash, recoverable as before.

Closes #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)