### PR TITLE
refactor(#130): update_rule absorbs set_rule_enabled with conditional elicitation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,7 @@ make coverage              # Coverage report
 **Core (Phase 1):** list_mailboxes, search_messages, get_message, send_email, mark_as_read
 **Attachments & Management (Phase 2):** send_email_with_attachments, get_attachments, save_attachments, move_messages, flag_message, create_mailbox, delete_messages
 **Reply/Forward (Phase 3):** reply_to_message, forward_message
-**Discovery & Rules (Phase 4):** list_accounts, list_rules, get_thread, set_rule_enabled, create_rule, update_rule, delete_rule
+**Discovery & Rules (Phase 4):** list_accounts, list_rules, get_thread, create_rule, update_rule, delete_rule
 **Templates (Phase 4 / v0.5.0):** list_templates, get_template, save_template, delete_template, render_template
 
 ## Core Principles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+**`update_rule` absorbs `set_rule_enabled` (#130):** The standalone `set_rule_enabled` MCP tool is removed; toggle a rule's enabled state via `update_rule(rule_index, enabled=True|False)` instead. `update_rule` now prompts for confirmation only when the patch touches `conditions`, `actions`, or `match_logic` (irreversible fields); patches limited to `enabled` and/or `name` skip the prompt. Migration: callers that did `set_rule_enabled(idx, True)` should call `update_rule(idx, enabled=True)`. First of the consolidations from the #129 audit (27 → 20 tools).
+
 ## [0.6.0] - 2026-05-03
 
 Performance and ergonomics release. The IMAP delegation arc started in v0.5.0 is now complete: `search_messages`, `get_message`, `get_attachments`, and `get_thread` all delegate to IMAP transparently when configured, with a clean cross-provider fallback story. Headline numbers: search drops 60s → 2.7s on a populous mailbox, the IMAP fast path is wired through every read tool, and a small per-account circuit breaker keeps offline / stale-credential bursts bounded. Setup is no longer a four-line raw-shell incantation — there's a real CLI with verification.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ An MCP server that provides programmatic access to Apple Mail, enabling AI assis
 
 > ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.6.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
 
-## Tools (27)
+## Tools (26)
 
 **Core:** list_mailboxes, search_messages, get_message, get_selected_messages, send_email, mark_as_read
 **Attachments & Management:** send_email_with_attachments, get_attachments, save_attachments, move_messages, flag_message, create_mailbox, delete_messages
 **Reply/Forward:** reply_to_message, forward_message
-**Discovery & Rules:** list_accounts, list_rules, get_thread, set_rule_enabled, create_rule, update_rule, delete_rule
+**Discovery & Rules:** list_accounts, list_rules, get_thread, create_rule, update_rule, delete_rule
 **Templates:** list_templates, get_template, save_template, delete_template, render_template
 
 See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for full parameter and return-shape documentation.

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -1050,7 +1050,7 @@ print(f"Thread has {thread['count']} messages")
 
 ### list_rules
 
-List all Mail.app rules. Returns each rule's 1-based positional index, name, and enabled state. The `index` is the handle the mutation tools (`set_rule_enabled`, `delete_rule`, `update_rule`) use to address a specific rule.
+List all Mail.app rules. Returns each rule's 1-based positional index, name, and enabled state. The `index` is the handle the mutation tools (`update_rule`, `delete_rule`) use to address a specific rule.
 
 **Parameters:** None.
 
@@ -1072,25 +1072,6 @@ List all Mail.app rules. Returns each rule's 1-based positional index, name, and
 - `index`: 1-based positional index, matching Mail.app's AppleScript reference (`rule N`). Indexes can shift if rules are reordered or deleted in Mail's UI between calls — re-fetch the list before mutating.
 - `name`: Rule display name. **Not guaranteed unique** — Mail.app allows multiple rules with the same name. Use `index`, not `name`, for unambiguous addressing.
 - `enabled`: Reflects the rule's toggle in Mail.app's Rules preferences.
-
----
-
-### set_rule_enabled
-
-Toggle a rule's enabled state.
-
-**Parameters:**
-
-- `rule_index` (int, required): 1-based index from `list_rules`.
-- `enabled` (bool, required): `true` to enable, `false` to disable.
-
-**Returns:**
-
-```json
-{"success": true, "rule_index": 3, "enabled": false}
-```
-
-No confirmation prompt — the change is trivially reversible by toggling again.
 
 ---
 
@@ -1128,7 +1109,7 @@ create_rule(
 
 ### update_rule
 
-Patch a rule's properties. Only the fields you pass are changed.
+Patch a rule's properties. Only the fields you pass are changed. Also serves as the enable/disable mechanism — pass `enabled=True|False` (the standalone `set_rule_enabled` tool was folded into this one in #130).
 
 **Parameters:**
 
@@ -1138,7 +1119,7 @@ Patch a rule's properties. Only the fields you pass are changed.
 - `match_logic` (str, optional): `"all"` or `"any"`.
 - `actions` (dict, optional): When provided, **replaces** the rule's actions wholesale (per the same schema as `create_rule`'s `actions`).
 
-**Confirmation:** elicits user confirmation before applying the change.
+**Conditional confirmation:** prompts the user via MCP elicitation only when the patch touches `conditions`, `actions`, or `match_logic` (irreversible replacements). Patches limited to `enabled` and/or `name` skip the prompt — both are trivially reversible.
 
 **Returns:**
 

--- a/src/apple_mail_mcp/security.py
+++ b/src/apple_mail_mcp/security.py
@@ -133,7 +133,6 @@ OPERATION_TIERS: dict[str, str] = {
     "flag_message": "expensive_ops",
     "create_mailbox": "expensive_ops",
     "delete_messages": "expensive_ops",
-    "set_rule_enabled": "expensive_ops",
     "delete_rule": "expensive_ops",
     "create_rule": "expensive_ops",
     "update_rule": "expensive_ops",
@@ -276,7 +275,6 @@ SEND_OPERATIONS = {
 # names start with the test prefix below. Protects the user's real rules
 # during integration testing.
 RULE_GATED_OPERATIONS = {
-    "set_rule_enabled",
     "create_rule",
     "update_rule",
     "delete_rule",

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -227,71 +227,6 @@ def _resolve_rule_name(rule_index: int) -> str | None:
 
 
 @mcp.tool()
-def set_rule_enabled(rule_index: int, enabled: bool) -> dict[str, Any]:
-    """
-    Enable or disable a Mail.app rule by 1-based positional index.
-
-    Trivially reversible — no confirmation prompt. The index is the one
-    returned by ``list_rules``; if you've changed rule order in Mail.app
-    since the last list_rules call, re-list before calling this.
-
-    Args:
-        rule_index: 1-based positional index from list_rules.
-        enabled: True to enable, False to disable.
-
-    Returns:
-        Dictionary with success status and the rule's name.
-    """
-    try:
-        rate_err = check_rate_limit(
-            "set_rule_enabled", {"rule_index": rule_index}
-        )
-        if rate_err:
-            return rate_err
-
-        rule_name = _resolve_rule_name(rule_index)
-        if rule_name is None:
-            return {
-                "success": False,
-                "error": f"No rule at index {rule_index}",
-                "error_type": "rule_not_found",
-            }
-
-        safety_err = check_test_mode_safety(
-            "set_rule_enabled", rule_name=rule_name
-        )
-        if safety_err:
-            return safety_err
-
-        mail.set_rule_enabled(rule_index, enabled)
-        operation_logger.log_operation(
-            "set_rule_enabled",
-            {"rule_index": rule_index, "enabled": enabled, "name": rule_name},
-            "success",
-        )
-        return {
-            "success": True,
-            "rule_index": rule_index,
-            "name": rule_name,
-            "enabled": enabled,
-        }
-
-    except MailRuleNotFoundError as e:
-        return {
-            "success": False,
-            "error": str(e),
-            "error_type": "rule_not_found",
-        }
-    except Exception as e:
-        logger.error(f"Error in set_rule_enabled: {e}")
-        return {
-            "success": False,
-            "error": str(e),
-            "error_type": "unknown",
-        }
-
-
-@mcp.tool()
 async def delete_rule(
     rule_index: int,
     ctx: Context | None = None,
@@ -466,11 +401,16 @@ async def update_rule(
     """
     Update an existing Mail.app rule (patch semantics).
 
-    Destructive — requires user confirmation via MCP elicitation before
-    running, because the previous condition/action state is irrecoverable
-    once replaced. Patch semantics: only fields you provide are changed.
-    ``conditions`` and ``actions``, when provided, REPLACE their respective
-    structures wholesale (not merged).
+    Patch semantics: only fields you provide are changed. ``conditions`` and
+    ``actions``, when provided, REPLACE their respective structures wholesale
+    (not merged).
+
+    Conditional confirmation: prompts the user via MCP elicitation only when
+    the patch touches ``conditions``, ``actions``, or ``match_logic`` —
+    those replacements are irrecoverable. Patches limited to ``enabled``
+    and/or ``name`` (trivially reversible) skip the prompt. The
+    enable/disable path replaces the removed ``set_rule_enabled`` tool: call
+    ``update_rule(rule_index, enabled=True|False)``.
 
     Refuses to update any rule whose existing actions include something
     outside the supported schema (run-AppleScript, redirect, reply text,
@@ -509,15 +449,21 @@ async def update_rule(
         if safety_err:
             return safety_err
 
-        summary = (
-            f"Update Mail.app rule '{rule_name}' (index {rule_index})? "
-            f"Previous condition/action state cannot be recovered."
+        needs_confirmation = (
+            conditions is not None
+            or actions is not None
+            or match_logic is not None
         )
-        cancel_err = await _elicit_confirmation(
-            ctx, summary, "update_rule", {"rule_index": rule_index}
-        )
-        if cancel_err:
-            return cancel_err
+        if needs_confirmation:
+            summary = (
+                f"Update Mail.app rule '{rule_name}' (index {rule_index})? "
+                f"Previous condition/action state cannot be recovered."
+            )
+            cancel_err = await _elicit_confirmation(
+                ctx, summary, "update_rule", {"rule_index": rule_index}
+            )
+            if cancel_err:
+                return cancel_err
 
         mail.update_rule(
             rule_index=rule_index,

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -28,6 +28,7 @@ EXPECTED_TOOLS = {
     "list_rules",
     "search_messages",
     "get_message",
+    "get_selected_messages",
     "get_thread",
     "get_attachments",
     # Send / reply / forward
@@ -43,7 +44,6 @@ EXPECTED_TOOLS = {
     "create_mailbox",
     "delete_messages",
     # Rule CRUD (#63)
-    "set_rule_enabled",
     "create_rule",
     "update_rule",
     "delete_rule",

--- a/tests/e2e/test_stdio_transport.py
+++ b/tests/e2e/test_stdio_transport.py
@@ -31,6 +31,7 @@ EXPECTED_TOOLS = {
     "list_rules",
     "search_messages",
     "get_message",
+    "get_selected_messages",
     "get_thread",
     "get_attachments",
     # Send / reply / forward
@@ -46,7 +47,6 @@ EXPECTED_TOOLS = {
     "create_mailbox",
     "delete_messages",
     # Rule CRUD (#63)
-    "set_rule_enabled",
     "create_rule",
     "update_rule",
     "delete_rule",

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -226,7 +226,7 @@ class TestCheckRateLimit:
             "mark_as_read", "move_messages", "flag_message", "create_mailbox",
             "delete_messages", "reply_to_message", "send_email",
             "send_email_with_attachments", "forward_message",
-            "set_rule_enabled", "delete_rule", "create_rule", "update_rule",
+            "delete_rule", "create_rule", "update_rule",
             "list_templates", "get_template", "save_template",
             "delete_template", "render_template",
         }
@@ -364,7 +364,7 @@ class TestCheckTestModeSafety:
         monkeypatch.setenv("MAIL_TEST_ACCOUNT", "TestAccount")
         assert (
             check_test_mode_safety(
-                "set_rule_enabled",
+                "update_rule",
                 rule_name="[apple-mail-mcp-test] my rule",
             )
             is None

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -52,7 +52,6 @@ from apple_mail_mcp.server import (
     search_messages,
     send_email,
     send_email_with_attachments,
-    set_rule_enabled,
     update_rule,
 )
 
@@ -185,31 +184,8 @@ class TestListRules:
 
 
 # ---------------------------------------------------------------------------
-# 0c. Rule mutations: set_rule_enabled, delete_rule, create_rule, update_rule
+# 0c. Rule mutations: delete_rule, create_rule, update_rule
 # ---------------------------------------------------------------------------
-
-
-class TestSetRuleEnabled:
-    def test_success_disables_rule(self, mock_mail: MagicMock) -> None:
-        mock_mail.list_rules.return_value = [
-            {"index": 1, "name": "X", "enabled": True},
-            {"index": 2, "name": "News", "enabled": True},
-        ]
-        result = set_rule_enabled(rule_index=2, enabled=False)
-        assert result["success"] is True
-        assert result["rule_index"] == 2
-        assert result["name"] == "News"
-        assert result["enabled"] is False
-        mock_mail.set_rule_enabled.assert_called_once_with(2, False)
-
-    def test_returns_rule_not_found_when_index_missing(
-        self, mock_mail: MagicMock
-    ) -> None:
-        mock_mail.list_rules.return_value = []
-        result = set_rule_enabled(rule_index=99, enabled=True)
-        assert result["success"] is False
-        assert result["error_type"] == "rule_not_found"
-        mock_mail.set_rule_enabled.assert_not_called()
 
 
 class TestDeleteRule:
@@ -293,7 +269,71 @@ class TestCreateRule:
 
 
 class TestUpdateRule:
-    async def test_success_with_accepted_ctx(
+    # ---- Irreversible patches: prompt required ---------------------------
+
+    async def test_conditions_patch_prompts_and_succeeds(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
+        mock_mail.list_rules.return_value = [
+            {"index": 1, "name": "Junk filter", "enabled": True},
+        ]
+        result = await update_rule(
+            rule_index=1,
+            conditions=[
+                {"field": "subject", "operator": "contains", "value": "X"}
+            ],
+            ctx=mock_ctx_accept,
+        )
+        assert result["success"] is True
+        mock_ctx_accept.elicit.assert_awaited_once()
+        mock_mail.update_rule.assert_called_once()
+
+    async def test_actions_patch_prompts_and_succeeds(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
+        mock_mail.list_rules.return_value = [
+            {"index": 1, "name": "Junk filter", "enabled": True},
+        ]
+        result = await update_rule(
+            rule_index=1,
+            actions={"mark_read": True},
+            ctx=mock_ctx_accept,
+        )
+        assert result["success"] is True
+        mock_ctx_accept.elicit.assert_awaited_once()
+        mock_mail.update_rule.assert_called_once()
+
+    async def test_match_logic_patch_prompts_and_succeeds(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
+        mock_mail.list_rules.return_value = [
+            {"index": 1, "name": "Junk filter", "enabled": True},
+        ]
+        result = await update_rule(
+            rule_index=1, match_logic="any", ctx=mock_ctx_accept
+        )
+        assert result["success"] is True
+        mock_ctx_accept.elicit.assert_awaited_once()
+        mock_mail.update_rule.assert_called_once()
+
+    async def test_declined_ctx_blocks_irreversible_update(
+        self, mock_mail: MagicMock, mock_ctx_decline: MagicMock
+    ) -> None:
+        mock_mail.list_rules.return_value = [
+            {"index": 1, "name": "X", "enabled": True},
+        ]
+        result = await update_rule(
+            rule_index=1,
+            actions={"delete": True},
+            ctx=mock_ctx_decline,
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "cancelled"
+        mock_mail.update_rule.assert_not_called()
+
+    # ---- Reversible-only patches: no prompt ------------------------------
+
+    async def test_enabled_only_patch_does_not_prompt(
         self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
     ) -> None:
         mock_mail.list_rules.return_value = [
@@ -303,21 +343,50 @@ class TestUpdateRule:
             rule_index=1, enabled=False, ctx=mock_ctx_accept
         )
         assert result["success"] is True
-        mock_ctx_accept.elicit.assert_awaited_once()
+        mock_ctx_accept.elicit.assert_not_awaited()
         mock_mail.update_rule.assert_called_once()
 
-    async def test_declined_ctx_blocks_update(
-        self, mock_mail: MagicMock, mock_ctx_decline: MagicMock
+    async def test_name_only_patch_does_not_prompt(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
+        mock_mail.list_rules.return_value = [
+            {"index": 1, "name": "Junk filter", "enabled": True},
+        ]
+        result = await update_rule(
+            rule_index=1, name="renamed", ctx=mock_ctx_accept
+        )
+        assert result["success"] is True
+        mock_ctx_accept.elicit.assert_not_awaited()
+        mock_mail.update_rule.assert_called_once()
+
+    async def test_enabled_plus_name_does_not_prompt(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
     ) -> None:
         mock_mail.list_rules.return_value = [
             {"index": 1, "name": "X", "enabled": True},
         ]
         result = await update_rule(
-            rule_index=1, enabled=False, ctx=mock_ctx_decline
+            rule_index=1,
+            enabled=False,
+            name="renamed",
+            ctx=mock_ctx_accept,
         )
-        assert result["success"] is False
-        assert result["error_type"] == "cancelled"
-        mock_mail.update_rule.assert_not_called()
+        assert result["success"] is True
+        mock_ctx_accept.elicit.assert_not_awaited()
+        mock_mail.update_rule.assert_called_once()
+
+    async def test_enabled_only_works_without_ctx(
+        self, mock_mail: MagicMock
+    ) -> None:
+        """Migration path for callers porting from set_rule_enabled."""
+        mock_mail.list_rules.return_value = [
+            {"index": 1, "name": "X", "enabled": True},
+        ]
+        result = await update_rule(rule_index=1, enabled=True)
+        assert result["success"] is True
+        mock_mail.update_rule.assert_called_once()
+
+    # ---- Error mapping ----------------------------------------------------
 
     async def test_returns_unsupported_action_error_type(
         self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
@@ -331,7 +400,9 @@ class TestUpdateRule:
             "uses run-script"
         )
         result = await update_rule(
-            rule_index=1, enabled=False, ctx=mock_ctx_accept
+            rule_index=1,
+            actions={"delete": True},
+            ctx=mock_ctx_accept,
         )
         assert result["success"] is False
         assert result["error_type"] == "unsupported_rule_action"


### PR DESCRIPTION
## Summary

First of the six consolidations from the #129 audit (27 → 20 tools). Closes #130.

- `update_rule` now elicits user confirmation **only** when the patch touches `conditions`, `actions`, or `match_logic` (irreversible replacements). Patches limited to `enabled` and/or `name` skip the prompt — both are trivially reversible.
- The standalone `set_rule_enabled` MCP tool is removed; callers use `update_rule(rule_index, enabled=True|False)` instead. The connector method `mail.set_rule_enabled()` stays as an internal primitive (integration test still exercises the AppleScript path).
- **Tool count: 27 → 26.**
- Drive-by: added `get_selected_messages` to both e2e `EXPECTED_TOOLS` sets — pre-existing omission since #11; the test was already failing on `main`.

## Migration

```python
# Before
set_rule_enabled(rule_index=3, enabled=False)

# After
update_rule(rule_index=3, enabled=False)   # no prompt, same behavior
```

CHANGELOG entry in the `[Unreleased]` / `Changed` block.

## Test plan

- [x] `make test` — 716 unit tests pass (4 net new conditional-elicitation tests in `TestUpdateRule`)
- [x] `make test-e2e` — 23 e2e tests pass, including the `EXPECTED_TOOLS` set assertions in both `test_mcp_tools.py` and `test_stdio_transport.py`
- [x] `make check-all` — lint, typecheck, complexity, version-sync, parity all green
- [x] Parity script warns (intentional) that `mail.set_rule_enabled()` connector method has no `@mcp.tool()` wrapper
- [x] `grep -c '^@mcp.tool()' src/apple_mail_mcp/server.py` → 26
- [ ] Manual smoke via Claude Desktop: `update_rule(idx, enabled=False)` runs silently; `update_rule(idx, actions={...})` prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)