### PR TITLE
feat(#75): add ImapConnectionPool — opt-in IMAP session reuse

### DIFF
--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -24,13 +24,18 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from datetime import date as _date
 from datetime import datetime as _datetime
 from datetime import timedelta as _timedelta
 from typing import Any
 
 from imapclient import IMAPClient
-from imapclient.exceptions import IMAPClientError
+from imapclient.exceptions import IMAPClientError, LoginError
 from imapclient.response_types import Envelope
 
 from .exceptions import MailMessageNotFoundError
@@ -49,8 +54,137 @@ CONNECT_TIMEOUT_S: float = 3.0
 fallback happens inside the graceful-degradation window without
 waiting for TCP's default timeout."""
 
+POOL_IDLE_TIMEOUT_S: float = 270.0
+"""Default pool idle threshold. iCloud and most providers drop IMAP
+sessions after ~30 min idle. 270s = 4.5 min keeps us comfortably under
+that while still amortizing connect cost across realistic interactive
+bursts (a series of search → get_message → get_attachments calls within
+a couple minutes of each other reuses one connection)."""
+
 _FLAG_SEEN = b"\\Seen"
 _FLAG_FLAGGED = b"\\Flagged"
+
+
+# ---------------------------------------------------------------------------
+# Connection pool (issue #75)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _PooledClient:
+    """Tracks one cached IMAPClient: the connection, a lock that
+    serializes its use across threads, and a monotonic timestamp for
+    idle-timeout decisions."""
+
+    client: IMAPClient
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    last_used: float = field(default_factory=time.monotonic)
+
+
+# Exceptions that should invalidate a pooled connection. LoginError /
+# IMAPClientError are direct protocol failures; OSError catches mid-
+# session network drops (broken pipe, conn reset). MailMessageNotFoundError
+# is NOT here — it's a clean "no match" answer, not a connection failure.
+_POOL_INVALIDATE_EXCS: tuple[type[BaseException], ...] = (
+    LoginError,
+    IMAPClientError,
+    OSError,
+)
+
+
+class ImapConnectionPool:
+    """Reuses IMAPClient sessions across calls keyed by (host, email).
+
+    Per the issue #75 design: opt-in (per-call lifecycle remains the
+    default in :class:`ImapConnector` until a pool is explicitly
+    passed). Lazy-reconnect on error and on idle timeout — if the
+    cached client is stale, the next ``session()`` drops it and opens
+    a fresh one transparently.
+
+    Thread-safety:
+    - The cache dict is guarded by ``_cache_lock``.
+    - Each cached client has its own per-connection lock that
+      ``session()`` holds for the duration of the yielded block.
+      Concurrent calls to the same (host, email) serialize; concurrent
+      calls to different keys run in parallel.
+    """
+
+    def __init__(self, *, idle_timeout_s: float = POOL_IDLE_TIMEOUT_S) -> None:
+        self._cache: dict[tuple[str, str], _PooledClient] = {}
+        self._cache_lock = threading.Lock()
+        self._idle_timeout_s = idle_timeout_s
+
+    @contextmanager
+    def session(
+        self,
+        host: str,
+        port: int,
+        email: str,
+        password: str,
+        connect_timeout: float,
+    ) -> Iterator[IMAPClient]:
+        """Yield a logged-in IMAPClient for use; manage its lifecycle.
+
+        On clean exit: bump ``last_used`` and keep the entry cached.
+
+        On failure of one of ``_POOL_INVALIDATE_EXCS``: drop the entry
+        (attempt logout, swallow logout errors) so the next call gets
+        a fresh connection. The original exception still propagates;
+        the orchestrator's existing fallback logic catches it.
+        """
+        key = (host, email)
+
+        with self._cache_lock:
+            entry = self._cache.get(key)
+            stale = (
+                entry is not None
+                and time.monotonic() - entry.last_used > self._idle_timeout_s
+            )
+            if entry is None or stale:
+                if entry is not None:
+                    # Stale — try to be polite about closing it.
+                    self._cache.pop(key, None)
+                    try:
+                        entry.client.logout()
+                    except Exception:  # noqa: BLE001 — best effort
+                        pass
+                client = IMAPClient(
+                    host, port=port, ssl=True, timeout=connect_timeout
+                )
+                client.login(email, password)
+                entry = _PooledClient(client=client)
+                self._cache[key] = entry
+
+        # Acquire the per-connection lock OUTSIDE the cache lock — we
+        # don't want a slow operation on one connection blocking cache
+        # reads for unrelated keys.
+        with entry.lock:
+            try:
+                yield entry.client
+            except _POOL_INVALIDATE_EXCS:
+                # Connection-level failure: drop and propagate.
+                with self._cache_lock:
+                    # Only drop if it's still the same entry — another
+                    # thread may have already reconnected.
+                    if self._cache.get(key) is entry:
+                        self._cache.pop(key, None)
+                try:
+                    entry.client.logout()
+                except Exception:  # noqa: BLE001 — best effort
+                    pass
+                raise
+            else:
+                entry.last_used = time.monotonic()
+
+    def close(self) -> None:
+        """Log out all cached clients. Safe to call multiple times."""
+        with self._cache_lock:
+            entries = list(self._cache.values())
+            self._cache.clear()
+        for entry in entries:
+            try:
+                entry.client.logout()
+            except Exception:  # noqa: BLE001 — best effort
+                pass
 
 _IMAP_MONTHS = (
     "Jan",
@@ -313,12 +447,42 @@ class ImapConnector:
         email: str,
         password: str,
         connect_timeout: float = CONNECT_TIMEOUT_S,
+        *,
+        pool: ImapConnectionPool | None = None,
     ) -> None:
         self._host = host
         self._port = port
         self._email = email
         self._password = password
         self._connect_timeout = connect_timeout
+        self._pool = pool
+
+    @contextmanager
+    def _session(self) -> Iterator[IMAPClient]:
+        """Yield a logged-in IMAPClient. Routes through the pool when
+        one was provided at construction; otherwise opens and closes a
+        fresh connection per call (the v0.5.0 behavior).
+
+        All four public methods of this connector (search_messages,
+        get_message, get_attachments, find_thread_members) use this
+        helper so the pool / no-pool decision lives in exactly one place.
+        """
+        if self._pool is not None:
+            with self._pool.session(
+                self._host, self._port, self._email,
+                self._password, self._connect_timeout,
+            ) as client:
+                yield client
+            return
+
+        client = IMAPClient(
+            self._host, port=self._port, ssl=True, timeout=self._connect_timeout
+        )
+        try:
+            client.login(self._email, self._password)
+            yield client
+        finally:
+            client.logout()
 
     def search_messages(
         self,
@@ -343,11 +507,7 @@ class ImapConnector:
             date_to,
         )
 
-        client = IMAPClient(
-            self._host, port=self._port, ssl=True, timeout=self._connect_timeout
-        )
-        try:
-            client.login(self._email, self._password)
+        with self._session() as client:
             client.select_folder(mailbox, readonly=True)
 
             uids = client.search(criteria)
@@ -377,8 +537,6 @@ class ImapConnector:
                     _envelope_to_dict(entry[b"ENVELOPE"], tuple(entry[b"FLAGS"]))
                 )
             return results
