### PR TITLE
feat(#158): from_account emits 'Display Name <email>' sender format

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -378,7 +378,10 @@ class AppleMailConnector:
         Returns:
             List of account dicts with keys:
               - id: account UUID (stable across name changes)
-              - name: account display name
+              - name: account preferences-sidebar label (e.g. "Gmail")
+              - full_name: per-message display name used in outgoing
+                "From" headers (e.g. "Alice Smith"), or None if no
+                full name is configured for the account
               - email_addresses: list of associated email addresses
               - account_type: lowercase Mail type (e.g., "imap", "pop", "iCloud")
               - enabled: whether the account is currently enabled in Mail.app
@@ -389,7 +392,9 @@ class AppleMailConnector:
             repeat with acc in accounts
                 set accEmails to email addresses of acc
                 if accEmails is missing value then set accEmails to {}
-                set accRecord to {|id|:(id of acc as text), |name|:(name of acc), |email_addresses|:accEmails, |account_type|:((account type of acc) as text), |enabled|:(enabled of acc)}
+                set accFullName to full name of acc
+                if accFullName is missing value then set accFullName to ""
+                set accRecord to {|id|:(id of acc as text), |name|:(name of acc), |full_name|:accFullName, |email_addresses|:accEmails, |account_type|:((account type of acc) as text), |enabled|:(enabled of acc)}
                 set end of resultData to accRecord
             end repeat
         end tell
@@ -397,15 +402,26 @@ class AppleMailConnector:
 
         script = _wrap_as_json_script(tell_body)
         result = self._run_applescript(script)
-        return cast(list[dict[str, Any]], parse_applescript_json(result))
+        accounts = cast(list[dict[str, Any]], parse_applescript_json(result))
+        # Normalize empty-string full_name to None so callers don't have
+        # to distinguish two "no display name" representations.
+        for acc in accounts:
+            if not (acc.get("full_name") or "").strip():
+                acc["full_name"] = None
+        return accounts
 
     def _resolve_account_to_sender(self, account: str) -> str:
-        """Resolve an account name or UUID to its primary email address.
+        """Resolve an account name or UUID to a sender string for the
+        AppleScript ``sender`` property.
 
-        Used by the send-path methods (#155) to wire up the AppleScript
-        ``sender`` property on outgoing messages. Accepts either form
-        matching the existing ``account`` convention on ``list_mailboxes``,
-        ``search_messages``, etc.
+        Returns ``"Display Name <email>"`` when the account has a
+        ``full_name`` configured (#158), or bare ``email`` as a graceful
+        fallback when no full name is set. The Display-Name form is what
+        recipients see in their inbox's From column.
+
+        Used by the draft lifecycle (``create_draft`` / ``update_draft``)
+        per #155. Accepts either name or UUID, matching the convention on
+        ``list_mailboxes``, ``search_messages``, etc.
 
         Raises:
             MailAccountNotFoundError: No account matches the given name/UUID.
@@ -419,7 +435,11 @@ class AppleMailConnector:
                         f"Account {account!r} has no email addresses "
                         f"configured."
                     )
-                return cast(str, emails[0])
+                email = cast(str, emails[0])
+                full_name = (acc.get("full_name") or "").strip()
+                if full_name:
+                    return f"{full_name} <{email}>"
+                return email
         raise MailAccountNotFoundError(
             f"Account {account!r} not found in Mail.app configured accounts."
         )

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -547,6 +547,81 @@ class TestDraftsLifecycleIntegration:
                 return  # success
         pytest.fail("draft still queryable 10s after delete")
 
+    def test_from_account_emits_display_name_sender(
+        self,
+        connector: AppleMailConnector,
+        test_account: str,
+    ) -> None:
+        """#158: when the test account has a full_name configured, a draft
+        created with from_account=<account> should land with a 'From'
+        header in `Display Name <email>` form.
+
+        Skips when the account has no full_name set (graceful fallback to
+        bare email is exercised by unit tests; integration covers the
+        happy path)."""
+        accounts = connector.list_accounts()
+        match = next(
+            (a for a in accounts if a["name"] == test_account), None
+        )
+        if not match:
+            pytest.skip(f"test account {test_account!r} not found")
+        full_name = (match.get("full_name") or "").strip()
+        if not full_name:
+            pytest.skip(
+                f"test account {test_account!r} has no full_name "
+                f"configured — display-name path is unverifiable here"
+            )
+        emails = match.get("email_addresses") or []
+        if not emails:
+            pytest.skip(f"test account {test_account!r} has no email addresses")
+
+        result = connector.create_draft(
+            seed="new",
+            to=["target@example.com"],
+            subject="ZZZ-AMM-INTEG-DISPLAY-NAME",
+            body="checking display-name sender",
+            from_account=test_account,
+        )
+        draft_id = result["draft_id"]
+
+        try:
+            # Read the draft's headers via osascript and confirm the
+            # From header includes both the display name and email.
+            import subprocess as _subprocess
+            script = f'''
+            tell application "Mail"
+                repeat with acc in accounts
+                    try
+                        repeat with mb in mailboxes of acc
+                            if name of mb contains "Drafts" then
+                                repeat with d in messages of mb
+                                    if (id of d as text) is "{draft_id}" then
+                                        return sender of d
+                                    end if
+                                end repeat
+                            end if
+                        end repeat
+                    end try
+                end repeat
+                return ""
+            end tell
+            '''
+            r = _subprocess.run(
+                ["/usr/bin/osascript", "-e", script],
+                capture_output=True, text=True, timeout=30,
+            )
+            sender_value = r.stdout.strip()
+            assert full_name in sender_value, (
+                f"sender {sender_value!r} should contain full_name "
+                f"{full_name!r}"
+            )
+            assert emails[0] in sender_value, (
+                f"sender {sender_value!r} should contain email "
+                f"{emails[0]!r}"
+            )
+        finally:
+            connector.delete_draft(draft_id)
+
 
 class TestErrorHandling:
     """Test error handling with real Mail.app."""

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -119,20 +119,36 @@ class TestAppleMailConnector:
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         mock_run.return_value = (
-            '[{"id":"UUID-1","name":"Gmail","email_addresses":["me@gmail.com"],'
+            '[{"id":"UUID-1","name":"Gmail","full_name":"Alice Smith",'
+            '"email_addresses":["me@gmail.com"],'
             '"account_type":"imap","enabled":true},'
-            '{"id":"UUID-2","name":"Work","email_addresses":["me@work.com","alt@work.com"],'
+            '{"id":"UUID-2","name":"Work","full_name":"",'
+            '"email_addresses":["me@work.com","alt@work.com"],'
             '"account_type":"iCloud","enabled":false}]'
         )
         result = connector.list_accounts()
         assert result == [
-            {"id": "UUID-1", "name": "Gmail",
+            {"id": "UUID-1", "name": "Gmail", "full_name": "Alice Smith",
              "email_addresses": ["me@gmail.com"],
              "account_type": "imap", "enabled": True},
-            {"id": "UUID-2", "name": "Work",
+            # Empty-string full_name normalized to None.
+            {"id": "UUID-2", "name": "Work", "full_name": None,
              "email_addresses": ["me@work.com", "alt@work.com"],
              "account_type": "iCloud", "enabled": False},
         ]
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_accounts_normalizes_whitespace_only_full_name_to_none(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Whitespace-only full_name is treated as not-configured."""
+        mock_run.return_value = (
+            '[{"id":"UUID-1","name":"Gmail","full_name":"   ",'
+            '"email_addresses":["me@gmail.com"],'
+            '"account_type":"imap","enabled":true}]'
+        )
+        result = connector.list_accounts()
+        assert result[0]["full_name"] is None
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_list_accounts_empty(
@@ -148,12 +164,14 @@ class TestAppleMailConnector:
     ) -> None:
         """An account with no email addresses must return email_addresses as []."""
         mock_run.return_value = (
-            '[{"id":"UUID-3","name":"LocalOnly","email_addresses":[],'
+            '[{"id":"UUID-3","name":"LocalOnly","full_name":"Local User",'
+            '"email_addresses":[],'
             '"account_type":"imap","enabled":true}]'
         )
         result = connector.list_accounts()
         assert result == [{
-            "id": "UUID-3", "name": "LocalOnly", "email_addresses": [],
+            "id": "UUID-3", "name": "LocalOnly", "full_name": "Local User",
+            "email_addresses": [],
             "account_type": "imap", "enabled": True,
         }]
 
@@ -161,13 +179,17 @@ class TestAppleMailConnector:
     def test_list_accounts_script_includes_type_and_enabled(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """Generated AppleScript must extract account_type (as text) and enabled."""
+        """Generated AppleScript must extract account_type (as text), enabled,
+        and the full_name (#158) used for the Display Name <email> sender."""
         mock_run.return_value = "[]"
         connector.list_accounts()
         script = mock_run.call_args[0][0]
         assert "|account_type|:((account type of acc) as text)" in script
         assert "|enabled|:(enabled of acc)" in script
         assert "|id|:(id of acc as text)" in script
+        # #158: full_name read with missing-value coercion.
+        assert "full name of acc" in script
+        assert "|full_name|:accFullName" in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_list_rules_returns_structured_data(
@@ -2384,13 +2406,33 @@ class TestAppleMailConnector:
 
 
     @patch.object(AppleMailConnector, "list_accounts")
-    def test_resolve_account_to_sender_lookup_by_name(
+    def test_resolve_account_to_sender_with_full_name_emits_display_form(
         self, mock_list: MagicMock, connector: AppleMailConnector
     ) -> None:
+        """#158: account with full_name -> 'Display Name <email>' form."""
         mock_list.return_value = [
             {
                 "id": "UUID-1",
                 "name": "iCloud",
+                "full_name": "Alice Smith",
+                "email_addresses": ["alice@icloud.com"],
+            },
+        ]
+        assert (
+            connector._resolve_account_to_sender("iCloud")
+            == "Alice Smith <alice@icloud.com>"
+        )
+
+    @patch.object(AppleMailConnector, "list_accounts")
+    def test_resolve_account_to_sender_without_full_name_falls_back_to_bare_email(
+        self, mock_list: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """#158: account without full_name -> bare email (graceful fallback)."""
+        mock_list.return_value = [
+            {
+                "id": "UUID-1",
+                "name": "iCloud",
+                "full_name": None,
                 "email_addresses": ["alice@icloud.com"],
             },
         ]
@@ -2399,18 +2441,37 @@ class TestAppleMailConnector:
         )
 
     @patch.object(AppleMailConnector, "list_accounts")
-    def test_resolve_account_to_sender_lookup_by_uuid(
+    def test_resolve_account_to_sender_whitespace_only_full_name_falls_back(
+        self, mock_list: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """#158: whitespace-only full_name treated as not-configured."""
+        mock_list.return_value = [
+            {
+                "id": "UUID-1",
+                "name": "iCloud",
+                "full_name": "   ",
+                "email_addresses": ["alice@icloud.com"],
+            },
+        ]
+        assert (
+            connector._resolve_account_to_sender("iCloud") == "alice@icloud.com"
+        )
+
+    @patch.object(AppleMailConnector, "list_accounts")
+    def test_resolve_account_to_sender_lookup_by_uuid_with_full_name(
         self, mock_list: MagicMock, connector: AppleMailConnector
     ) -> None:
         mock_list.return_value = [
             {
                 "id": "UUID-1",
                 "name": "iCloud",
+                "full_name": "Alice Smith",
                 "email_addresses": ["alice@icloud.com"],
             },
         ]
         assert (
-            connector._resolve_account_to_sender("UUID-1") == "alice@icloud.com"
+            connector._resolve_account_to_sender("UUID-1")
+            == "Alice Smith <alice@icloud.com>"
         )
 
     @patch.object(AppleMailConnector, "list_accounts")
@@ -2423,6 +2484,7 @@ class TestAppleMailConnector:
             {
                 "id": "UUID-1",
                 "name": "iCloud",
+                "full_name": "Alice",
                 "email_addresses": ["alice@icloud.com"],
             },
         ]
@@ -2434,7 +2496,12 @@ class TestAppleMailConnector:
         self, mock_list: MagicMock, connector: AppleMailConnector
     ) -> None:
         mock_list.return_value = [
-            {"id": "UUID-1", "name": "Empty", "email_addresses": []},
+            {
+                "id": "UUID-1",
+                "name": "Empty",
+                "full_name": "Nobody",
+                "email_addresses": [],
+            },
         ]
         with pytest.raises(ValueError, match="email addresses"):
             connector._resolve_account_to_sender("Empty")
@@ -3390,9 +3457,34 @@ class TestCreateDraft:
         assert "set beforeIds to" not in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_new_with_from_account_sets_sender(
+    def test_new_with_from_account_sets_display_name_sender(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
+        """#158: when the resolver returns a Display Name <email> string,
+        the AppleScript embeds it verbatim (escaped) on the sender line."""
+        mock_run.return_value = "1"
+        with patch.object(
+            connector, "_resolve_account_to_sender",
+            return_value="Alice Smith <me@x.com>",
+        ):
+            connector.create_draft(
+                seed="new",
+                to=["a@example.com"],
+                subject="hi",
+                body="x",
+                from_account="Gmail",
+            )
+        script = mock_run.call_args[0][0]
+        assert (
+            'set sender of theMessage to "Alice Smith <me@x.com>"' in script
+        )
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_new_with_from_account_bare_email_passthrough(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """#158: when the resolver returns a bare email (no display name
+        configured), the AppleScript embeds the bare form."""
         mock_run.return_value = "1"
         with patch.object(
             connector, "_resolve_account_to_sender", return_value="me@x.com"


### PR DESCRIPTION
## Summary

- Polish follow-up to #157: `from_account` now produces a From header in `Display Name <email>` form (e.g. `Alice Smith <alice@example.com>`) instead of just the bare address.
- `list_accounts()` gains a `full_name: str | None` field exposing Mail.app's `full name of account` AppleScript property. Empty / whitespace-only / missing values all normalize to `None`.
- `_resolve_account_to_sender` returns the Display-Name form when `full_name` is non-empty after stripping; bare email as graceful fallback otherwise.
- Backwards compatible — `from_account` parameter shape is unchanged; only the AppleScript-emitted sender string changes.

Closes #158.

## Test plan

- [x] **Unit**: 810 tests pass, coverage 90.05%. New tests cover the new `full_name` field shape, both resolver branches (with / without full name, including whitespace-only fallback), and both AppleScript sender forms in `create_draft`.
- [x] **Integration**: 5/5 in `TestDraftsLifecycleIntegration` pass against real Mail.app, including a new test that confirms a draft created with `from_account=<test_account>` lands with the configured `full_name` and email in its sender property. Test skips gracefully when the account has no full_name configured.
- [x] `make check-all` clean (lint, mypy strict, complexity ≤ 20, version-sync, client-server parity).
- [x] **Manual smoke**: probed `full name of account` against all 5 of my real Mail accounts — property is set and returns expected strings; the missing-value fallback is exercised in unit tests with a normalized `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)