### PR TITLE
feat(#122): add X-GM-THRID Tier 1 dispatch to find_thread_members

### DIFF
--- a/docs/research/imap-thread-strategies.md
+++ b/docs/research/imap-thread-strategies.md
@@ -163,3 +163,50 @@ Both are independent of each other and of the current iCloud path. iCloud users 
 - iCloud CAPABILITY + THREAD probe: live measurement against `p42-imap.mail.me.com:993` on 2026-05-02.
 - Gmail / Fastmail / Dovecot capability claims: public vendor docs and standards (RFC 5256, Gmail IMAP extensions docs at <https://developers.google.com/gmail/imap/imap-extensions>).
 - Round-trip-cost estimates: derived from current code shape (`find_thread_members` in `imap_connector.py`) and measured per-round-trip cost on iCloud (~150-300 ms typical, occasional ~1 s under burst load).
+
+---
+
+## Addendum: live Gmail observations (2026-05-03, post #122 setup)
+
+Once the user configured Gmail IMAP delegation, we re-ran the capability probe directly. **One prediction in this doc was wrong** and worth correcting:
+
+```
+caps (21): [APPENDLIMIT=35651584, CHILDREN, COMPRESS=DEFLATE, CONDSTORE,
+            ENABLE, ESEARCH, ID, IDLE, IMAP4REV1, LIST-EXTENDED,
+            LIST-STATUS, LITERAL-, MOVE, NAMESPACE, QUOTA, SPECIAL-USE,
+            UIDPLUS, UNSELECT, UTF8=ACCEPT, X-GM-EXT-1, XLIST]
+THREAD variants: []           # ← NOT advertised
+X-GM-EXT-1 advertised? True   # ← advertised
+folder count: 92
+```
+
+- **`X-GM-EXT-1` confirmed** — Tier 1 (X-GM-THRID) is available, as predicted.
+- **`THREAD=*` is NOT advertised** on this Gmail account, contradicting the public-docs claim earlier in this doc. So Tier 2 (RFC 5256 THREAD) wouldn't fire on Gmail anyway — even if we implemented it, capability detection would skip it. **Tier 1 is the only IMAP optimization Gmail will accept**, and the BFS is the only fallback.
+- **92 folders** confirms the magnitude: 92 × N=4 × 3 ≈ 1100 SEARCH round-trips for the BFS path on this account. Tier 1 collapses that to ~5 round-trips, mailbox-count-independent.
+
+This finding makes #122 (Tier 1) the single highest-impact perf optimization for Gmail users. #123 (Tier 2) remains valuable for Fastmail / Dovecot deployments, where neither X-GM-EXT-1 nor a Gmail-class folder count applies.
+
+Capability matrix updated based on live probe:
+
+| Provider | THREAD advertised? | X-GM-EXT-1? | Notes |
+|----------|--------------------|--------------|-------|
+| iCloud | NO (verified 2026-05-02) | NO | BFS or AppleScript only. |
+| Gmail | **NO (verified 2026-05-03)** ← was YES per docs | YES | X-GM-THRID is the only IMAP optimization that fires here. |
+| Fastmail | YES (per public docs) | NO | THREAD per-mailbox is the win — no live verification yet. |
+| Dovecot-based | DEPENDS | NO | Capability detection per-server. |
+
+### Sub-finding: `[Gmail]/All Mail` is opt-in over IMAP
+
+The first cut of #122 (Tier 1) used SPECIAL-USE's `\\All` flag to find `[Gmail]/All Mail`, then ran one `SEARCH HEADER Message-ID` + one `FETCH X-GM-THRID` + one `SEARCH X-GM-THRID` against it. Total: 5 round-trips, mailbox-count-independent. Beautiful in theory.
+
+**In practice on the user's account, the folder isn't there.** The post-login folder listing (92 folders) had no entry with the `\\All` flag at all. Live `LIST` output shows only `\\Drafts`, `\\Important`, `\\Sent`, `\\Junk` (Spam), `\\Starred`, `\\Trash` — no `\\All Mail`. Manually trying `SELECT [Gmail]/All Mail` returned `[NONEXISTENT] Unknown Mailbox`.
+
+Cause: Gmail Settings → "Forwarding and POP/IMAP" → "Folder size limits" → the option **"Do not show this folder in IMAP"** can be toggled per-folder. Many Gmail users hide All Mail from IMAP because it's enormous and otherwise appears in every IMAP client's mailbox list. When hidden, the folder simply isn't enumerated by `LIST` and isn't selectable.
+
+This makes Tier 1 (as designed) a no-op for any Gmail user who has hidden All Mail. The dispatcher correctly falls through to Tier 3 (BFS), so correctness is fine — but the ~5-round-trip perf win never materializes.
+
+**For users who can enable All Mail in IMAP**: the Gmail Settings flip is one click; #122's Tier 1 then activates fully. Worth documenting in a setup-guide or README note.
+
+**For users who can't or won't**: needs a per-mailbox X-GM-THRID variant. SELECT INBOX (or any folder where the anchor lives), FETCH X-GM-THRID for the anchor's UID, then iterate selectable folders running `SEARCH X-GM-THRID <thrid>` per mailbox. Cost: M × 2 round-trips (vs. ~5 for the All-Mail path; vs. M × N × 3 for BFS). Still a 6× win over BFS on a 92-folder account. Filed as **#125**.
+
+This sub-finding doesn't invalidate #122 — Tier 1 still fires for Gmail users with All Mail exposed, which is a meaningful subset. It just means the universal X-GM-THRID path is a separate, more general optimization.

--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass, field
 from datetime import date as _date
 from datetime import datetime as _datetime
 from datetime import timedelta as _timedelta
-from typing import Any
+from typing import Any, cast
 
 from imapclient import IMAPClient
 from imapclient.exceptions import IMAPClientError, LoginError
@@ -691,22 +691,36 @@ class ImapConnector:
     ) -> list[dict[str, Any]]:
         """Return all messages in the anchor's thread across the account.
 
-        Iterates every mailbox on the server. For each mailbox, searches
-        for any message whose Message-ID, In-Reply-To, or References
-        header matches any of the known thread IDs (the anchor plus its
-        known ancestors from the anchor's References header). Collects
-        matches, dedupes by Message-ID, sorts chronologically.
+        Tiered, capability-detected dispatch (issue #122):
 
-        A single pass suffices because well-formed replies copy the entire
-        References chain of their parent — so searching on the anchor's
-        Message-ID against the References header captures all descendants
-        regardless of tree depth.
+        - **Tier 1 (Gmail X-GM-THRID)** — when ``X-GM-EXT-1`` is in the
+          server's CAPABILITY list, look the conversation up by Gmail's
+          64-bit thread ID against ``[Gmail]/All Mail`` (resolved via
+          ``\\All`` SPECIAL-USE flag, which is localization-safe). Five
+          round-trips total, mailbox-count-independent — replaces a
+          ~1100-round-trip BFS on a 91-label Gmail account with ~5.
+
+        - **Tier 3 (header-search BFS)** — universal fallback. Iterates
+          every mailbox on the server; searches Message-ID / In-Reply-To /
+          References for every known thread ID. Used on iCloud, Fastmail,
+          and any provider that doesn't advertise the X-GM-EXT-1 path.
+          Also used when Tier 1 advertises but rejects mid-flight (server
+          lied about its capabilities).
+
+        Tier 2 (RFC 5256 THREAD) is reserved for #123 — slot in another
+        capability check between Tier 1 and Tier 3 there.
+
+        A single ``_session()`` covers all tiers, so a Tier 1 → Tier 3
+        fall-through doesn't pay a second connect+login. With the pool
+        (#75), both tiers share the cached connection.
 
         Args:
             anchor_rfc_message_id: RFC 5322 Message-ID of the thread anchor,
                 bracketless (as returned by _strip_brackets).
             anchor_references: List of Message-IDs from the anchor's
-                References header, bracketless, order preserved.
+                References header, bracketless, order preserved. Used by
+                Tier 3; Tier 1 doesn't need them (X-GM-THRID is the
+                authoritative grouping).
 
         Returns:
             List of message dicts in the same shape as search_messages
@@ -714,70 +728,189 @@ class ImapConnector:
             ``read_status``, ``flagged``), deduped by Message-ID, sorted
             chronologically ascending.
         """
-        known_ids: set[str] = {anchor_rfc_message_id} | set(anchor_references)
-
         with self._session() as client:
-            mailboxes = client.list_folders()
-            collected: dict[str, dict[str, Any]] = {}
+            # Tier 1: Gmail X-GM-THRID — fastest, mailbox-count-independent.
+            if self._has_capability(client, b"X-GM-EXT-1"):
+                tier1 = self._thread_via_xgm_thrid(client, anchor_rfc_message_id)
+                if tier1 is not None:
+                    return tier1
+                # Else fall through to Tier 3 in the same session.
 
-            for _flags, _delimiter, raw_name in mailboxes:
-                # imapclient returns names as str when its decoder succeeds,
-                # bytes/bytearray on failure. Coerce to str either way.
-                if isinstance(raw_name, (bytes, bytearray)):
-                    mailbox_name = raw_name.decode("utf-8", errors="replace")
-                else:
-                    mailbox_name = raw_name
-
-                try:
-                    client.select_folder(mailbox_name, readonly=True)
-                except IMAPClientError as exc:
-                    # Some mailboxes (e.g. Gmail smart labels) reject SELECT.
-                    # Matches the AppleScript path's precedent of skipping
-                    # them silently.
-                    logger.debug(
-                        "find_thread_members: skipping mailbox %s: %s",
-                        mailbox_name, exc,
-                    )
-                    continue
-
-                # Search for each known id across three header types. IMAP
-                # returns UIDs whose specified header contains the given
-                # substring; each search is server-side and indexed.
-                uids_found: set[int] = set()
-                for id_ in known_ids:
-                    id_quoted = f"<{id_}>"
-                    for header in ("Message-ID", "In-Reply-To", "References"):
-                        try:
-                            uids = client.search(["HEADER", header, id_quoted])
-                        except IMAPClientError as exc:
-                            logger.debug(
-                                "find_thread_members: search failed in %s for "
-                                "%s=%s: %s",
-                                mailbox_name, header, id_quoted, exc,
-                            )
-                            continue
-                        uids_found.update(uids)
-
-                if not uids_found:
-                    continue
-
-                fetched = client.fetch(
-                    list(uids_found), [b"ENVELOPE", b"FLAGS"]
-                )
-                for fetch_entry in fetched.values():
-                    envelope = fetch_entry.get(b"ENVELOPE")
-                    if envelope is None:
-                        continue
-                    raw_msgid = getattr(envelope, "message_id", None)
-                    if not raw_msgid:
-                        continue
-                    clean_msgid = _strip_brackets(_decode(raw_msgid))
-                    if clean_msgid in collected:
-                        continue
-                    flags = tuple(fetch_entry.get(b"FLAGS", ()) or ())
-                    collected[clean_msgid] = _envelope_to_dict(envelope, flags)
-
-            return sorted(
-                collected.values(),
-                key=lambda m: m.get("date_received") or "",
+            # Tier 3: header-search BFS — universal fallback.
+            return self._find_thread_members_bfs(
+                client, anchor_rfc_message_id, anchor_references,
             )
+
+    @staticmethod
+    def _has_capability(client: IMAPClient, name: bytes) -> bool:
+        """True if ``name`` (e.g. ``b"X-GM-EXT-1"``) is in the post-login
+        capability list. IMAPClient caches CAPABILITY across the session;
+        this is a local lookup, no round trip."""
+        return name in client.capabilities()
+
+    @staticmethod
+    def _find_all_mail_folder(client: IMAPClient) -> str | None:
+        """Return the Gmail All Mail folder name via the ``\\All``
+        SPECIAL-USE flag, or None if not found.
+
+        Hardcoding ``[Gmail]/All Mail`` would break on localized Gmail
+        accounts (e.g. ``[Google Mail]/Tutta la posta``); the SPECIAL-USE
+        flag is the standard way to find it regardless of label."""
+        for flags, _delim, name in client.list_folders():
+            if b"\\All" in flags:
+                if isinstance(name, (bytes, bytearray)):
+                    return name.decode("utf-8", errors="replace")
+                return cast(str, name)
+        return None
+
+    def _thread_via_xgm_thrid(
+        self,
+        client: IMAPClient,
+        anchor_rfc_message_id: str,
+    ) -> list[dict[str, Any]] | None:
+        """Tier 1 (Gmail X-GM-THRID) implementation. Returns thread member
+        dicts on success, OR ``None`` when the strategy can't run (no
+        ``\\All`` folder, anchor not in All Mail, X-GM-THRID query
+        rejected mid-flight). On None, the caller falls through to Tier 3.
+
+        Returning None (rather than raising) keeps the dispatcher's
+        control flow clean — exceptions are reserved for failures the
+        orchestrator's ``_IMAP_FALLBACK_EXCS`` should observe."""
+        all_mail = self._find_all_mail_folder(client)
+        if all_mail is None:
+            return None
+
+        client.select_folder(all_mail, readonly=True)
+
+        bracketed = f"<{anchor_rfc_message_id}>"
+        try:
+            anchor_uids = client.search(["HEADER", "Message-ID", bracketed])
+        except IMAPClientError:
+            return None
+        if not anchor_uids:
+            return None
+
+        try:
+            thrid_fetch = client.fetch(anchor_uids[:1], [b"X-GM-THRID"])
+        except IMAPClientError:
+            return None
+        thrid_entry: dict[bytes, Any] = next(iter(thrid_fetch.values()), {})
+        thrid = thrid_entry.get(b"X-GM-THRID")
+        if thrid is None:
+            return None
+
+        try:
+            thread_uids = client.search(["X-GM-THRID", str(thrid)])
+        except IMAPClientError:
+            return None
+        if not thread_uids:
+            return None
+
+        fetched = client.fetch(thread_uids, [b"ENVELOPE", b"FLAGS"])
+
+        collected: dict[str, dict[str, Any]] = {}
+        for fetch_entry in fetched.values():
+            envelope = fetch_entry.get(b"ENVELOPE")
+            if envelope is None:
+                continue
+            raw_msgid = getattr(envelope, "message_id", None)
+            if not raw_msgid:
+                continue
+            clean_msgid = _strip_brackets(_decode(raw_msgid))
+            if clean_msgid in collected:
+                continue
+            flags = tuple(fetch_entry.get(b"FLAGS", ()) or ())
+            collected[clean_msgid] = _envelope_to_dict(envelope, flags)
+
+        return sorted(
+            collected.values(),
+            key=lambda m: m.get("date_received") or "",
+        )
+
+    @staticmethod
+    def _find_thread_members_bfs(
+        client: IMAPClient,
+        anchor_rfc_message_id: str,
+        anchor_references: list[str],
+    ) -> list[dict[str, Any]]:
+        """Tier 3: per-mailbox header-search BFS. Universal fallback —
+        works against any IMAP server that supports basic SEARCH HEADER
+        (RFC 3501).
+
+        For each mailbox, searches the Message-ID / In-Reply-To /
+        References headers for every known thread ID (the anchor plus
+        its known ancestors). A single pass suffices because well-formed
+        replies copy the entire References chain of their parent — so
+        searching on the anchor's Message-ID against the References
+        header captures all descendants regardless of tree depth.
+
+        Cost: M × N × 3 SEARCHes + M SELECTs + up to M FETCHes, where
+        M is mailbox count and N is the size of the known-IDs set.
+        Slow on accounts with many mailboxes; #122 (X-GM-THRID) is the
+        Gmail-specific optimization, #123 (RFC 5256 THREAD) the more
+        general one."""
+        known_ids: set[str] = {anchor_rfc_message_id} | set(anchor_references)
+        mailboxes = client.list_folders()
+        collected: dict[str, dict[str, Any]] = {}
+
+        for _flags, _delimiter, raw_name in mailboxes:
+            # imapclient returns names as str when its decoder succeeds,
+            # bytes/bytearray on failure. Coerce to str either way.
+            if isinstance(raw_name, (bytes, bytearray)):
+                mailbox_name = raw_name.decode("utf-8", errors="replace")
+            else:
+                mailbox_name = raw_name
+
+            try:
+                client.select_folder(mailbox_name, readonly=True)
+            except IMAPClientError as exc:
+                # Some mailboxes (e.g. Gmail smart labels) reject SELECT.
+                # Matches the AppleScript path's precedent of skipping
+                # them silently.
+                logger.debug(
+                    "find_thread_members: skipping mailbox %s: %s",
+                    mailbox_name, exc,
+                )
+                continue
+
+            # Search for each known id across three header types. IMAP
+            # returns UIDs whose specified header contains the given
+            # substring; each search is server-side and indexed.
+            uids_found: set[int] = set()
+            for id_ in known_ids:
+                id_quoted = f"<{id_}>"
+                for header in ("Message-ID", "In-Reply-To", "References"):
+                    try:
+                        uids = client.search(["HEADER", header, id_quoted])
+                    except IMAPClientError as exc:
+                        logger.debug(
+                            "find_thread_members: search failed in %s for "
+                            "%s=%s: %s",
+                            mailbox_name, header, id_quoted, exc,
+                        )
+                        continue
+                    uids_found.update(uids)
+
+            if not uids_found:
+                continue
+
+            fetched = client.fetch(
+                list(uids_found), [b"ENVELOPE", b"FLAGS"]
+            )
+            for fetch_entry in fetched.values():
+                envelope = fetch_entry.get(b"ENVELOPE")
+                if envelope is None:
+                    continue
+                raw_msgid = getattr(envelope, "message_id", None)
+                if not raw_msgid:
+                    continue
+                clean_msgid = _strip_brackets(_decode(raw_msgid))
+                if clean_msgid in collected:
+                    continue
+                flags = tuple(fetch_entry.get(b"FLAGS", ()) or ())
+                collected[clean_msgid] = _envelope_to_dict(envelope, flags)
+
+        return sorted(
+            collected.values(),
+            key=lambda m: m.get("date_received") or "",
+        )

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from imapclient.exceptions import IMAPClientError
 from imapclient.response_types import Address, Envelope
 
 from apple_mail_mcp.imap_connector import CONNECT_TIMEOUT_S, ImapConnector
@@ -1196,3 +1197,309 @@ class TestGetAttachments:
                 "abc@x", mailbox="INBOX",
             )
         client.logout.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Issue #122: Gmail X-GM-THRID dispatch in find_thread_members
+# ---------------------------------------------------------------------------
+
+
+def _gmail_caps_with_xgm() -> set[bytes]:
+    """Capability list as Gmail returns it post-login (live-probed
+    2026-05-02 — see docs/research/imap-thread-strategies.md addendum)."""
+    return {
+        b"IMAP4REV1", b"UNSELECT", b"IDLE", b"NAMESPACE", b"QUOTA",
+        b"ID", b"XLIST", b"CHILDREN", b"X-GM-EXT-1", b"UIDPLUS",
+        b"COMPRESS=DEFLATE", b"ENABLE", b"MOVE", b"CONDSTORE", b"ESEARCH",
+        b"UTF8=ACCEPT", b"LIST-EXTENDED", b"LIST-STATUS", b"LITERAL-",
+        b"SPECIAL-USE", b"APPENDLIMIT=35651584",
+    }
+
+
+def _generic_caps_no_xgm() -> set[bytes]:
+    """Capability list for a non-Gmail server (e.g. iCloud, Fastmail).
+    No X-GM-EXT-1 → Tier 1 must skip."""
+    return {
+        b"IMAP4REV1", b"UNSELECT", b"IDLE", b"NAMESPACE", b"QUOTA",
+        b"ID", b"UIDPLUS", b"ENABLE", b"CONDSTORE", b"ESEARCH",
+        b"SPECIAL-USE",
+    }
+
+
+def _gmail_folder_listing_with_all() -> list:
+    """A Gmail-style folder listing with the \\All SPECIAL-USE flag."""
+    return [
+        ((b"\\HasNoChildren",), b"/", "INBOX"),
+        ((b"\\HasNoChildren", b"\\Drafts"), b"/", "[Gmail]/Drafts"),
+        ((b"\\HasNoChildren", b"\\Sent"), b"/", "[Gmail]/Sent Mail"),
+        ((b"\\HasNoChildren", b"\\All"), b"/", "[Gmail]/All Mail"),
+        ((b"\\HasNoChildren", b"\\Trash"), b"/", "[Gmail]/Trash"),
+        ((b"\\HasNoChildren", b"\\Junk"), b"/", "[Gmail]/Spam"),
+    ]
+
+
+def _localized_gmail_folder_listing() -> list:
+    """A localized Gmail (Italian) listing — \\All flag present, name
+    differs. Hardcoding `[Gmail]/All Mail` would miss this; SPECIAL-USE
+    is the robust answer."""
+    return [
+        ((b"\\HasNoChildren",), b"/", "INBOX"),
+        ((b"\\HasNoChildren", b"\\All"), b"/", "[Google Mail]/Tutta la posta"),
+    ]
+
+
+def _generic_folder_listing_no_all() -> list:
+    """A non-Gmail listing with no \\All flag — Tier 1 must skip even
+    when the capability is advertised."""
+    return [
+        ((b"\\HasNoChildren",), b"/", "INBOX"),
+        ((b"\\HasNoChildren", b"\\Sent"), b"/", "Sent"),
+        ((b"\\HasNoChildren", b"\\Trash"), b"/", "Trash"),
+    ]
+
+
+class TestFindThreadMembersGmail:
+    """Tier 1 (Gmail X-GM-THRID) dispatch in find_thread_members.
+
+    The dispatcher itself lives in find_thread_members; these tests
+    drive it via mocked IMAPClient and assert the right strategy fired
+    based on the server's advertised capabilities."""
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_uses_xgm_thrid_when_capability_advertised(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """The headline path: X-GM-EXT-1 advertised, anchor in All Mail
+        → 5 round trips, mailbox-count-independent. BFS path NOT hit."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_with_all()
+        # SEARCH HEADER Message-ID → anchor's UID
+        # SEARCH X-GM-THRID → all UIDs in conversation
+        client.search.side_effect = [[100], [100, 101, 102]]
+        # FETCH X-GM-THRID → conversation ID; FETCH ENVELOPE FLAGS → members
+        client.fetch.side_effect = [
+            {100: {b"X-GM-THRID": 1234567890123456789}},
+            _fake_fetch_result([100, 101, 102]),
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        # Tier 1 SELECTed the All Mail folder (resolved via SPECIAL-USE).
+        client.select_folder.assert_called_once_with(
+            "[Gmail]/All Mail", readonly=True,
+        )
+        # Two SEARCHes (anchor lookup + thread expansion); two FETCHes.
+        assert client.search.call_count == 2
+        assert client.fetch.call_count == 2
+        # The X-GM-THRID search uses the conversation ID returned by FETCH.
+        thrid_search = client.search.call_args_list[1][0][0]
+        assert thrid_search == ["X-GM-THRID", "1234567890123456789"]
+        # All three thread members surfaced (deduped by Message-ID).
+        assert len(result) == 3
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_falls_back_to_bfs_when_xgm_ext_not_advertised(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Non-Gmail server (no X-GM-EXT-1) skips Tier 1 entirely and
+        runs the BFS — the Tier-1 helpers are never invoked."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _generic_caps_no_xgm()
+        client.list_folders.return_value = _generic_folder_listing_no_all()
+        client.search.return_value = []  # BFS finds nothing → fast exit
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        # BFS iterates folders. No SEARCH for X-GM-THRID was ever issued.
+        for call in client.search.call_args_list:
+            args = call[0][0]
+            assert args[0] != "X-GM-THRID", (
+                "X-GM-THRID query must not run when X-GM-EXT-1 is absent"
+            )
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_falls_back_to_bfs_when_no_all_mail_folder(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """X-GM-EXT-1 advertised but no \\All folder in the listing —
+        unusual but possible (e.g. SPECIAL-USE not set up). Tier 1
+        returns None; BFS runs in the same session."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _generic_folder_listing_no_all()
+        client.search.return_value = []
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        # No SELECT of any "All Mail" folder.
+        for call in client.select_folder.call_args_list:
+            assert "All Mail" not in call[0][0]
+        # BFS path SELECTed the regular folders.
+        assert client.select_folder.called
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_falls_back_to_bfs_when_anchor_not_in_all_mail(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """SEARCH HEADER returns no UID (anchor not present in All Mail).
+        Could happen during sync lag or if the message was hard-deleted
+        from All Mail. Fall through to BFS."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_with_all()
+        # First search is anchor-in-All-Mail → empty. Subsequent searches
+        # are the BFS per-folder per-id-per-header sequence — return empty.
+        client.search.return_value = []
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="missing@gmail.com",
+            anchor_references=[],
+        )
+
+        # Tier 1 attempted: All Mail SELECTed first.
+        first_select = client.select_folder.call_args_list[0]
+        assert first_select[0][0] == "[Gmail]/All Mail"
+        # Then BFS fired: many more SELECTs followed.
+        assert client.select_folder.call_count > 1
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_falls_back_to_bfs_on_xgm_thrid_query_rejection(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Server advertised X-GM-EXT-1 but rejects the X-GM-THRID query
+        anyway (quirky server / partial extension support). Tier 1
+        returns None; BFS picks up cleanly."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_with_all()
+        # Anchor lookup succeeds (Tier 1 SEARCH HEADER returns [100]);
+        # subsequent BFS searches find nothing.
+        client.search.side_effect = [[100]] + [[]] * 100
+        # First FETCH (Tier 1's X-GM-THRID query) is rejected; any later
+        # FETCH (BFS only fetches when SEARCH found something — it
+        # didn't, above — but be defensive) returns empty.
+        client.fetch.side_effect = [IMAPClientError("BAD X-GM-THRID"), {}, {}]
+
+        # Should NOT raise — IMAPClientError inside Tier 1 maps to None,
+        # not a re-raise. (Connection is still healthy; only the
+        # optimization path is broken.)
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        # BFS ran after the Tier 1 fall-through (multiple SELECTs).
+        assert client.select_folder.call_count > 1
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_uses_localized_all_mail_via_special_use(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Italian Gmail: All Mail is named `[Google Mail]/Tutta la posta`.
+        SPECIAL-USE flag is the only safe way to find it."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _localized_gmail_folder_listing()
+        client.search.side_effect = [[1], [1]]
+        client.fetch.side_effect = [
+            {1: {b"X-GM-THRID": 999}},
+            _fake_fetch_result([1]),
+        ]
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        client.select_folder.assert_called_once_with(
+            "[Google Mail]/Tutta la posta", readonly=True,
+        )
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_returns_thread_members_in_chronological_order(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """The Tier 1 path must match Tier 3's existing sort: ascending
+        date_received. Callers depend on this — get_thread surfaces
+        results in chronological order."""
+        from datetime import datetime as _dt
+
+        # Three messages with intentionally OUT-OF-ORDER fetch UIDs vs dates.
+        e_old = _fake_envelope(
+            message_id=b"<old@gmail.com>", subject=b"Original",
+            date=_dt(2026, 1, 1, 12, 0, 0),
+        )
+        e_mid = _fake_envelope(
+            message_id=b"<mid@gmail.com>", subject=b"Re: Original",
+            date=_dt(2026, 1, 5, 12, 0, 0),
+        )
+        e_new = _fake_envelope(
+            message_id=b"<new@gmail.com>", subject=b"Re: Re: Original",
+            date=_dt(2026, 1, 10, 12, 0, 0),
+        )
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_with_all()
+        client.search.side_effect = [[100], [102, 100, 101]]
+        client.fetch.side_effect = [
+            {100: {b"X-GM-THRID": 555}},
+            {
+                100: {b"ENVELOPE": e_old, b"FLAGS": (b"\\Seen",)},
+                101: {b"ENVELOPE": e_mid, b"FLAGS": (b"\\Seen",)},
+                102: {b"ENVELOPE": e_new, b"FLAGS": ()},
+            },
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="old@gmail.com",
+            anchor_references=[],
+        )
+
+        ids = [r["id"] for r in result]
+        assert ids == ["old@gmail.com", "mid@gmail.com", "new@gmail.com"]
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_dedups_by_message_id(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Defensive: even if the FETCH response somehow includes the
+        same Message-ID twice (unusual but observed in practice with
+        some servers when a message appears under multiple labels but
+        has the same RFC 5322 Message-ID), the result has unique IDs."""
+        e1 = _fake_envelope(message_id=b"<dup@gmail.com>", subject=b"S")
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_with_all()
+        client.search.side_effect = [[1], [1, 2]]
+        client.fetch.side_effect = [
+            {1: {b"X-GM-THRID": 7}},
+            {
+                1: {b"ENVELOPE": e1, b"FLAGS": ()},
+                2: {b"ENVELOPE": e1, b"FLAGS": ()},  # same Message-ID
+            },
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="dup@gmail.com",
+            anchor_references=[],
+        )
+
+        assert len(result) == 1


### PR DESCRIPTION
## Summary

- New `_thread_via_xgm_thrid` strategy on `ImapConnector` — looks up the conversation by Gmail's 64-bit thread ID against `[Gmail]/All Mail` (resolved via `\\All` SPECIAL-USE flag, localization-safe).
- `find_thread_members` becomes a tiered dispatcher: Tier 1 (X-GM-THRID) → Tier 3 (header-search BFS).
- 8 new unit tests; existing 63 imap_connector tests pass unchanged. 712 total pass; check-all green.
- Lays the dispatch framework that #123 (Tier 2 RFC 5256 THREAD) and #125 (per-mailbox X-GM-THRID) will slot into.

## Headline

For Gmail users with All Mail exposed over IMAP, this collapses the BFS path's **M × N × 3** round-trips (e.g. ~1100 on a 91-label account, N=4) to **5**, mailbox-count-independent.

## Algorithm

When `X-GM-EXT-1` is advertised AND the `\\All` SPECIAL-USE flag is present:

1. SELECT `\\All Mail` (readonly).
2. SEARCH HEADER Message-ID `<anchor-id>` → 1 UID (or 0 → fall through).
3. FETCH `<uid>` X-GM-THRID → 64-bit conversation ID.
4. SEARCH X-GM-THRID `<thrid>` → all UIDs in conversation.
5. FETCH `<uids>` ENVELOPE FLAGS → result dicts.

`_thread_via_xgm_thrid` returns `None` (not raises) for non-applicable states (no `\\All` folder, anchor not in All Mail, X-GM-THRID query rejected mid-flight). The dispatcher falls through to BFS in the **same session** — pool-friendly and no second connect+login.

## Live verification + sub-finding

Live test against the user's just-configured Gmail account. **Surfaced one ergonomic gotcha worth knowing about:**

Gmail's `[Gmail]/All Mail` is **opt-in over IMAP**. Settings → Forwarding and POP/IMAP → \"Folder size limits\" → \"Do not show this folder in IMAP\". Many users disable it because All Mail is enormous and clutters every IMAP client. When disabled, the `\\All` flag isn't enumerated by `LIST` and `SELECT [Gmail]/All Mail` returns `[NONEXISTENT]`.

On this user's account All Mail is hidden. Tier 1 correctly falls through to BFS (~136 s for a 1-message thread on 92 folders), proving the fall-through path works. **The perf win this PR delivers only materializes for users with All Mail exposed** — they get the ~5-round-trip path. Users who hide All Mail get no benefit until #125 ships (per-mailbox X-GM-THRID iteration; ~6× BFS speedup, mailbox-count-dependent).

Updated capability matrix in `docs/research/imap-thread-strategies.md`:

| Provider | THREAD | X-GM-EXT-1 | Notes |
|----------|--------|------------|-------|
| iCloud | NO (verified 2026-05-02) | NO | BFS only. |
| Gmail | NO (verified 2026-05-03) ← was YES per docs | YES | Tier 1 fires when All Mail is exposed; else falls through. |

## Test coverage (8 new)

- Tier 1 happy path (X-GM-EXT-1 + `\\All` + anchor found)
- Falls back when X-GM-EXT-1 not advertised
- Falls back when no `\\All` folder
- Falls back when anchor not in All Mail
- Falls back on X-GM-THRID query rejection
- Localized All Mail (`[Google Mail]/Tutta la posta`) found via `\\All` flag
- Members returned in chronological order (matches existing BFS output)
- Dedup by Message-ID (defensive)

## Test plan

- [x] `make test` — 712/712 green (+8 new)
- [x] `make check-all` — green
- [x] Live: confirmed Tier 1 → Tier 3 fall-through works correctly when `\\All` is hidden
- [ ] Live (post-merge): user enables \"Show All Mail in IMAP\" in Gmail Settings, re-runs `find_thread_members` against a multi-message thread, confirms sub-second timing

## Non-goals

- **Tier 2 (RFC 5256 THREAD)** is #123. Live probe just confirmed Gmail doesn't advertise THREAD anyway.
- **Per-mailbox X-GM-THRID iteration** is #125 (filed during this PR). Addresses the All-Mail-hidden case.
- **No tool surface change.** `get_thread` keeps its current signature.
- **No iCloud changes.** iCloud doesn't advertise X-GM-EXT-1; capability check skips Tier 1 there.

Closes #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)