-        finally:
-            client.logout()
 
     def get_message(
         self,
@@ -443,11 +601,7 @@ class ImapConnector:
             # servers send less data this way; some don't care.
             fetch_keys.append(b"BODY[HEADER]")
 
-        client = IMAPClient(
-            self._host, port=self._port, ssl=True, timeout=self._connect_timeout
-        )
-        try:
-            client.login(self._email, self._password)
+        with self._session() as client:
             client.select_folder(mailbox, readonly=True)
 
             uids = client.search(["HEADER", "Message-ID", bracketed])
@@ -469,8 +623,6 @@ class ImapConnector:
             else:
                 result["content"] = ""
             return result
-        finally:
-            client.logout()
 
     def get_attachments(
         self,
@@ -516,11 +668,7 @@ class ImapConnector:
             else f"<{message_id}>"
         )
 
-        client = IMAPClient(
-            self._host, port=self._port, ssl=True, timeout=self._connect_timeout
-        )
-        try:
-            client.login(self._email, self._password)
+        with self._session() as client:
             client.select_folder(mailbox, readonly=True)
 
             uids = client.search(["HEADER", "Message-ID", bracketed])
@@ -535,8 +683,6 @@ class ImapConnector:
             return _bodystructure_extract_attachments(
                 entry.get(b"BODYSTRUCTURE")
             )
-        finally:
-            client.logout()
 
     def find_thread_members(
         self,
@@ -570,11 +716,7 @@ class ImapConnector:
         """
         known_ids: set[str] = {anchor_rfc_message_id} | set(anchor_references)
 
-        client = IMAPClient(
-            self._host, port=self._port, ssl=True, timeout=self._connect_timeout
-        )
-        try:
-            client.login(self._email, self._password)
+        with self._session() as client:
             mailboxes = client.list_folders()
             collected: dict[str, dict[str, Any]] = {}
 
@@ -639,5 +781,3 @@ class ImapConnector:
                 collected.values(),
                 key=lambda m: m.get("date_received") or "",
             )
-        finally:
-            client.logout()

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -24,7 +24,7 @@ from .exceptions import (
     MailRuleNotFoundError,
     MailUnsupportedRuleActionError,
 )
-from .imap_connector import ImapConnector
+from .imap_connector import ImapConnectionPool, ImapConnector
 from .keychain import get_imap_password
 from .utils import (
     applescript_account_clause,
@@ -204,14 +204,26 @@ def _bulk_repeat_block(
 class AppleMailConnector:
     """Interface to Apple Mail via AppleScript."""
 
-    def __init__(self, timeout: int = 60) -> None:
+    def __init__(
+        self,
+        timeout: int = 60,
+        *,
+        imap_pool: ImapConnectionPool | None = None,
+    ) -> None:
         """
         Initialize the Mail connector.
 
         Args:
-            timeout: Timeout in seconds for AppleScript operations
+            timeout: Timeout in seconds for AppleScript operations.
+            imap_pool: Optional ImapConnectionPool. When provided, every
+                IMAP-delegated call (search_messages, get_message,
+                get_attachments, get_thread) reuses cached connections
+                across calls, amortizing the ~400 ms TCP+TLS+LOGIN
+                overhead per call. Default None (per-call lifecycle —
+                the v0.5.0 behavior). See issue #75.
         """
         self.timeout = timeout
+        self._imap_pool = imap_pool
         # Accounts for which we've already logged a WARNING about IMAP failure.
         # Subsequent failures for the same account are demoted to DEBUG per
         # invariant 5 in docs/research/imap-auth-options-decision.md.
@@ -894,7 +906,7 @@ class AppleMailConnector:
         """
         host, port, email = self._resolve_imap_config(account)
         password = get_imap_password(account, email)
-        imap = ImapConnector(host, port, email, password)
+        imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.search_messages(
             mailbox=mailbox,
             sender_contains=sender_contains,
@@ -1207,7 +1219,7 @@ class AppleMailConnector:
         """
         host, port, email = self._resolve_imap_config(account)
         password = get_imap_password(account, email)
-        imap = ImapConnector(host, port, email, password)
+        imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.get_message(
             message_id,
             mailbox=mailbox,
@@ -1577,7 +1589,7 @@ class AppleMailConnector:
         """
         host, port, email = self._resolve_imap_config(account)
         password = get_imap_password(account, email)
-        imap = ImapConnector(host, port, email, password)
+        imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.get_attachments(message_id, mailbox=mailbox)
 
     def _get_attachments_applescript(
@@ -1675,7 +1687,7 @@ class AppleMailConnector:
         account = cast(str, anchor["account"])
         host, port, email = self._resolve_imap_config(account)
         password = get_imap_password(account, email)
-        imap = ImapConnector(host, port, email, password)
+        imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.find_thread_members(
             anchor_rfc_message_id=cast(str, anchor["rfc_message_id"]),
             anchor_references=cast(list[str], anchor.get("references") or []),

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -22,6 +22,7 @@ from .exceptions import (
     MailTemplateNotFoundError,
     MailUnsupportedRuleActionError,
 )
+from .imap_connector import ImapConnectionPool
 from .mail_connector import AppleMailConnector
 from .security import (
     check_rate_limit,
@@ -42,8 +43,25 @@ logger = logging.getLogger(__name__)
 # Create FastMCP server
 mcp = FastMCP("apple-mail")
 
-# Initialize mail connector
-mail = AppleMailConnector()
+# Initialize mail connector. Pool is opt-in via APPLE_MAIL_MCP_IMAP_POOL=1
+# (default off, per #75 acceptance criteria — keep per-call lifecycle the
+# default until benchmarks prove the speedup is worth the lifecycle
+# complexity, then a follow-up can flip the default).
+def _build_imap_pool() -> ImapConnectionPool | None:
+    """Build an ImapConnectionPool when the opt-in env var is set.
+
+    Pooling stays opt-in per #75's acceptance criteria: per-call lifecycle
+    is the default until benchmarks prove the speedup is worth the
+    lifecycle complexity, then a follow-up can flip the default."""
+    import os
+    flag = os.getenv("APPLE_MAIL_MCP_IMAP_POOL", "0").strip().lower()
+    if flag in ("1", "true", "yes", "on"):
+        logger.info("IMAP connection pool enabled (APPLE_MAIL_MCP_IMAP_POOL)")
+        return ImapConnectionPool()
+    return None
+
+
+mail = AppleMailConnector(imap_pool=_build_imap_pool())
 
 
 def _build_send_summary(

--- a/tests/benchmarks/baseline.json
+++ b/tests/benchmarks/baseline.json
@@ -1,4 +1,6 @@
 {
+  "imap_repeat_5_calls_no_pool": 10.603,
+  "imap_repeat_5_calls_pooled": 6.33,
   "mark_as_read_50_msgs": 3.65,
   "move_messages_50_msgs": 17.167,
   "save_attachments_one_file": 0.432,

--- a/tests/benchmarks/test_imap_pool.py
+++ b/tests/benchmarks/test_imap_pool.py
@@ -1,0 +1,149 @@
+"""Benchmarks for the IMAP connection pool (issue #75).
+
+Per #75's acceptance criterion: a benchmark must demonstrate measurable
+speedup on a realistic repeat-call workflow. The shape is the natural
+interactive burst — search → get_message → get_attachments → search →
+get_message — five sequential IMAP calls against the same account.
+
+Skips gracefully when:
+- No Keychain entry for the test account (IMAP path can't run).
+- The test account's INBOX is empty (no message id to feed get_message
+  / get_attachments).
+
+Two benchmarks captured side by side:
+- ``imap_repeat_5_calls_no_pool`` — current behavior, one TCP+TLS+LOGIN
+  per call (~5 × ~400 ms overhead).
+- ``imap_repeat_5_calls_pooled`` — one connection reused across all
+  five calls (~1 × ~400 ms overhead).
+
+The delta is the pool's headline win.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apple_mail_mcp.imap_connector import ImapConnectionPool
+from apple_mail_mcp.mail_connector import AppleMailConnector
+
+from .conftest import (
+    BenchmarkResult,
+    assert_within_baseline,
+    measure_median,
+)
+
+
+def _skip_if_no_imap(
+    connector: AppleMailConnector, test_account: str
+) -> tuple[str, str]:
+    """Verify IMAP is configured for the test account; skip if not.
+
+    Returns (mailbox, message_id) for the burst. Tries common mailbox
+    names in order; uses whichever has at least one message. Matches
+    the `benchmark_mailbox` fixture pattern in test_search.py.
+    """
+    from apple_mail_mcp.exceptions import (
+        MailKeychainAccessDeniedError,
+        MailKeychainEntryNotFoundError,
+    )
+    from apple_mail_mcp.keychain import get_imap_password
+
+    try:
+        _, _, email = connector._resolve_imap_config(test_account)
+        get_imap_password(test_account, email)
+    except (MailKeychainEntryNotFoundError, MailKeychainAccessDeniedError):
+        pytest.skip(
+            f"No Keychain entry for {test_account!r} — pool can't be "
+            f"exercised. Run `apple-mail-mcp setup-imap` first."
+        )
+
+    for mb in ("INBOX", "Archive", "Sent Messages"):
+        try:
+            matches = connector.search_messages(
+                account=test_account, mailbox=mb, limit=1,
+            )
+        except Exception:
+            continue
+        if matches:
+            return (mb, matches[0]["id"])
+
+    pytest.skip(
+        f"No mailbox in {test_account!r} has any messages "
+        f"(checked INBOX, Archive, Sent Messages)."
+    )
+
+
+def _five_call_burst(
+    connector: AppleMailConnector,
+    test_account: str,
+    mailbox: str,
+    message_id: str,
+) -> None:
+    """The realistic interactive burst: two searches plus message and
+    attachment fetches against the same account/mailbox. Designed to
+    mirror what an agent does when narrowing down a query and inspecting
+    a hit."""
+    connector.search_messages(account=test_account, mailbox=mailbox, limit=5)
+    connector.get_message(message_id, account=test_account, mailbox=mailbox)
+    connector.get_attachments(message_id, account=test_account, mailbox=mailbox)
+    connector.search_messages(
+        account=test_account, mailbox=mailbox, sender_contains="@", limit=5,
+    )
+    connector.get_message(message_id, account=test_account, mailbox=mailbox)
+
+
+def test_imap_repeat_5_calls_no_pool(
+    connector: AppleMailConnector,
+    test_account: str,
+    baselines: dict[str, float],
+    capture_mode: bool,
+) -> None:
+    """Baseline: per-call lifecycle (the current default). Each of the
+    five calls eats its own TCP + TLS + LOGIN handshake."""
+    mailbox, message_id = _skip_if_no_imap(connector, test_account)
+    name = "imap_repeat_5_calls_no_pool"
+
+    result: BenchmarkResult = measure_median(
+        lambda: _five_call_burst(connector, test_account, mailbox, message_id),
+        name=name,
+    )
+    assert_within_baseline(name, result, baselines, capture_mode)
+
+
+def test_imap_repeat_5_calls_pooled(
+    test_account: str,
+    baselines: dict[str, float],
+    capture_mode: bool,
+) -> None:
+    """The same five-call burst with the pool enabled. One TCP + TLS +
+    LOGIN amortized across all five calls.
+
+    Uses a fresh AppleMailConnector with `imap_pool=ImapConnectionPool()`
+    rather than the session-scoped fixture, so the pool starts empty
+    for each repeat in `measure_median` and reuses the connection only
+    within a single iteration. This isolates the per-iteration savings
+    cleanly: each iteration pays exactly one connect + login, then five
+    operations.
+
+    A real production server would keep the pool alive across many
+    iterations (an even bigger win), but pretending the pool is fresh
+    each time gives a conservative lower-bound estimate of the speedup
+    that doesn't depend on how stale `last_used` happens to be at
+    measurement time.
+    """
+    pool = ImapConnectionPool()
+    pooled_connector = AppleMailConnector(timeout=600, imap_pool=pool)
+    mailbox, message_id = _skip_if_no_imap(pooled_connector, test_account)
+    name = "imap_repeat_5_calls_pooled"
+
+    def run() -> None:
+        # Drop any cached connection from the previous iteration so each
+        # iteration's amortization is observable independently.
+        pool.close()
+        _five_call_burst(pooled_connector, test_account, mailbox, message_id)
+
+    try:
+        result: BenchmarkResult = measure_median(run, name=name)
+        assert_within_baseline(name, result, baselines, capture_mode)
+    finally:
+        pool.close()

--- a/tests/unit/test_imap_pool.py
+++ b/tests/unit/test_imap_pool.py
@@ -1,0 +1,509 @@
+"""Tests for ImapConnectionPool (issue #75).
+
+The pool reuses IMAPClient sessions across calls keyed by (host, email).
+These tests cover:
+
+- Reuse: same key → same client; login() runs once across N calls.
+- Per-account isolation: different keys → independent clients/locks.
+- Idle reconnect: stale entries are dropped + reopened transparently.
+- Error invalidation: LoginError / IMAPClientError / OSError drops the
+  cached entry so the next call gets a fresh connection.
+- Per-connection locking: one client serializes use across threads.
+- close(): logs out every cached client.
+- ImapConnector wiring: methods route through the pool when one is set.
+
+The IMAPClient class itself is mocked at the module level — these are
+unit tests, no real network.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from imapclient.exceptions import IMAPClientError, LoginError
+
+from apple_mail_mcp.imap_connector import (
+    POOL_IDLE_TIMEOUT_S,
+    ImapConnectionPool,
+    ImapConnector,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pool() -> ImapConnectionPool:
+    """Default pool — production idle threshold."""
+    return ImapConnectionPool()
+
+
+@pytest.fixture
+def short_idle_pool() -> ImapConnectionPool:
+    """Pool with a tiny idle window for the reconnect tests."""
+    return ImapConnectionPool(idle_timeout_s=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Reuse + per-account isolation
+# ---------------------------------------------------------------------------
+
+
+class TestSessionReuse:
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_two_consecutive_calls_share_one_client(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """The headline win: two calls to the same (host, email) reuse one
+        IMAPClient instance — IMAPClient() called once, login() called once."""
+        client = MagicMock()
+        mock_cls.return_value = client
+
+        with pool.session("h", 993, "u@e.com", "pw", 3.0) as c1:
+            assert c1 is client
+        with pool.session("h", 993, "u@e.com", "pw", 3.0) as c2:
+            assert c2 is client
+
+        mock_cls.assert_called_once()
+        client.login.assert_called_once_with("u@e.com", "pw")
+        # No logout between calls — connection stays alive.
+        client.logout.assert_not_called()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_different_accounts_get_independent_clients(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """Two different (host, email) keys produce two separate clients,
+        connected once each."""
+        clients = [MagicMock(), MagicMock()]
+        mock_cls.side_effect = clients
+
+        with pool.session("h1", 993, "a@e.com", "pw", 3.0) as c1:
+            assert c1 is clients[0]
+        with pool.session("h2", 993, "b@e.com", "pw", 3.0) as c2:
+            assert c2 is clients[1]
+
+        assert mock_cls.call_count == 2
+        clients[0].login.assert_called_once_with("a@e.com", "pw")
+        clients[1].login.assert_called_once_with("b@e.com", "pw")
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_same_host_different_email_are_separate(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """Pool key is (host, email), not just host. Two users on the
+        same server need independent sessions."""
+        clients = [MagicMock(), MagicMock()]
+        mock_cls.side_effect = clients
+
+        with pool.session("h", 993, "alice@e.com", "pw", 3.0):
+            pass
+        with pool.session("h", 993, "bob@e.com", "pw", 3.0):
+            pass
+
+        assert mock_cls.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Idle reconnect
+# ---------------------------------------------------------------------------
+
+
+class TestIdleReconnect:
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_stale_entry_is_dropped_and_reopened(
+        self, mock_cls: MagicMock,
+        short_idle_pool: ImapConnectionPool,
+    ) -> None:
+        """If `now - last_used > idle_timeout`, the next session() call
+        drops the cached client (logging it out politely) and opens a
+        fresh one. Tests use a 10ms idle window so we don't sleep long."""
+        clients = [MagicMock(), MagicMock()]
+        mock_cls.side_effect = clients
+
+        with short_idle_pool.session("h", 993, "u@e.com", "pw", 3.0):
+            pass
+
+        # Wait long enough for the entry to be considered stale.
+        time.sleep(0.05)
+
+        with short_idle_pool.session("h", 993, "u@e.com", "pw", 3.0) as c:
+            assert c is clients[1]  # second client, fresh connection
+
+        assert mock_cls.call_count == 2
+        # Old client was logged out before being replaced.
+        clients[0].logout.assert_called_once()
+        clients[1].logout.assert_not_called()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_within_idle_window_reuses(
+        self, mock_cls: MagicMock,
+        pool: ImapConnectionPool,
+    ) -> None:
+        """The default 270s window comfortably covers any tight burst of
+        calls a user / agent makes in succession."""
+        client = MagicMock()
+        mock_cls.return_value = client
+
+        for _ in range(5):
+            with pool.session("h", 993, "u@e.com", "pw", 3.0):
+                pass
+
+        mock_cls.assert_called_once()
+        client.login.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Error invalidation
+# ---------------------------------------------------------------------------
+
+
+class TestErrorInvalidation:
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_login_error_drops_entry(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """A LoginError raised inside the session block (e.g. server
+        decided mid-session our auth is no longer valid) drops the
+        cached entry. The exception still propagates so the orchestrator
+        can fall back to AppleScript."""
+        clients = [MagicMock(), MagicMock()]
+        mock_cls.side_effect = clients
+
+        with pytest.raises(LoginError):
+            with pool.session("h", 993, "u@e.com", "pw", 3.0):
+                raise LoginError("rejected")
+
+        # Next call must reconnect — the bad entry was dropped.
+        with pool.session("h", 993, "u@e.com", "pw", 3.0):
+            pass
+
+        assert mock_cls.call_count == 2
+        clients[0].logout.assert_called_once()  # invalidation tries to be polite
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_imap_client_error_drops_entry(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """Protocol-level error mid-session (e.g. server returned BAD,
+        connection went away). Same invalidation path as LoginError."""
+        clients = [MagicMock(), MagicMock()]
+        mock_cls.side_effect = clients
+
+        with pytest.raises(IMAPClientError):
+            with pool.session("h", 993, "u@e.com", "pw", 3.0):
+                raise IMAPClientError("BAD command")
+
+        with pool.session("h", 993, "u@e.com", "pw", 3.0):
+            pass
+
+        assert mock_cls.call_count == 2
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_oserror_drops_entry(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """Network drop mid-session (broken pipe, conn reset). Pool must
+        invalidate so the next call reconnects rather than blindly
+        reusing a dead socket."""
+        clients = [MagicMock(), MagicMock()]
+        mock_cls.side_effect = clients
+
+        with pytest.raises(OSError):
+            with pool.session("h", 993, "u@e.com", "pw", 3.0):
+                raise OSError("broken pipe")
+
+        with pool.session("h", 993, "u@e.com", "pw", 3.0):
+            pass
+
+        assert mock_cls.call_count == 2
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_logout_failure_during_invalidation_is_swallowed(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """If the cached client's logout() ITSELF raises during
+        invalidation (the connection is already dead, so logout would
+        too), we swallow it. The original exception still propagates."""
+        clients = [MagicMock(), MagicMock()]
+        clients[0].logout.side_effect = OSError("logout: broken")
+        mock_cls.side_effect = clients
+
+        with pytest.raises(IMAPClientError, match="BAD"):
+            with pool.session("h", 993, "u@e.com", "pw", 3.0):
+                raise IMAPClientError("BAD")
+
+        # Cache is empty; next call reconnects cleanly.
+        with pool.session("h", 993, "u@e.com", "pw", 3.0):
+            pass
+
+        assert mock_cls.call_count == 2
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_non_invalidating_exception_keeps_entry_cached(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """An exception NOT in _POOL_INVALIDATE_EXCS — e.g. a clean
+        MailMessageNotFoundError that the caller surfaces as a
+        not-found result — should NOT drop the connection. The session
+        is still valid; the message just wasn't there."""
+        client = MagicMock()
+        mock_cls.return_value = client
+
+        with pytest.raises(ValueError):
+            with pool.session("h", 993, "u@e.com", "pw", 3.0):
+                raise ValueError("not a connection-level failure")
+
+        # Same key reuses the same client — no invalidation happened.
+        with pool.session("h", 993, "u@e.com", "pw", 3.0):
+            pass
+
+        mock_cls.assert_called_once()
+        client.logout.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Per-connection locking
+# ---------------------------------------------------------------------------
+
+
+class TestPerConnectionLocking:
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_same_key_serializes_across_threads(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """Two threads asking for the same (host, email) at once must
+        not run inside `with session()` simultaneously — IMAPClient is
+        not safe for concurrent use on one connection.
+
+        Held by thread A: thread B blocks until A exits the with-block.
+        """
+        client = MagicMock()
+        mock_cls.return_value = client
+
+        a_inside = threading.Event()
+        a_release = threading.Event()
+        b_done = threading.Event()
+        observed_overlap = threading.Event()
+
+        def thread_a() -> None:
+            with pool.session("h", 993, "u@e.com", "pw", 3.0):
+                a_inside.set()
+                a_release.wait(timeout=2)
+                if b_done.is_set():
+                    observed_overlap.set()
+
+        def thread_b() -> None:
+            a_inside.wait(timeout=2)
+            with pool.session("h", 993, "u@e.com", "pw", 3.0):
+                b_done.set()
+
+        ta = threading.Thread(target=thread_a)
+        tb = threading.Thread(target=thread_b)
+        ta.start()
+        tb.start()
+
+        # Give B a moment — if it managed to enter while A is holding,
+        # b_done would fire before a_release.
+        time.sleep(0.05)
+        b_done_during_a = b_done.is_set()
+        a_release.set()
+        ta.join(timeout=2)
+        tb.join(timeout=2)
+
+        # B must NOT have entered while A was holding the per-connection lock.
+        assert not b_done_during_a, "Lock failed: B entered while A held"
+        assert b_done.is_set()
+        assert not observed_overlap.is_set()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_different_keys_run_concurrently(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """The cache lock is held only for dict lookup. Two threads
+        accessing different (host, email) keys must NOT serialize."""
+        clients = [MagicMock(), MagicMock()]
+        mock_cls.side_effect = clients
+
+        a_inside = threading.Event()
+        b_inside = threading.Event()
+        release = threading.Event()
+        both_were_inside = threading.Event()
+
+        def thread_a() -> None:
+            with pool.session("h1", 993, "a@e.com", "pw", 3.0):
+                a_inside.set()
+                # If b also enters, both events will be set together.
+                if b_inside.wait(timeout=1):
+                    both_were_inside.set()
+                release.wait(timeout=2)
+
+        def thread_b() -> None:
+            with pool.session("h2", 993, "b@e.com", "pw", 3.0):
+                b_inside.set()
+                a_inside.wait(timeout=1)
+                release.wait(timeout=2)
+
+        ta = threading.Thread(target=thread_a)
+        tb = threading.Thread(target=thread_b)
+        ta.start()
+        tb.start()
+
+        # Allow them to ramp up; they should both be inside.
+        time.sleep(0.05)
+        both_inside_now = a_inside.is_set() and b_inside.is_set()
+        release.set()
+        ta.join(timeout=2)
+        tb.join(timeout=2)
+
+        assert both_inside_now or both_were_inside.is_set(), (
+            "Different keys must run in parallel"
+        )
+
+
+# ---------------------------------------------------------------------------
+# close()
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_close_logs_out_every_cached_client(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        clients = [MagicMock(), MagicMock()]
+        mock_cls.side_effect = clients
+
+        with pool.session("h1", 993, "a@e.com", "pw", 3.0):
+            pass
+        with pool.session("h2", 993, "b@e.com", "pw", 3.0):
+            pass
+
+        pool.close()
+
+        clients[0].logout.assert_called_once()
+        clients[1].logout.assert_called_once()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_close_swallows_individual_logout_errors(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """Bad cached client shouldn't prevent cleaning up the others."""
+        clients = [MagicMock(), MagicMock()]
+        clients[0].logout.side_effect = OSError("dead")
+        mock_cls.side_effect = clients
+
+        with pool.session("h1", 993, "a@e.com", "pw", 3.0):
+            pass
+        with pool.session("h2", 993, "b@e.com", "pw", 3.0):
+            pass
+
+        pool.close()  # must not raise
+
+        clients[1].logout.assert_called_once()
+
+    def test_close_is_idempotent(
+        self, pool: ImapConnectionPool
+    ) -> None:
+        pool.close()
+        pool.close()  # second call must not raise on empty cache
+
+
+# ---------------------------------------------------------------------------
+# ImapConnector wiring
+# ---------------------------------------------------------------------------
+
+
+class TestImapConnectorWithPool:
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_no_pool_keeps_per_call_lifecycle(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Default behavior (pool=None) is unchanged: open + login +
+        op + logout per call. This is what existing tests rely on."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.search.return_value = []
+
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        conn.search_messages()
+        conn.search_messages()
+
+        # Each call did its own connect + login + logout.
+        assert mock_cls.call_count == 2
+        assert client.login.call_count == 2
+        assert client.logout.call_count == 2
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_with_pool_amortizes_login_across_calls(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """The headline win: with a pool, two consecutive calls share
+        one login + one logout (zero, technically — pool keeps it open
+        for reuse). This test exercises the same observable change end-
+        to-end through ImapConnector.search_messages."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.search.return_value = []
+
+        pool = ImapConnectionPool()
+        conn = ImapConnector("h", 993, "u@e.com", "pw", pool=pool)
+        conn.search_messages()
+        conn.search_messages()
+
+        mock_cls.assert_called_once()
+        client.login.assert_called_once()
+        # No logout yet — pool still holds the entry.
+        client.logout.assert_not_called()
+
+        # Closing the pool finally logs the cached client out.
+        pool.close()
+        client.logout.assert_called_once()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_pool_invalidates_on_imap_client_error_through_connector(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """When ImapConnector.search_messages raises an
+        IMAPClientError mid-call (e.g. SEARCH failed), the pool
+        invalidates the cached entry. The next call reconnects cleanly."""
+        clients = [MagicMock(), MagicMock()]
+        clients[0].search.side_effect = IMAPClientError("BAD")
+        clients[1].search.return_value = []
+        mock_cls.side_effect = clients
+
+        pool = ImapConnectionPool()
+        conn = ImapConnector("h", 993, "u@e.com", "pw", pool=pool)
+
+        with pytest.raises(IMAPClientError):
+            conn.search_messages()
+        # Recovery: next call reconnects.
+        result = conn.search_messages()
+
+        assert result == []
+        assert mock_cls.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Sanity
+# ---------------------------------------------------------------------------
+
+
+class TestPoolDefaults:
+    def test_default_idle_timeout_is_below_icloud_drop_threshold(self) -> None:
+        """iCloud and most providers drop sessions ~30 min idle. The
+        default must comfortably stay under that so we never hand out
+        a half-dead connection."""
+        # 30 min = 1800s. Default should be well under that.
+        assert POOL_IDLE_TIMEOUT_S < 30 * 60
+        # And large enough to amortize a typical interactive burst
+        # (search → get_message → get_attachments within a minute).
+        assert POOL_IDLE_TIMEOUT_S > 60
+
+    def test_pool_constructor_accepts_custom_idle_timeout(self) -> None:
+        p = ImapConnectionPool(idle_timeout_s=42.0)
+        assert p._idle_timeout_s == 42.0  # noqa: SLF001 — internal check is the point

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1031,7 +1031,8 @@ class TestAppleMailConnector:
         mock_resolve.assert_called_once_with("iCloud")
         mock_keychain.assert_called_once_with("iCloud", "user@icloud.com")
         mock_imap_cls.assert_called_once_with(
-            "imap.mail.me.com", 993, "user@icloud.com", "app-password"
+            "imap.mail.me.com", 993, "user@icloud.com", "app-password",
+            pool=None,
         )
         # Parameters forwarded 1:1 to the IMAP connector (minus `account`).
         mock_imap.search_messages.assert_called_once_with(
@@ -1133,7 +1134,8 @@ class TestAppleMailConnector:
         mock_resolve.assert_called_once_with("iCloud")
         mock_keychain.assert_called_once_with("iCloud", "user@icloud.com")
         mock_imap_cls.assert_called_once_with(
-            "imap.mail.me.com", 993, "user@icloud.com", "app-password"
+            "imap.mail.me.com", 993, "user@icloud.com", "app-password",
+            pool=None,
         )
         mock_imap.find_thread_members.assert_called_once_with(
             anchor_rfc_message_id="anchor@x",


### PR DESCRIPTION
## Summary

- New `ImapConnectionPool` class — caches IMAPClient sessions keyed by `(host, email)`, reused across calls.
- `ImapConnector` collapses its four per-method connect/login/logout blocks into a single `_session()` context manager that routes through the pool when one is set, falls through to per-call when not.
- Pool is opt-in via `APPLE_MAIL_MCP_IMAP_POOL=1` env var (default off, per the issue's acceptance criterion).
- 20 new unit tests + 2 new benchmarks. All 692 unit tests pass; check-all green.

## Headline result (live, against iCloud)

The benchmark exercises the realistic interactive burst the issue body called out — search → get_message → get_attachments → search → get_message in succession:

| Benchmark | Median | Notes |
|-----------|--------|-------|
| `imap_repeat_5_calls_no_pool` | **10.60s** | Each call re-handshakes |
| `imap_repeat_5_calls_pooled`  | **6.33s**  | One handshake, five ops |

**~40% faster** on a 5-call burst. CV is 3-7% on both, so the gap is ~5-10x larger than the noise.

## Default-OFF rationale

Issue #75 is explicit: \"Connection pool is opt-in via constructor argument or config, so per-call remains the default until proven necessary.\" These benchmark numbers prove the speedup, but flipping the default in this PR would muddy the change. A follow-up can do that once we want pooling on for everyone — the existing fallback story stays solid (any LoginError / IMAPClientError / OSError still triggers the AppleScript fallback, just one round trip later).

## Lifecycle in detail

- **Cache key:** `(host, email)`. Two users on the same server get separate sessions; same user across two providers gets two sessions.
- **Idle timeout:** `POOL_IDLE_TIMEOUT_S = 270s` (~4.5 min). Comfortably below iCloud's ~30 min drop threshold, large enough to amortize a typical interactive burst.
- **Invalidation:** `LoginError` / `IMAPClientError` / `OSError` mid-session → drop entry, attempt logout (swallow failure), propagate original exception so the orchestrator's `_IMAP_FALLBACK_EXCS` catches it. `ValueError` / `MailMessageNotFoundError` are *not* invalidating — those are clean protocol-level answers, not connection failures.
- **Locking:** cache dict guarded by one lock; each cached client has its own per-connection lock. Same-key concurrent calls serialize (IMAPClient isn't safe on one connection); different-key concurrent calls run in parallel. Designed to be safe even though FastMCP isn't multi-threaded today — costs ~0 to design in.
- **`close()`:** logs out every cached client; swallows individual logout failures; idempotent.

## Test coverage breakdown

**Unit — `tests/unit/test_imap_pool.py` (20 new tests):**
- *Reuse:* two calls share one client; per-account isolation; same-host different-email kept separate.
- *Idle:* stale entry dropped+reopened; within-window reuses.
- *Invalidation:* LoginError, IMAPClientError, OSError each drop entry; logout-failure-during-invalidation swallowed; non-invalidating exception (ValueError) keeps entry cached.
- *Locking:* same key serializes across threads; different keys run concurrently (threading.Event-driven).
- *Close:* logs out everything, swallows individual failures, idempotent.
- *ImapConnector wiring:* no-pool keeps per-call lifecycle; with-pool amortizes login across calls; protocol error invalidates through the connector path.

**Existing tests:** All 63 imap_connector tests pass without modification — the per-call branch in `_session()` is observably identical to the old code.

**Benchmarks — `tests/benchmarks/test_imap_pool.py` (2 new):** captured baselines above.

## Test plan

- [x] `make test` — 692/692 green (+20 new)
- [x] `make check-all` — green
- [x] Live: 5-call burst against iCloud, 10.60s → 6.33s
- [ ] Manual smoke: post-merge, set `APPLE_MAIL_MCP_IMAP_POOL=1` in Claude Desktop config, exercise repeated search → get_message workflow, observe latency drop

## Non-goals

- **Default stays per-call.** A follow-up flips it.
- **No NOOP keepalive.** Lazy reconnect on error already handles drops; NOOP needs a background task, not worth the complexity.
- **Circuit breaker (#118) is NOT bundled.** The pool's per-account state makes it a small follow-up; keeping it separate keeps this PR scoped.

## Lays groundwork for #118

The pool already tracks per-account state. Adding the circuit breaker is roughly: add a `_failure_until: dict[(host,email), float]` next to the cache, check it before opening a session, set it from the existing invalidation path. Bonus: the specialized LoginError warning fits naturally on top.

Closes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)