### PR TITLE
feat(#145,#146): body_contains and text_contains filters; slow-operation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+**`body_contains` and `text_contains` filters on `search_messages` (#145):** Substring match against message body content (`body_contains`) or headers + body (`text_contains`, RFC 3501 `TEXT` semantics). Sub-second on the IMAP path (server-side `BODY` / `TEXT` predicates). Slow on the AppleScript fallback — measured 148s for 100 cold-cache messages on a 47k-message Gmail INBOX. AppleScript `text_contains` approximates the IMAP semantic by matching `content + subject + sender` (recipients omitted). Combinable with all other filter parameters and with `source=[ids]` scoping.
+
+**Slow-operation warnings (#146):** `search_messages` responses may include a new `warnings: list[str]` field that surfaces proactive cost concerns before slow paths run. v0.7.0 detection: when the call commits to AppleScript with `body_contains` or `text_contains` set, the response includes a warning advising IMAP setup for sub-second body search. Schema is additive — existing callers ignoring the field are unaffected, the field is omitted entirely when no warnings fire. Mechanism is general enough that future tools can opt in.
+
 ### Changed
 
 **`update_rule` absorbs `set_rule_enabled` (#130):** The standalone `set_rule_enabled` MCP tool is removed; toggle a rule's enabled state via `update_rule(rule_index, enabled=True|False)` instead. `update_rule` now prompts for confirmation only when the patch touches `conditions`, `actions`, or `match_logic` (irreversible fields); patches limited to `enabled` and/or `name` skip the prompt. Migration: callers that did `set_rule_enabled(idx, True)` should call `update_rule(idx, enabled=True)`. First of the consolidations from the #129 audit (27 → 20 tools).

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -29,6 +29,8 @@ Search for messages matching specified criteria.
 | `limit` | integer | No | 50 | Maximum number of results to return |
 | `source` | list[string] \| null | No | null | Optional list of message ids (with optional `"SELECTED"` sentinel) to scope the search to. `null` (default) searches the account/mailbox normally. |
 | `include_attachments` | boolean | No | false | When true, each row includes an `attachments` field with per-attachment metadata. Default off — opt-in because the AppleScript fallback path can be slow on cold caches (#142). Free on the IMAP fast path. |
+| `body_contains` | string | No | None | Substring match against message body content. IMAP: server-side `BODY` predicate (sub-second). AppleScript: per-message body read (very slow — see performance note). Case-insensitive. |
+| `text_contains` | string | No | None | Substring match against headers + body (RFC 3501 `TEXT`). IMAP: server-side `TEXT` predicate. AppleScript: matches `content + subject + sender` (recipients omitted). Same perf characteristics as `body_contains`. |
 
 **Notes:**
 - Returns metadata-only rows (id, subject, sender, date_received, read_status, flagged). For full bodies, pipe the result ids into `get_messages([ids])`.
@@ -38,6 +40,27 @@ Search for messages matching specified criteria.
 - For thread retrieval, call `get_thread(message_id)` to expand an anchor into thread member ids; pipe those ids into `source=[ids]` for filtered metadata.
 - Omitting both `account` and `source` returns `error_type: validation_error`.
 - `include_attachments` defaults to **false** for `search_messages` (unlike `get_messages` which defaults to true). Reason: search results can span 50+ rows, and the AppleScript fallback path enumerates attachments per row — measured 1s for 50 messages but 97s for 100 cold-cache messages on a 47k-message Gmail INBOX (#142). To get attachment metadata for a small known set, prefer the two-step: `search_messages(...)` to get ids → `get_messages([those_ids])` (default-on attachments, bounded cardinality).
+
+**Performance note for `body_contains` / `text_contains`:**
+
+On the IMAP path, body search is server-side and sub-second. On the AppleScript fallback, body search is **dramatically slower** — measured 148s for 100 cold-cache messages on a 47k-message INBOX, vs 1s for `subject_contains` on the same slice. This is because Mail.app must read each candidate message's body from disk. To get sub-second body search, run `apple-mail-mcp setup-imap --account <name>` to enable IMAP delegation for that account.
+
+When the call commits to the AppleScript path **and** a body/text filter is set, the response includes a `warnings` field describing the cost — see "Warnings" below.
+
+**Warnings field:**
+
+`search_messages` responses may include an optional `warnings: list[str]` field that surfaces proactive cost concerns before slow paths run. The field is **omitted** when there are no warnings (don't pollute the cheap-call default case). Currently only fires for AppleScript-path body/text search; future detection conditions may extend the mechanism. Example:
+
+```json
+{
+  "success": true,
+  "messages": [...],
+  "count": 17,
+  "warnings": [
+    "AppleScript body search can take minutes on large mailboxes (measured 148s for 100 cold-cache messages on a 47k-message Gmail INBOX). Run `apple-mail-mcp setup-imap --account 'Gmail'` for sub-second IMAP body search."
+  ]
+}
+```
 
 **Returns:**
 

--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -228,6 +228,8 @@ def _build_search_criteria(
     is_flagged: bool | None,
     date_from: str | None = None,
     date_to: str | None = None,
+    body_contains: str | None = None,
+    text_contains: str | None = None,
 ) -> list[Any]:
     """Translate ImapConnector.search_messages parameters to IMAP SEARCH criteria.
 
@@ -251,6 +253,10 @@ def _build_search_criteria(
         criteria.extend(["SINCE", _iso_to_imap_date(date_from, "date_from")])
     if date_to is not None:
         criteria.extend(["BEFORE", _iso_to_imap_before(date_to, "date_to")])
+    if body_contains:
+        criteria.extend(["BODY", body_contains])
+    if text_contains:
+        criteria.extend(["TEXT", text_contains])
     return criteria or ["ALL"]
 
 
@@ -496,6 +502,8 @@ class ImapConnector:
         has_attachment: bool | None = None,
         limit: int | None = None,
         include_attachments: bool = False,
+        body_contains: str | None = None,
+        text_contains: str | None = None,
     ) -> list[dict[str, Any]]:
         # Validate and translate filters before opening a connection so that
         # invalid input fails fast without the TCP-connect + LOGIN round trip.
@@ -506,6 +514,8 @@ class ImapConnector:
             is_flagged,
             date_from,
             date_to,
+            body_contains,
+            text_contains,
         )
 
         with self._session() as client:

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 import time
 import warnings
+from collections.abc import Callable
 from datetime import date as _date
 from datetime import timedelta as _timedelta
 from pathlib import Path
@@ -940,6 +941,8 @@ class AppleMailConnector:
         has_attachment: bool | None = None,
         limit: int | None = None,
         include_attachments: bool = False,
+        body_contains: str | None = None,
+        text_contains: str | None = None,
     ) -> list[dict[str, Any]]:
         """Run search_messages through the IMAP path.
 
@@ -970,6 +973,8 @@ class AppleMailConnector:
             has_attachment=has_attachment,
             limit=limit,
             include_attachments=include_attachments,
+            body_contains=body_contains,
+            text_contains=text_contains,
         )
 
     def search_messages(
@@ -985,6 +990,9 @@ class AppleMailConnector:
         has_attachment: bool | None = None,
         limit: int | None = None,
         include_attachments: bool = False,
+        body_contains: str | None = None,
+        text_contains: str | None = None,
+        on_warning: Callable[[str], None] | None = None,
     ) -> list[dict[str, Any]]:
         """Search for messages matching criteria.
 
@@ -1001,7 +1009,17 @@ class AppleMailConnector:
         FETCH); on the AppleScript fallback, per-row attachment enumeration
         can be expensive on cold caches — see the ``include_attachments``
         notes in TOOLS.md and #142.
+
+        ``body_contains`` and ``text_contains`` filter by message content
+        (RFC 3501 ``BODY`` / ``TEXT`` semantics on IMAP; ``content of msg``
+        on AppleScript). On AppleScript these can be very slow — measured
+        148s for 100 cold-cache messages on a 47k-message INBOX. When the
+        call commits to AppleScript and a body/text filter is set,
+        ``on_warning`` (if provided) is invoked with a human-readable string
+        describing the cost. See #145 / #146.
         """
+        body_search = bool(body_contains or text_contains)
+
         if not self._imap_breaker_open(account):
             try:
                 result = self._imap_search(
@@ -1016,12 +1034,26 @@ class AppleMailConnector:
                     has_attachment,
                     limit,
                     include_attachments,
+                    body_contains,
+                    text_contains,
                 )
                 self._imap_clear_breaker(account)
                 return result
             except _IMAP_FALLBACK_EXCS as exc:
                 self._log_imap_fallback(account, exc)
                 # fall through to AppleScript
+
+        # We're committed to the AppleScript path. Warn proactively if a
+        # body/text search is set — that's the multi-order-of-magnitude
+        # slow case (#146).
+        if on_warning is not None and body_search:
+            on_warning(
+                f"AppleScript body search can take minutes on large "
+                f"mailboxes (measured 148s for 100 cold-cache messages on "
+                f"a 47k-message Gmail INBOX). Run "
+                f"`apple-mail-mcp setup-imap --account {account!r}` for "
+                f"sub-second IMAP body search."
+            )
 
         start = time.perf_counter()
         try:
@@ -1037,6 +1069,8 @@ class AppleMailConnector:
                 has_attachment,
                 limit,
                 include_attachments,
+                body_contains,
+                text_contains,
             )
         finally:
             elapsed = time.perf_counter() - start
@@ -1062,6 +1096,8 @@ class AppleMailConnector:
         has_attachment: bool | None = None,
         limit: int | None = None,
         include_attachments: bool = False,
+        body_contains: str | None = None,
+        text_contains: str | None = None,
     ) -> list[dict[str, Any]]:
         """AppleScript path for search_messages (the universal baseline).
 
@@ -1174,6 +1210,32 @@ class AppleMailConnector:
             filter_checks.append(
                 "if (count of mail attachments of msg) > 0 "
                 "then set includeThis to false"
+            )
+
+        # Body / text filters (#145). AppleScript `contains` is
+        # case-insensitive by default, matching IMAP `SEARCH BODY`/`TEXT`
+        # semantics. Reading `content of msg` is expensive — see #146 for
+        # the proactive warning surfaced before this script runs.
+        if body_contains:
+            body_safe = escape_applescript_string(sanitize_input(body_contains))
+            filter_checks.append(
+                f'if (content of msg) does not contain "{body_safe}" '
+                f'then set includeThis to false'
+            )
+
+        if text_contains:
+            # `text_contains` is the IMAP `TEXT` predicate — substring match
+            # against headers + body. AppleScript can't easily address all
+            # headers in a per-msg property; we approximate with content +
+            # subject + sender (the practical cases). Recipients omitted —
+            # callers who need recipient matching should use `sender_contains`
+            # or future params. Documented in TOOLS.md.
+            text_safe = escape_applescript_string(sanitize_input(text_contains))
+            filter_checks.append(
+                f'if not ((content of msg) contains "{text_safe}" or '
+                f'(subject of msg) contains "{text_safe}" or '
+                f'(sender of msg) contains "{text_safe}") '
+                f'then set includeThis to false'
             )
 
         # Render filter checks each on their own line, indented for the loop.

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -629,6 +629,8 @@ def _apply_search_filters(
     date_to: str | None,
     has_attachment: bool | None,
     limit: int,
+    body_contains: str | None = None,
+    text_contains: str | None = None,
 ) -> list[dict[str, Any]]:
     """Post-filter a list of message dicts in Python.
 
@@ -639,6 +641,12 @@ def _apply_search_filters(
     IMAP/AppleScript search paths apply server-side, then truncate to
     ``limit``. The corpus is bounded by the caller's id list, so the
     cost is negligible.
+
+    ``body_contains`` and ``text_contains`` (#145) match against the
+    ``content`` field — the server tier forces ``include_content=True``
+    on the per-id fetch when these filters are set, so ``content`` is
+    populated. ``text_contains`` checks ``content + subject + sender``
+    (the practical IMAP ``TEXT`` approximation; recipients omitted).
     """
     def matches(m: dict[str, Any]) -> bool:
         if sender_contains is not None and sender_contains.lower() not in str(
@@ -661,6 +669,21 @@ def _apply_search_filters(
             m.get("has_attachment")
         ) != has_attachment:
             return False
+        if body_contains is not None and body_contains.lower() not in str(
+            m.get("content", "")
+        ).lower():
+            return False
+        if text_contains is not None:
+            needle = text_contains.lower()
+            haystack = (
+                str(m.get("content", "")).lower()
+                + " "
+                + str(m.get("subject", "")).lower()
+                + " "
+                + str(m.get("sender", "")).lower()
+            )
+            if needle not in haystack:
+                return False
         return True
 
     return [m for m in messages if matches(m)][:limit]
@@ -680,6 +703,8 @@ def search_messages(
     limit: int = 50,
     source: list[str] | None = None,
     include_attachments: bool = False,
+    body_contains: str | None = None,
+    text_contains: str | None = None,
 ) -> dict[str, Any]:
     """
     Search for messages matching criteria. Returns metadata-only rows.
@@ -729,6 +754,17 @@ def search_messages(
             IMAP fast path. To fetch attachment metadata for a known list
             of ids cheaply, prefer ``get_messages([ids])`` (default-on
             attachments, bounded cardinality).
+        body_contains: Substring match against message body content. IMAP
+            uses ``BODY`` predicate (sub-second); AppleScript reads
+            ``content of msg`` per candidate (very slow on large mailboxes
+            — measured 148s for 100 cold-cache messages). When the call
+            commits to AppleScript with this filter set, a ``warnings``
+            field is included in the response. Case-insensitive on both
+            paths.
+        text_contains: Substring match against headers + body (RFC 3501
+            ``TEXT`` semantics). On AppleScript, approximated as
+            ``content + subject + sender`` (recipients and other headers
+            not matched). Same perf characteristics as ``body_contains``.
 
     Returns:
         Dictionary containing matching messages. Each message row includes
@@ -744,10 +780,16 @@ def search_messages(
         {"success": True, "messages": [...], "count": 3}
     """
     try:
+        warnings: list[str] = []
+
         if source is not None:
+            # body/text filters need bodies on the resolved messages so the
+            # post-filter can match content. Force include_content=True for
+            # the per-id fetch when these filters are set.
+            need_body = bool(body_contains or text_contains)
             resolved = _resolve_id_list_to_messages(
                 source,
-                include_content=False,
+                include_content=need_body,
                 account=account,
                 mailbox=mailbox,
                 include_attachments=include_attachments,
@@ -762,6 +804,8 @@ def search_messages(
                 date_to,
                 has_attachment,
                 limit,
+                body_contains=body_contains,
+                text_contains=text_contains,
             )
             operation_logger.log_operation(
                 "search_messages",
@@ -775,17 +819,22 @@ def search_messages(
                         "date_from": date_from,
                         "date_to": date_to,
                         "has_attachment": has_attachment,
+                        "body_contains": body_contains,
+                        "text_contains": text_contains,
                     },
                 },
                 "success",
             )
-            return {
+            response: dict[str, Any] = {
                 "success": True,
                 "account": None,
                 "mailbox": None,
                 "messages": filtered,
                 "count": len(filtered),
             }
+            if warnings:
+                response["warnings"] = warnings
+            return response
 
         if account is None:
             return {
@@ -821,6 +870,9 @@ def search_messages(
             has_attachment=has_attachment,
             limit=limit,
             include_attachments=include_attachments,
+            body_contains=body_contains,
+            text_contains=text_contains,
+            on_warning=warnings.append,
         )
 
         operation_logger.log_operation(
@@ -836,18 +888,23 @@ def search_messages(
                     "date_from": date_from,
                     "date_to": date_to,
                     "has_attachment": has_attachment,
+                    "body_contains": body_contains,
+                    "text_contains": text_contains,
                 },
             },
             "success"
         )
 
-        return {
+        response = {
             "success": True,
             "account": account,
             "mailbox": mailbox,
             "messages": messages,
             "count": len(messages),
         }
+        if warnings:
+            response["warnings"] = warnings
+        return response
 
     except (MailAccountNotFoundError, MailMailboxNotFoundError) as e:
         logger.error(f"Not found error: {e}")

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1232,6 +1232,8 @@ class TestAppleMailConnector:
             has_attachment=None,
             include_attachments=False,
             limit=5,
+            body_contains=None,
+            text_contains=None,
         )
         assert result == [{"id": "1", "subject": "S"}]
 
@@ -1632,6 +1634,8 @@ class TestAppleMailConnector:
             True,
             10,
             False,  # include_attachments
+            None,  # body_contains
+            None,  # text_contains
         )
 
     @patch.object(AppleMailConnector, "_search_messages_applescript")

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -11,7 +11,7 @@ operation_logger calls.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp.server.elicitation import (
@@ -494,6 +494,9 @@ class TestSearchMessages:
             has_attachment=None,
             limit=10,
             include_attachments=False,
+            body_contains=None,
+            text_contains=None,
+            on_warning=ANY,
         )
         mock_logger.log_operation.assert_called_once()
         logged_op, logged_params, logged_status = mock_logger.log_operation.call_args.args
@@ -552,6 +555,9 @@ class TestSearchMessages:
             has_attachment=True,
             limit=25,
             include_attachments=False,
+            body_contains=None,
+            text_contains=None,
+            on_warning=ANY,
         )
         logged_params = mock_logger.log_operation.call_args.args[1]
         assert logged_params["filters"] == {
@@ -562,6 +568,8 @@ class TestSearchMessages:
             "date_from": "2026-04-01",
             "date_to": "2026-04-15",
             "has_attachment": True,
+            "body_contains": None,
+            "text_contains": None,
         }
 
     def test_malformed_date_maps_to_validation_error(
@@ -879,6 +887,149 @@ class TestSearchMessages:
 
         first_call = mock_mail.get_message.call_args_list[0]
         assert first_call.kwargs.get("include_attachments") is True
+
+    # ---- body_contains / text_contains (#145) ---------------------------
+
+    def test_body_contains_passes_through_to_connector(
+        self, mock_mail: MagicMock
+    ) -> None:
+        mock_mail.search_messages.return_value = []
+
+        search_messages("Gmail", body_contains="urgent")
+
+        kwargs = mock_mail.search_messages.call_args.kwargs
+        assert kwargs["body_contains"] == "urgent"
+
+    def test_text_contains_passes_through_to_connector(
+        self, mock_mail: MagicMock
+    ) -> None:
+        mock_mail.search_messages.return_value = []
+
+        search_messages("Gmail", text_contains="alice")
+
+        kwargs = mock_mail.search_messages.call_args.kwargs
+        assert kwargs["text_contains"] == "alice"
+
+    def test_body_and_text_contains_both_supplied(
+        self, mock_mail: MagicMock
+    ) -> None:
+        """Both filters compose (AND)."""
+        mock_mail.search_messages.return_value = []
+
+        search_messages(
+            "Gmail", body_contains="report", text_contains="alice"
+        )
+
+        kwargs = mock_mail.search_messages.call_args.kwargs
+        assert kwargs["body_contains"] == "report"
+        assert kwargs["text_contains"] == "alice"
+
+    def test_default_no_body_or_text_contains(
+        self, mock_mail: MagicMock
+    ) -> None:
+        mock_mail.search_messages.return_value = []
+
+        search_messages("Gmail")
+
+        kwargs = mock_mail.search_messages.call_args.kwargs
+        assert kwargs["body_contains"] is None
+        assert kwargs["text_contains"] is None
+
+    def test_source_list_with_body_contains_forces_content_fetch(
+        self, mock_mail: MagicMock
+    ) -> None:
+        """source=[ids] + body_contains: per-id fetch must include content
+        so the post-filter can match against bodies."""
+        mock_mail.get_message.return_value = {
+            "id": "1",
+            "subject": "x",
+            "sender": "a@example.com",
+            "date_received": "2026-04-01",
+            "read_status": True,
+            "flagged": False,
+            "content": "this body contains urgent text",
+        }
+
+        search_messages(source=["1"], body_contains="urgent")
+
+        first_call = mock_mail.get_message.call_args_list[0]
+        # Body needed for the post-filter — include_content forced True.
+        assert first_call.kwargs.get("include_content") is True
+
+    def test_source_list_body_contains_post_filters(
+        self, mock_mail: MagicMock
+    ) -> None:
+        """source=[ids] post-filter drops rows whose body doesn't match."""
+        mock_mail.get_message.side_effect = [
+            {
+                "id": "match",
+                "subject": "x",
+                "sender": "a@example.com",
+                "date_received": "2026-04-01",
+                "read_status": True,
+                "flagged": False,
+                "content": "the body has urgent text",
+            },
+            {
+                "id": "no-match",
+                "subject": "x",
+                "sender": "b@example.com",
+                "date_received": "2026-04-02",
+                "read_status": True,
+                "flagged": False,
+                "content": "nothing relevant here",
+            },
+        ]
+
+        result = search_messages(
+            source=["match", "no-match"], body_contains="urgent"
+        )
+
+        assert [m["id"] for m in result["messages"]] == ["match"]
+
+    # ---- warnings field (#146) ------------------------------------------
+
+    def test_warnings_field_present_when_callback_fires(
+        self, mock_mail: MagicMock
+    ) -> None:
+        """When the connector emits a warning via the on_warning callback,
+        the response includes a warnings list."""
+        def fake_search(**kwargs: Any) -> list[dict[str, Any]]:
+            on_warning = kwargs.get("on_warning")
+            if on_warning is not None:
+                on_warning("AppleScript body search may be slow")
+            return []
+
+        mock_mail.search_messages.side_effect = fake_search
+
+        result = search_messages("Gmail", body_contains="urgent")
+
+        assert "warnings" in result
+        assert any(
+            "AppleScript body search" in w for w in result["warnings"]
+        )
+
+    def test_warnings_field_omitted_when_no_callback_fires(
+        self, mock_mail: MagicMock
+    ) -> None:
+        """No warnings emitted by connector → response has no warnings field
+        (don't pollute the cheap-call default case)."""
+        mock_mail.search_messages.return_value = []
+
+        result = search_messages("Gmail")
+
+        assert "warnings" not in result
+
+    def test_on_warning_callback_passed_to_connector(
+        self, mock_mail: MagicMock
+    ) -> None:
+        """Server creates a callback and passes it through to the connector."""
+        mock_mail.search_messages.return_value = []
+
+        search_messages("Gmail", body_contains="x")
+
+        kwargs = mock_mail.search_messages.call_args.kwargs
+        assert callable(kwargs.get("on_warning"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Coordinated PR. Closes #145. Closes #146.

Adds two new filter parameters to `search_messages` (#145) and a new `warnings: list[str]` response field that surfaces proactive cost concerns before slow paths run (#146). They pair naturally because body search on the AppleScript fallback is the motivating slow case for the warning system.

**Tool count unchanged: 24.**

## Bench data (motivating the warning)

Real-data probe against Gmail INBOX, 47,547 messages, 100 cold-cache messages:

| Filter | Cost |
|---|---|
| `subject contains "the"` (existing baseline) | 1s |
| `content contains "the"` (proposed new filter) | **148s** |

That's ~150× slower for body search on the AppleScript path. On a full 47k INBOX, an unfiltered body search via AppleScript could take minutes-to-hours. IMAP's `BODY` predicate is server-side and sub-second for the same query — the warning system's job is to tell callers this when they're about to land on the slow side of that fork.

## Changes

### #145: `body_contains` / `text_contains`
- `imap_connector.py`: `_build_search_criteria` emits `BODY` / `TEXT` predicates. `ImapConnector.search_messages` accepts the params.
- `mail_connector.py`: `AppleMailConnector.search_messages` adds the params + an `on_warning: Callable[[str], None] | None` callback. `_search_messages_applescript` builds per-message filter clauses for body/text. `text_contains` on AppleScript matches `content + subject + sender` (recipients omitted — practical IMAP `TEXT` approximation).
- `server.py`: `search_messages` MCP tool adds the params; passes through. For the `source=[ids]` path, forces `include_content=True` on the per-id fetch when body/text filter is set so the post-filter can match against bodies. `_apply_search_filters` extended with body/text predicates.

### #146: `warnings: list[str]`
- Connector accepts `on_warning` callback. When committing to the AppleScript path with body/text search active, fires the callback with a warning string.
- Server creates a `warnings: list[str]`, passes `warnings.append` as the callback, includes the list in the response if non-empty. Field is **omitted** when empty — schema is additive, existing callers unaffected.
- Mechanism is general enough that future tools can opt in.

## Migration

No migration required. Both features are additive.

```python
# Body search (cheap on IMAP, slow + warned on AppleScript)
search_messages(account="Gmail", body_contains="urgent", limit=10)

# Body search on a specific id list (works on both paths; bodies fetched per-id)
search_messages(source=["12345", "67890"], body_contains="invoice")
```

CHANGELOG entry under `[Unreleased] / Added`.

## Test plan

- [x] `make test` — 737 unit tests pass (was 728; +9 net for new body/text/warnings cases on `TestSearchMessages`)
- [x] `make test-e2e` — 21 e2e tests pass (no surface changes)
- [x] `make check-all` — lint, typecheck, complexity, version-sync, parity all green
- [x] `grep -c '^@mcp.tool()' src/apple_mail_mcp/server.py` → 24 (unchanged)
- [ ] Manual smoke via Claude Desktop:
  - `search_messages(account="Gmail", body_contains="urgent", limit=5)` on an IMAP-configured account: returns matches, no `warnings`.
  - Same call on an account without IMAP configured: returns matches, includes `warnings: ["AppleScript body search can take minutes…"]`.
  - `search_messages(source=["msg-id"], body_contains="foo")` — fetches body for msg-id, filters by body match.

## Out of scope

- Other slow-path detection conditions (large mailbox unfiltered scan, large `source=[ids]`, attachment-on-search). The mechanism is in place; future work can extend.
- Mailbox-size threshold heuristics (would need `STATUS` round-trip).
- Refusing the slow path (#146 specified warn-don't-fail).
- Multi-term / regex / wildcard search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)