### PR TITLE
feat(#102): add update_mailbox tool (rename only)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,11 +23,12 @@ make coverage              # Coverage report
 
 **Running the server:** `uv run python -m apple_mail_mcp.server` or via Claude Desktop config.
 
-## API Surface (21 MCP tools)
+## API Surface (22 MCP tools)
 
 **Core:** list_mailboxes, search_messages, get_messages, update_message
 **Drafts lifecycle (#134):** create_draft, update_draft, delete_draft
-**Attachments & Management:** save_attachments, create_mailbox, delete_messages
+**Mailbox CRUD:** create_mailbox, update_mailbox (rename only — delete and move via IMAP follow-ups #162/#163)
+**Attachments & Management:** save_attachments, delete_messages
 **Discovery & Rules:** list_accounts, list_rules, get_thread, create_rule, update_rule, delete_rule
 **Templates:** list_templates, get_template, save_template, delete_template, render_template
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ An MCP server that provides programmatic access to Apple Mail, enabling AI assis
 
 > ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.6.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
 
-## Tools (21)
+## Tools (22)
 
 **Core:** list_mailboxes, search_messages, get_messages, update_message
 **Drafts lifecycle:** create_draft, update_draft, delete_draft
-**Attachments & Management:** save_attachments, create_mailbox, delete_messages
+**Mailbox CRUD:** create_mailbox, update_mailbox
+**Attachments & Management:** save_attachments, delete_messages
 **Discovery & Rules:** list_accounts, list_rules, get_thread, create_rule, update_rule, delete_rule
 **Templates:** list_templates, get_template, save_template, delete_template, render_template
 

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -612,6 +612,63 @@ create_mailbox(account="Gmail", name="Q2", parent_mailbox="2024")
 
 ---
 
+### update_mailbox
+
+Rename an existing mailbox.
+
+**Scope (v0.7.0):** rename only. Re-parenting (moving a mailbox between
+parents) and deletion are tracked as IMAP-based follow-ups (#163, #162)
+because Mail.app's AppleScript dictionary does not expose working
+primitives for either.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `account` | string | Yes | - | Mail.app account name or UUID (from `list_accounts`) |
+| `name` | string | Yes | - | Current mailbox name. Slash-separated for nested mailboxes (e.g. `"Archive/2024"`) |
+| `new_name` | string | Yes | - | Replacement name. Path-traversal characters (`..`, `/`, `\`) are stripped via `sanitize_mailbox_name`; an entirely-stripped value returns `validation_error` |
+
+**Returns:**
+
+```json
+{
+  "success": true,
+  "account": "Gmail",
+  "name": "Archive",
+  "new_name": "Archive-2024"
+}
+```
+
+**Examples:**
+
+```python
+# Simple rename
+update_mailbox(account="Gmail", name="ToDo", new_name="Tasks")
+
+# Rename a nested mailbox (slash-separated path)
+update_mailbox(
+    account="Gmail",
+    name="Projects/Q1",
+    new_name="Q1-Archive",
+)
+```
+
+**Caveat — Gmail system labels:** Renaming a Gmail folder under
+`[Gmail]/` (Drafts, Sent Mail, Trash, etc.) may not stick — Gmail's
+IMAP server may auto-restore the canonical name. User-created Gmail
+labels behave normally. Tracked as #164.
+
+**Error Codes:**
+
+- `validation_error`: Empty / whitespace-only `name` or `new_name`, or `new_name` sanitizes to empty.
+- `mailbox_not_found`: No mailbox at `name` in `account`.
+- `account_not_found`: `account` doesn't match any configured Mail.app account.
+- `applescript_error`: Mail.app rejected the rename for an underlying reason.
+- `unknown`: Unexpected error.
+
+---
+
 ### delete_messages
 
 Delete messages — always moves them to the account's Trash mailbox.

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -2318,6 +2318,69 @@ class AppleMailConnector:
         result = self._run_applescript(script)
         return int(result) if result.isdigit() else 0
 
+    def update_mailbox(
+        self,
+        account: str,
+        name: str,
+        new_name: str,
+    ) -> bool:
+        """Rename an existing mailbox.
+
+        v1 supports rename only. Mail.app's AppleScript dictionary does
+        not expose working primitives for delete or re-parent on
+        mailboxes — those are tracked as IMAP-based follow-ups (#162,
+        #163). The IMAP `RENAME` operation does support move via path
+        change, but that's deferred for a unified IMAP write path.
+
+        Args:
+            account: Account name or UUID.
+            name: Current mailbox name. Slash-separated for nested
+                mailboxes (e.g. "Archive/2024").
+            new_name: Replacement name. Validated + sanitized against
+                path-traversal via ``sanitize_mailbox_name``.
+
+        Returns:
+            True on success.
+
+        Raises:
+            ValueError: If new_name is invalid after sanitization.
+            MailAccountNotFoundError: If account doesn't exist.
+            MailMailboxNotFoundError: If the source mailbox doesn't exist.
+            MailAppleScriptError: If the rename otherwise fails.
+        """
+        from .utils import sanitize_mailbox_name
+
+        sanitized_new = sanitize_mailbox_name(new_name)
+        if not sanitized_new:
+            raise ValueError(f"Invalid new_name: {new_name}")
+
+        account_clause = applescript_account_clause(account)
+        name_safe = escape_applescript_string(sanitize_input(name))
+        new_name_safe = escape_applescript_string(sanitized_new)
+
+        script = f"""
+        tell application "Mail"
+            set accountRef to {account_clause}
+            try
+                set mb to mailbox "{name_safe}" of accountRef
+            on error
+                error "MAILBOX_NOT_FOUND"
+            end try
+            set name of mb to "{new_name_safe}"
+            return "success"
+        end tell
+        """
+
+        try:
+            result = self._run_applescript(script)
+        except MailAppleScriptError as e:
+            if "MAILBOX_NOT_FOUND" in str(e):
+                raise MailMailboxNotFoundError(
+                    f"mailbox {name!r} not found in account {account!r}"
+                ) from e
+            raise
+        return result == "success"
+
     def create_mailbox(
         self,
         account: str,

--- a/src/apple_mail_mcp/security.py
+++ b/src/apple_mail_mcp/security.py
@@ -129,6 +129,7 @@ OPERATION_TIERS: dict[str, str] = {
     "search_messages": "expensive_ops",
     "update_message": "expensive_ops",
     "create_mailbox": "expensive_ops",
+    "update_mailbox": "expensive_ops",
     "delete_messages": "expensive_ops",
     "delete_rule": "expensive_ops",
     "create_rule": "expensive_ops",

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -1400,6 +1400,117 @@ def create_mailbox(
 
 
 @mcp.tool()
+def update_mailbox(
+    account: str,
+    name: str,
+    new_name: str,
+) -> dict[str, Any]:
+    """Rename an existing mailbox in Apple Mail.
+
+    v1 ships rename only. Re-parenting (move) and deletion are tracked
+    as IMAP-based follow-ups (#163, #162) — Mail.app's AppleScript
+    dictionary does not expose working primitives for either, so they
+    require a different delivery path.
+
+    Caveat (#164): renaming a Gmail system label under ``[Gmail]/``
+    (Drafts, Sent Mail, Trash, etc.) may not stick — Gmail's IMAP
+    server may auto-restore the canonical name. User-created Gmail
+    labels behave normally.
+
+    Args:
+        account: Mail.app account display name or UUID (from
+            ``list_accounts``).
+        name: Current mailbox name. Slash-separated for nested
+            mailboxes (e.g. "Archive/2024").
+        new_name: Replacement name. Path-traversal characters are
+            stripped via ``sanitize_mailbox_name``; an entirely-stripped
+            value returns a ``validation_error``.
+
+    Returns:
+        ``{"success": True, "account": ..., "name": <old>, "new_name": <new>}``
+        on success, or a structured ``{success: False, error_type, error}``
+        response on failure.
+    """
+    try:
+        safety_err = check_test_mode_safety("update_mailbox", account=account)
+        if safety_err:
+            return safety_err
+
+        if not name or not name.strip():
+            return {
+                "success": False,
+                "error": "Mailbox name cannot be empty",
+                "error_type": "validation_error",
+            }
+        if not new_name or not new_name.strip():
+            return {
+                "success": False,
+                "error": "new_name cannot be empty",
+                "error_type": "validation_error",
+            }
+
+        rate_err = check_rate_limit(
+            "update_mailbox",
+            {"account": account, "name": name, "new_name": new_name},
+        )
+        if rate_err:
+            return rate_err
+
+        logger.info(
+            f"Renaming mailbox {name!r} -> {new_name!r} in account {account}"
+        )
+
+        success = mail.update_mailbox(
+            account=account, name=name, new_name=new_name
+        )
+        operation_logger.log_operation(
+            "update_mailbox",
+            {"account": account, "name": name, "new_name": new_name},
+            "success" if success else "failure",
+        )
+
+        return {
+            "success": success,
+            "account": account,
+            "name": name,
+            "new_name": new_name,
+        }
+
+    except ValueError as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "validation_error",
+        }
+    except MailMailboxNotFoundError as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "mailbox_not_found",
+        }
+    except MailAccountNotFoundError:
+        return {
+            "success": False,
+            "error": f"Account {account!r} not found",
+            "error_type": "account_not_found",
+        }
+    except MailAppleScriptError as e:
+        logger.error(f"AppleScript error in update_mailbox: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "applescript_error",
+        }
+    except Exception as e:
+        logger.exception(f"Unexpected error in update_mailbox: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "unknown",
+        }
+
+
+@mcp.tool()
 def delete_messages(
     message_ids: list[str],
     permanent: bool = False,

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -37,6 +37,7 @@ EXPECTED_TOOLS = {
     "update_message",
     "save_attachments",
     "create_mailbox",
+    "update_mailbox",
     "delete_messages",
     # Rule CRUD (#63)
     "create_rule",
@@ -180,6 +181,12 @@ INVOCATION_CASES: list[tuple[str, dict[str, Any], str, Any]] = [
         "create_mailbox",
         {"account": "TestAccount", "name": "NewBox"},
         "create_mailbox",
+        True,
+    ),
+    (
+        "update_mailbox",
+        {"account": "TestAccount", "name": "Old", "new_name": "New"},
+        "update_mailbox",
         True,
     ),
     (

--- a/tests/e2e/test_stdio_transport.py
+++ b/tests/e2e/test_stdio_transport.py
@@ -40,6 +40,7 @@ EXPECTED_TOOLS = {
     "update_message",
     "save_attachments",
     "create_mailbox",
+    "update_mailbox",
     "delete_messages",
     # Rule CRUD (#63)
     "create_rule",

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -547,6 +547,38 @@ class TestDraftsLifecycleIntegration:
                 return  # success
         pytest.fail("draft still queryable 10s after delete")
 
+    def test_update_mailbox_renames_in_place(
+        self,
+        connector: AppleMailConnector,
+        test_account: str,
+    ) -> None:
+        """#102: full create -> rename via update_mailbox -> verify cycle.
+
+        Doesn't test delete (Mail.app's AppleScript dictionary doesn't
+        expose a working delete primitive — tracked as #162). This means
+        the test leaves the renamed fixture mailbox behind for cleanup
+        via Mail.app's GUI."""
+        import uuid as _uuid
+        fixture = f"ZZZ-AMM-RENAME-INT-{_uuid.uuid4().hex[:8]}"
+        new_name = f"{fixture}-renamed"
+
+        # Create the fixture.
+        assert connector.create_mailbox(account=test_account, name=fixture)
+
+        # Rename via update_mailbox.
+        assert connector.update_mailbox(
+            account=test_account, name=fixture, new_name=new_name
+        )
+
+        # Verify via list_mailboxes — old name gone, new name present.
+        names = {m["name"] for m in connector.list_mailboxes(test_account)}
+        assert new_name in names, (
+            f"renamed mailbox {new_name!r} not in listing"
+        )
+        assert fixture not in names, (
+            f"old name {fixture!r} still in listing"
+        )
+
     def test_from_account_emits_display_name_sender(
         self,
         connector: AppleMailConnector,

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -3764,3 +3764,114 @@ class TestExtractDraftAttachments:
         script = mock_run.call_args[0][0]
         assert "save a in (POSIX file tp)" in script
         assert "mail attachments of foundDraft" in script
+
+
+class TestUpdateMailbox:
+    """Tests for AppleMailConnector.update_mailbox (rename only — #102)."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_rename_success(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "success"
+        assert connector.update_mailbox(
+            account="Gmail", name="Old", new_name="New"
+        ) is True
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_script_uses_set_name(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "success"
+        connector.update_mailbox(
+            account="Gmail", name="Old", new_name="New"
+        )
+        script = mock_run.call_args[0][0]
+        assert 'set name of mb to "New"' in script
+        assert 'mailbox "Old"' in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_script_handles_nested_path(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Slash-separated path passes through to Mail.app's
+        `mailbox "Parent/Child"` form."""
+        mock_run.return_value = "success"
+        connector.update_mailbox(
+            account="Gmail", name="Archive/2024", new_name="Archive2024"
+        )
+        script = mock_run.call_args[0][0]
+        assert 'mailbox "Archive/2024"' in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_mailbox_not_found_raises(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.side_effect = MailAppleScriptError("MAILBOX_NOT_FOUND")
+        from apple_mail_mcp.exceptions import MailMailboxNotFoundError
+        with pytest.raises(MailMailboxNotFoundError):
+            connector.update_mailbox(
+                account="Gmail", name="Missing", new_name="New"
+            )
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_other_applescript_errors_propagate(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.side_effect = MailAppleScriptError("something else")
+        with pytest.raises(MailAppleScriptError):
+            connector.update_mailbox(
+                account="Gmail", name="Old", new_name="New"
+            )
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_path_traversal_chars_stripped_before_applescript(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """``sanitize_mailbox_name`` strips traversal chars (``..``, ``/``,
+        ``\\``) rather than rejecting them outright. Verify the AppleScript
+        embeds the sanitized form, not the raw user input."""
+        mock_run.return_value = "success"
+        connector.update_mailbox(
+            account="Gmail", name="Old", new_name="../../bad-name"
+        )
+        script = mock_run.call_args[0][0]
+        # The dots and slashes are stripped; what's left is "bad-name".
+        assert '"../../bad-name"' not in script
+        assert '"bad-name"' in script
+
+    def test_new_name_that_sanitizes_to_empty_raises(
+        self, connector: AppleMailConnector
+    ) -> None:
+        """A new_name of just traversal chars sanitizes to empty -> reject."""
+        with pytest.raises(ValueError, match="Invalid new_name"):
+            connector.update_mailbox(
+                account="Gmail", name="Old", new_name="../"
+            )
+
+    def test_empty_new_name_raises(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with pytest.raises(ValueError, match="Invalid new_name"):
+            connector.update_mailbox(
+                account="Gmail", name="Old", new_name=""
+            )
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_account_clause_uses_uuid_when_uuid_passed(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Mirror the convention from create_mailbox: account UUIDs
+        produce `account id "..."` and names produce `account "..."`."""
+        mock_run.return_value = "success"
+        connector.update_mailbox(
+            account="DC5AC137-2F7A-4299-B3D0-4D3E06C18DD5",
+            name="Old", new_name="New",
+        )
+        script = mock_run.call_args[0][0]
+        # applescript_account_clause emits `account id "<UUID>"`.
+        assert 'account id "DC5AC137-2F7A-4299-B3D0-4D3E06C18DD5"' in script

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -223,7 +223,7 @@ class TestCheckRateLimit:
         expected_ops = {
             "list_accounts", "list_rules", "list_mailboxes", "get_messages",
             "get_thread", "save_attachments", "search_messages",
-            "update_message", "create_mailbox",
+            "update_message", "create_mailbox", "update_mailbox",
             "delete_messages", "reply_to_message", "send_email",
             "send_email_with_attachments", "forward_message",
             "delete_rule", "create_rule", "update_rule",

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1662,6 +1662,110 @@ class TestCreateMailbox:
         assert result["error_type"] == "unknown"
 
 
+class TestUpdateMailboxTool:
+    """Tests for the update_mailbox MCP tool (rename only — #102)."""
+
+    def test_rename_success(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.server import update_mailbox
+
+        mock_mail.update_mailbox.return_value = True
+        result = update_mailbox(account="Gmail", name="Old", new_name="New")
+
+        assert result == {
+            "success": True,
+            "account": "Gmail",
+            "name": "Old",
+            "new_name": "New",
+        }
+        mock_mail.update_mailbox.assert_called_once_with(
+            account="Gmail", name="Old", new_name="New"
+        )
+
+    def test_empty_name_validation_error(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.server import update_mailbox
+
+        result = update_mailbox(account="Gmail", name="", new_name="New")
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_mail.update_mailbox.assert_not_called()
+
+    def test_empty_new_name_validation_error(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.server import update_mailbox
+
+        result = update_mailbox(account="Gmail", name="Old", new_name="")
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_mail.update_mailbox.assert_not_called()
+
+    def test_whitespace_only_new_name_validation_error(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.server import update_mailbox
+
+        result = update_mailbox(account="Gmail", name="Old", new_name="   ")
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+
+    def test_mailbox_not_found(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.exceptions import MailMailboxNotFoundError
+        from apple_mail_mcp.server import update_mailbox
+
+        mock_mail.update_mailbox.side_effect = MailMailboxNotFoundError(
+            "no mailbox 'Old'"
+        )
+        result = update_mailbox(account="Gmail", name="Old", new_name="New")
+        assert result["error_type"] == "mailbox_not_found"
+
+    def test_account_not_found(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.server import update_mailbox
+
+        mock_mail.update_mailbox.side_effect = MailAccountNotFoundError(
+            "no account"
+        )
+        result = update_mailbox(account="Bogus", name="Old", new_name="New")
+        assert result["error_type"] == "account_not_found"
+
+    def test_connector_value_error_maps_to_validation_error(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """sanitize_mailbox_name in the connector can reject a new_name
+        whose sanitized form is empty (e.g. '../') — surface as
+        validation_error to the caller."""
+        from apple_mail_mcp.server import update_mailbox
+
+        mock_mail.update_mailbox.side_effect = ValueError("Invalid new_name")
+        result = update_mailbox(account="Gmail", name="Old", new_name="../")
+        assert result["error_type"] == "validation_error"
+
+    def test_applescript_error(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.server import update_mailbox
+
+        mock_mail.update_mailbox.side_effect = MailAppleScriptError("boom")
+        result = update_mailbox(account="Gmail", name="Old", new_name="New")
+        assert result["error_type"] == "applescript_error"
+
+    def test_unexpected_exception_maps_to_unknown(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.server import update_mailbox
+
+        mock_mail.update_mailbox.side_effect = RuntimeError("boom")
+        result = update_mailbox(account="Gmail", name="Old", new_name="New")
+        assert result["error_type"] == "unknown"
+
+
 # ---------------------------------------------------------------------------
 # 12. delete_messages
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds the rename half of the requested mailbox CRUD. AppleScript probes during implementation revealed Mail.app's dictionary lacks working `delete mailbox` and re-parent primitives, so this PR ships only what works. The full original-spec scope (delete + move) is filed as IMAP-based follow-ups.

Closes #102 (rename portion). Filed for the rest:
- #162 — `delete_mailbox` via IMAP
- #163 — `update_mailbox` re-parent via IMAP
- #164 — Gmail label-aware mailbox CRUD

## AppleScript probe findings

| Operation | AppleScript verb | Result |
|---|---|---|
| Rename | `set name of mailbox X of accountRef to "Y"` | ✅ Works |
| Re-parent | `set mailbox of mailbox X to mailbox Y` | ❌ Silent no-op |
| Re-parent | `move mailbox X to mailbox Y` | ❌ \`AppleEvent handler failed\` |
| Delete | `delete mailbox X` (any reference form) | ❌ \`AppleEvent handler failed\`, even on empty just-created mailbox |

## Tool surface

```python
update_mailbox(
    account: str,           # name or UUID
    name: str,              # current name; slash-separated path for nested
    new_name: str,          # rename target
) -> dict[str, Any]
```

Return: `{success, account, name, new_name}` or structured error.

## Test plan

- [x] **Unit**: 9 connector tests + 9 server-tool tests covering validation matrix, success path, all five mapped exception types, sanitization-strips-then-embeds, and account-clause UUID-vs-name dispatch.
- [x] **Integration**: new test in `TestDraftsLifecycleIntegration` does create → rename → verify against real Gmail.
- [x] **E2E**: added `update_mailbox` to `EXPECTED_TOOLS` and the parameterized invocation case.
- [x] **`make check-all`** clean (lint, mypy strict, complexity ≤ 20, version-sync, client-server parity).
- [x] 829 unit + e2e tests pass.

## Caveats documented in the tool docstring

- Slash-separated path for nested mailboxes (matches what `list_mailboxes` already returns).
- Gmail system labels under `[Gmail]/` may auto-restore canonical names after rename — Gmail IMAP server-side behavior, not a bug in this PR.

## ⚠️ Probe artifacts in test Gmail account

Leftover probe mailboxes from this session that I could not clean up programmatically (since `delete mailbox` doesn't work via AppleScript). These need manual removal via Mail.app's GUI:
- `ZZZ-AMM-PROBE-MB-242995D7-renamed`
- `ZZZAMMP527F58`
- `ZZZ-PARENT-D85E3C`
- `ZZZ-CHILD-14D0B8`
- `ZZZ-AMM-RENAME-SMOKE-7d0e329c-renamed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)