### PR TITLE
release: v0.6.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Mail via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.5.0 | **Tests:** 571 unit / 23 e2e | **Coverage:** 92%
+**Version:** v0.6.0 | **Tests:** 712 unit / 23 e2e | **Coverage:** 92%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-03
+
+Performance and ergonomics release. The IMAP delegation arc started in v0.5.0 is now complete: `search_messages`, `get_message`, `get_attachments`, and `get_thread` all delegate to IMAP transparently when configured, with a clean cross-provider fallback story. Headline numbers: search drops 60s → 2.7s on a populous mailbox, the IMAP fast path is wired through every read tool, and a small per-account circuit breaker keeps offline / stale-credential bursts bounded. Setup is no longer a four-line raw-shell incantation — there's a real CLI with verification.
+
+### Added
+
+**Setup-IMAP CLI (#76):** New `apple-mail-mcp setup-imap --account <name>` subcommand replaces the raw `security add-generic-password` recipe. Prompts for the password via `getpass` (no shell history), writes the Keychain entry idempotently, opens an IMAP connection to verify the password actually works, rolls back on auth failure. `--uninstall` removes the entry. `--email` overrides the Mail.app-derived default for the rare alias case. Default invocation (no subcommand) still starts the MCP server, so Claude Desktop is unaffected. (#116)
+
+**IMAP delegation for read tools:**
+- `get_message` (#72): one-round-trip lookup via `SEARCH HEADER Message-ID` + `FETCH` when `account` and `mailbox` are supplied. Replaces the AppleScript account×mailbox scan (~6-18s worst case). New `headers_only` knob skips body fetch when only metadata is needed. Surfaced + fixed a latent identifier mismatch: AppleScript path uses Mail.app's internal numeric id; IMAP returns RFC 5322 Message-IDs. Callers who forward `account`+`mailbox` from `search_messages` now stay on the IMAP path consistently. (#117)
+- `get_attachments` (#73): one BODYSTRUCTURE FETCH replaces the per-attachment property loop. Also surfaces three classes of attachment Mail.app's AppleScript silently drops: forwarded `message/rfc822` parts, multipart/related inline images with filenames, Unicode filenames. (#119)
+- `get_thread` (#122): tiered, capability-detected dispatch. Tier 1 is Gmail's `X-GM-THRID` against `[Gmail]/All Mail` — ~5 round-trips, mailbox-count-independent (replaces ~1100 round-trips on a 91-label account when All Mail is exposed over IMAP). Falls through cleanly to the existing per-mailbox header-search BFS when the capability or `[Gmail]/All Mail` isn't available. (#126)
+
+**IMAP connection pooling (#75):** New `ImapConnectionPool` class — opt-in via `APPLE_MAIL_MCP_IMAP_POOL=1` env var, default off. Caches IMAP sessions keyed by `(host, email)`, with idle-timeout reconnect (270s default), per-connection locking (thread-safety designed in even though FastMCP is single-threaded today), and invalidation on protocol/network errors. **Live measurement on a 5-call interactive workflow against iCloud: 10.6s → 6.3s, ~40% faster.** (#120)
+
+**IMAP failure circuit breaker (#118):** Per-account 30s cooldown on `AppleMailConnector` after non-benign IMAP failures. Bursts of calls during offline / stale-credential conditions stop wasting round-trips on the same broken account. Specialized `LoginError` warning text now names the exact `setup-imap` command — surfaces silent IMAP degradation that the AppleScript fallback otherwise hides indefinitely. (#121)
+
+**Benchmark suite (#31):** Captured baselines for search, attachment, bulk-ops, and pool scenarios. `make benchmark` / `make benchmark-baseline` Makefile targets. Skipped by default; opt-in via `--run-benchmark`. (#100)
+
+**`get_selected_messages` tool (#11):** Returns the messages currently selected in Mail.app's UI. External contribution.
+
+### Changed
+
+**`search_messages` AppleScript fallback path is 22× faster on large mailboxes (#32).** Replaced `whose <filter>` server-side predicate (which forces full-mailbox materialization on Mail.app's side) with manual reverse-order iteration plus per-message IF filters. Live: 60s → 2.7s on a populous mailbox; new `search_messages_with_zero_matches` benchmark confirms full-scan worst case stays bounded. INFO-level log fires when AppleScript search exceeds 5s, pointing users at IMAP setup. **Observable behavior change**: results now return newest-first; previously oldest-first. Callers that relied on the old order should reverse the result list. (#114)
+
+**Bulk operations cubic loop fix (#103).** `move_messages`, `flag_message`, `mark_as_read`, `delete_messages` accepted a new optional `source_mailbox` parameter that narrows the AppleScript scan from O(N × accounts × mailboxes) to O(N) when the caller knows where the messages are. (#112)
+
+**`/merge-and-status` slash command** now surfaces untriaged contributor issues alongside contributor PRs. (#104, #105)
+
+### Fixed
+
+**`delete_messages(permanent=True)` was a silent no-op (#111).** Empirically probed Mail.app's AppleScript surface — confirmed there's no path to permanent-delete that bypasses Trash. Parameter now emits `DeprecationWarning` so callers see the gap; docs corrected to describe actual behavior; AppleScript path unchanged (still moves to Trash, recoverable). (#115)
+
+**Dependency bumps:** fastmcp ≥3.2.4, pytest ≥9.0.3, ruff ≥0.15.12, mypy ≥1.20.2, pytest-cov ≥7.1.0. uv.lock regenerated. (#106-110, #113)
+
+**`check_dependencies.sh`** now invokes pip-audit via `uv run` — fixes a CI-only failure mode. (#99)
+
+### Documentation
+
+**Research: IMAP thread-discovery strategies** (`docs/research/imap-thread-strategies.md`, #80, #124). Empirical capability survey of iCloud, Gmail, and documented-from-public-docs Fastmail/Dovecot. Discovered iCloud doesn't advertise THREAD (contradicting public claims), Gmail doesn't advertise THREAD on the live account, and Gmail's `[Gmail]/All Mail` is opt-in over IMAP. Recommended a tiered, capability-detected dispatch — Tier 1 (X-GM-THRID) shipped in #122; Tier 2 (RFC 5256 THREAD) tracked as #123, Tier 1.5 (per-mailbox X-GM-THRID for hidden All Mail) tracked as #125. Both deferred to v0.7.0.
+
+**README** rewritten to reflect the new IMAP setup flow (single CLI command instead of raw `security` recipe).
+
+### Tooling
+
+- `pyproject.toml` `version = "0.6.0"`
+- `__init__.py` `__version__ = "0.6.0"`
+
 ## [0.5.0] - 2026-04-26
 
 Major minor release. Fifteen new MCP tools across four feature areas (account discovery, rule management, email templates, IMAP-backed performance), several long-standing AppleScript-injection bugs closed, and contributor-experience tightening prompted by an honest look at how earlier external PRs got handled. The README, CONTRIBUTING.md, and `.github/PULL_REQUEST_TEMPLATE.md` were all reworked to make the project safer and more welcoming to contribute to.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server that provides programmatic access to Apple Mail, enabling AI assistants like Claude to read, send, search, and manage emails on macOS.
 
-> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.5.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading. The aim is to reach 1.0 once the v0.6.0 polish work lands.
+> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.6.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
 
 ## Tools (27)
 

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -4,8 +4,8 @@ Complete reference for all MCP tools provided by the Apple Mail MCP server.
 
 ## Overview
 
-**Current Version:** v0.5.0 (Phase 4)
-**Total Tools:** 17 (5 from Phase 1 + 7 from Phase 2 + 2 from Phase 3 + 3 from Phase 4)
+**Current Version:** v0.6.0
+**Total Tools:** 27
 
 ## Phase 1 Tools (v0.1.0) - Core Foundation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-mail-mcp"
-version = "0.5.0"
+version = "0.6.0"
 description = "MCP server for Apple Mail integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_mail_mcp/__init__.py
+++ b/src/apple_mail_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Mail MCP Server
 A Model Context Protocol server for Apple Mail integration.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-mcp"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- IMAP delegation arc complete: `search_messages`, `get_message`, `get_attachments`, `get_thread` all delegate to IMAP transparently when configured.
- `search_messages` AppleScript path **22× faster** on populous mailboxes (60s → 2.7s).
- New opt-in connection pool (~40% faster on 5-call bursts), per-account circuit breaker, real setup CLI.
- 712 unit tests pass, coverage 92%, all release-validation scripts green.

## Closes
#32, #72, #73, #75, #76, #80, #100, #103, #111, #118, #122

## Headline numbers (live)
- `search_messages` (60s populous-mailbox baseline) → 2.7s
- `imap_repeat_5_calls` with pool: 10.6s → 6.3s
- `get_message` IMAP path: ~1.7s vs ~6-18s AppleScript

## Search ordering note (observable behavior change)
`search_messages` now returns newest-first; previously oldest-first. Callers that relied on the old order should reverse the result list. CHANGELOG calls this out under **Changed**.

## Deferred to v0.7.0
- #123 — RFC 5256 THREAD (Tier 2)
- #125 — per-mailbox X-GM-THRID (Tier 1.5; addresses Gmail accounts that hide All Mail from IMAP)
- #127 — atexit hook for ImapConnectionPool.close

## Test plan
- [x] `make test` (712/712 green)
- [x] `make check-all` (lint + typecheck + tests + complexity + version-sync + parity)
- [x] `./scripts/check_dependencies.sh` (vulnerability scan clean after pip 26.0.1 → 26.1)
- [x] `./scripts/check_applescript_safety.sh` (sanitize_input 34 refs, single subprocess.run)
- [x] Live verification on iCloud + Gmail accounts during PR development

## Code review
- Reviewed end-to-end against v0.5.0 by `superpowers:code-reviewer`. No release-blocking issues. One observable behavior change (search ordering, now in CHANGELOG); two follow-ups filed (#127, plus existing #125 / #123).

🤖 Generated with [Claude Code](https://claude.com/claude-code)