### PR TITLE
feat(#162,#163): mailbox delete + move via IMAP

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,11 +23,11 @@ make coverage              # Coverage report
 
 **Running the server:** `uv run python -m apple_mail_mcp.server` or via Claude Desktop config.
 
-## API Surface (22 MCP tools)
+## API Surface (23 MCP tools)
 
 **Core:** list_mailboxes, search_messages, get_messages, update_message
 **Drafts lifecycle (#134):** create_draft, update_draft, delete_draft
-**Mailbox CRUD:** create_mailbox, update_mailbox (rename only — delete and move via IMAP follow-ups #162/#163)
+**Mailbox CRUD:** create_mailbox, update_mailbox (rename + move via IMAP), delete_mailbox (IMAP-only)
 **Attachments & Management:** save_attachments, delete_messages
 **Discovery & Rules:** list_accounts, list_rules, get_thread, create_rule, update_rule, delete_rule
 **Templates:** list_templates, get_template, save_template, delete_template, render_template

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ An MCP server that provides programmatic access to Apple Mail, enabling AI assis
 
 > ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.6.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
 
-## Tools (22)
+## Tools (23)
 
 **Core:** list_mailboxes, search_messages, get_messages, update_message
 **Drafts lifecycle:** create_draft, update_draft, delete_draft
-**Mailbox CRUD:** create_mailbox, update_mailbox
+**Mailbox CRUD:** create_mailbox, update_mailbox, delete_mailbox
 **Attachments & Management:** save_attachments, delete_messages
 **Discovery & Rules:** list_accounts, list_rules, get_thread, create_rule, update_rule, delete_rule
 **Templates:** list_templates, get_template, save_template, delete_template, render_template

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -614,12 +614,12 @@ create_mailbox(account="Gmail", name="Q2", parent_mailbox="2024")
 
 ### update_mailbox
 
-Rename an existing mailbox.
+Rename and/or re-parent (move) an existing mailbox.
 
-**Scope (v0.7.0):** rename only. Re-parenting (moving a mailbox between
-parents) and deletion are tracked as IMAP-based follow-ups (#163, #162)
-because Mail.app's AppleScript dictionary does not expose working
-primitives for either.
+**Two delivery paths:**
+
+- **Rename only** (`new_name` set, `new_parent` is `None`): AppleScript's `set name of mailbox X to "Y"`. Fast, no IMAP credentials needed.
+- **Move** (`new_parent` set, optionally combined with rename): IMAP `RENAME`. Requires IMAP credentials in Keychain (#73 opt-in flow) — returns `error_type: "imap_required"` when missing.
 
 **Parameters:**
 
@@ -627,7 +627,8 @@ primitives for either.
 |-----------|------|----------|---------|-------------|
 | `account` | string | Yes | - | Mail.app account name or UUID (from `list_accounts`) |
 | `name` | string | Yes | - | Current mailbox name. Slash-separated for nested mailboxes (e.g. `"Archive/2024"`) |
-| `new_name` | string | Yes | - | Replacement name. Path-traversal characters (`..`, `/`, `\`) are stripped via `sanitize_mailbox_name`; an entirely-stripped value returns `validation_error` |
+| `new_name` | string | No | None | Replacement leaf name. `None` keeps the current leaf when moving. Path-traversal characters stripped via `sanitize_mailbox_name`. At least one of `new_name` / `new_parent` is required. |
+| `new_parent` | string | No | None | Destination parent path. `None` keeps current parent (rename-only). `""` (empty string) moves to top-level. Non-empty string moves under that path. |
 
 **Returns:**
 
@@ -635,36 +636,109 @@ primitives for either.
 {
   "success": true,
   "account": "Gmail",
-  "name": "Archive",
-  "new_name": "Archive-2024"
+  "name": "Archive/2024",
+  "new_name": null,
+  "new_parent": "OldStuff"
 }
 ```
 
 **Examples:**
 
 ```python
-# Simple rename
+# Simple rename (no IMAP needed)
 update_mailbox(account="Gmail", name="ToDo", new_name="Tasks")
 
 # Rename a nested mailbox (slash-separated path)
 update_mailbox(
-    account="Gmail",
-    name="Projects/Q1",
-    new_name="Q1-Archive",
+    account="Gmail", name="Projects/Q1", new_name="Q1-Archive",
 )
+
+# Move a nested mailbox to a different parent (IMAP)
+update_mailbox(
+    account="Gmail", name="Inbox/Projects/Q1",
+    new_parent="Archive/2024",
+)
+# -> "Inbox/Projects/Q1" becomes "Archive/2024/Q1"
+
+# Promote a nested mailbox to top-level
+update_mailbox(account="Gmail", name="Inbox/Old", new_parent="")
+# -> "Inbox/Old" becomes "Old"
+
+# Move + rename in one IMAP RENAME
+update_mailbox(
+    account="Gmail", name="A/B", new_name="Renamed", new_parent="C",
+)
+# -> "A/B" becomes "C/Renamed"
 ```
 
-**Caveat — Gmail system labels:** Renaming a Gmail folder under
+**Caveat — Gmail system labels:** Renaming or moving a Gmail folder under
 `[Gmail]/` (Drafts, Sent Mail, Trash, etc.) may not stick — Gmail's
 IMAP server may auto-restore the canonical name. User-created Gmail
 labels behave normally. Tracked as #164.
 
 **Error Codes:**
 
-- `validation_error`: Empty / whitespace-only `name` or `new_name`, or `new_name` sanitizes to empty.
-- `mailbox_not_found`: No mailbox at `name` in `account`.
-- `account_not_found`: `account` doesn't match any configured Mail.app account.
-- `applescript_error`: Mail.app rejected the rename for an underlying reason.
+- `validation_error`: Empty / whitespace-only `name`, missing both `new_name` and `new_parent`, or `new_name` sanitizes to empty.
+- `imap_required`: Move requested but no IMAP credentials in Keychain for `account`.
+- `mailbox_not_found`: No mailbox at `name`.
+- `account_not_found`: `account` doesn't match any configured account.
+- `applescript_error`: Mail.app rejected a rename for an underlying reason.
+- `unknown`: Unexpected error.
+
+---
+
+### delete_mailbox
+
+Delete a mailbox via IMAP. Mail.app's AppleScript dictionary doesn't
+expose a working delete primitive for mailboxes (verified by probe), so
+this operation requires IMAP credentials in Keychain (#73 opt-in flow).
+
+**Always elicits user confirmation** (destructive). Refuses non-empty
+mailboxes by default to prevent accidental data loss; pass
+`delete_messages=True` to cascade.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `account` | string | Yes | - | Mail.app account name or UUID |
+| `name` | string | Yes | - | Mailbox name. Slash-separated for nested. |
+| `delete_messages` | boolean | No | False | When False, refuses if the mailbox contains messages. When True, cascade-deletes the mailbox and its contents. |
+
+**Returns:**
+
+```json
+{
+  "success": true,
+  "account": "Gmail",
+  "name": "Old/Archive",
+  "deleted_message_count": 0
+}
+```
+
+`deleted_message_count` is 0 when the mailbox was empty; positive when
+`delete_messages=True` cascaded.
+
+**Examples:**
+
+```python
+# Safe delete (refuses if any messages)
+delete_mailbox(account="Gmail", name="Old/Empty")
+
+# Cascade-delete a non-empty mailbox
+delete_mailbox(
+    account="Gmail", name="Old/Archive", delete_messages=True,
+)
+```
+
+**Error Codes:**
+
+- `cancelled`: User declined the elicitation prompt.
+- `validation_error`: Empty `name`.
+- `imap_required`: No IMAP credentials in Keychain for `account`.
+- `mailbox_not_empty`: Mailbox contains messages and `delete_messages=False`.
+- `mailbox_not_found`: No mailbox at `name`.
+- `account_not_found`: `account` doesn't match any configured account.
 - `unknown`: Unexpected error.
 
 ---

--- a/src/apple_mail_mcp/exceptions.py
+++ b/src/apple_mail_mcp/exceptions.py
@@ -21,6 +21,22 @@ class MailMailboxNotFoundError(MailError):
     pass
 
 
+class MailMailboxNotEmptyError(MailError):
+    """Mailbox cannot be deleted because it contains messages and the
+    caller did not opt in to cascade-delete via ``delete_messages=True``."""
+
+    pass
+
+
+class MailImapRequiredError(MailError):
+    """The requested operation requires IMAP credentials and the user
+    hasn't opted in (no Keychain entry, or entry is unreachable). Surfaces
+    the gap so the caller can prompt the user to set up IMAP if they want
+    the operation."""
+
+    pass
+
+
 class MailMessageNotFoundError(MailError):
     """Message does not exist."""
 

--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -770,6 +770,77 @@ class ImapConnector:
                 client, anchor_rfc_message_id, anchor_references,
             )
 
+    def delete_mailbox(self, name: str, *, allow_non_empty: bool = False) -> int:
+        """Delete an IMAP mailbox via the IMAP DELETE command.
+
+        Pre-flight: SELECT readonly to read the EXISTS count. Refuses if
+        the mailbox has messages and ``allow_non_empty=False`` — surface
+        as ``MailMailboxNotEmptyError`` from the caller.
+
+        Args:
+            name: Mailbox name (slash-separated for nested).
+            allow_non_empty: When True, skips the message-count refusal
+                and lets IMAP DELETE remove the mailbox along with its
+                contents.
+
+        Returns:
+            The message count that was on the mailbox at the moment of
+            delete (0 if empty, N if cascading).
+
+        Raises:
+            ValueError: If the mailbox is non-empty and the caller did
+                not opt in to ``allow_non_empty``.
+            imapclient.exceptions.IMAPClientError: Server-side error
+                (mailbox doesn't exist, permission denied, etc.).
+        """
+        with self._session() as client:
+            try:
+                info = client.select_folder(name, readonly=True)
+            except IMAPClientError:
+                # Surface "mailbox doesn't exist" via the original IMAP error.
+                raise
+            count = int(info.get(b"EXISTS", 0))
+            if count > 0 and not allow_non_empty:
+                # CLOSE the readonly select before raising — leaves the
+                # connection clean for any subsequent reuse via the pool.
+                try:
+                    client.close_folder()
+                except IMAPClientError:
+                    pass
+                raise ValueError(
+                    f"mailbox {name!r} is not empty ({count} messages); "
+                    f"pass allow_non_empty=True to cascade-delete"
+                )
+            # IMAP DELETE requires the mailbox NOT to be selected on most
+            # servers; CLOSE first.
+            try:
+                client.close_folder()
+            except IMAPClientError:
+                pass
+            client.delete_folder(name)
+            return count
+
+    def rename_mailbox(self, old_name: str, new_name: str) -> None:
+        """Rename a mailbox via the IMAP RENAME command.
+
+        IMAP RENAME also serves as the move primitive — destination path
+        with a different parent (e.g. ``"OldParent/Child"`` →
+        ``"NewParent/Child"``) re-parents the mailbox in one operation.
+
+        Args:
+            old_name: Current mailbox name (slash-separated for nested).
+            new_name: Destination name. Slash-separated; intermediate
+                parents must exist (server behavior varies — most refuse
+                to auto-create missing parents).
+
+        Raises:
+            imapclient.exceptions.IMAPClientError: Server-side error
+                (source missing, destination exists, parent missing,
+                permission denied, etc.).
+        """
+        with self._session() as client:
+            client.rename_folder(old_name, new_name)
+
     @staticmethod
     def _has_capability(client: IMAPClient, name: bytes) -> bool:
         """True if ``name`` (e.g. ``b"X-GM-EXT-1"``) is in the post-login

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -20,8 +20,10 @@ from .exceptions import (
     MailAccountNotFoundError,
     MailAppleScriptError,
     MailDraftNotFoundError,
+    MailImapRequiredError,
     MailKeychainAccessDeniedError,
     MailKeychainEntryNotFoundError,
+    MailMailboxNotEmptyError,
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
     MailRuleNotFoundError,
@@ -2322,64 +2324,185 @@ class AppleMailConnector:
         self,
         account: str,
         name: str,
-        new_name: str,
+        new_name: str | None = None,
+        new_parent: str | None = None,
     ) -> bool:
-        """Rename an existing mailbox.
+        """Rename and/or re-parent an existing mailbox.
 
-        v1 supports rename only. Mail.app's AppleScript dictionary does
-        not expose working primitives for delete or re-parent on
-        mailboxes — those are tracked as IMAP-based follow-ups (#162,
-        #163). The IMAP `RENAME` operation does support move via path
-        change, but that's deferred for a unified IMAP write path.
+        - **Rename only** (``new_name`` set, ``new_parent`` is ``None``):
+          AppleScript's ``set name of mailbox X to "Y"``. Fast, no IMAP
+          credentials needed.
+        - **Move** (``new_parent`` set): IMAP RENAME with the destination
+          path computed from ``new_parent`` + the leaf of ``name``.
+          ``new_parent=""`` means move to top-level.
+          Requires IMAP credentials in Keychain (#73 opt-in flow).
+
+        At least one of ``new_name`` / ``new_parent`` must be provided.
+        Combined ("move and rename") works in one IMAP RENAME.
 
         Args:
             account: Account name or UUID.
             name: Current mailbox name. Slash-separated for nested
-                mailboxes (e.g. "Archive/2024").
-            new_name: Replacement name. Validated + sanitized against
-                path-traversal via ``sanitize_mailbox_name``.
+                mailboxes (e.g. ``"Archive/2024"``).
+            new_name: Replacement leaf name. ``None`` to keep the current
+                leaf. Sanitized via ``sanitize_mailbox_name``.
+            new_parent: Destination parent path. ``None`` means keep
+                current parent (rename only). ``""`` (empty string) means
+                move to top-level. Non-empty string means move under that
+                path.
 
         Returns:
             True on success.
 
         Raises:
-            ValueError: If new_name is invalid after sanitization.
+            ValueError: If neither ``new_name`` nor ``new_parent`` was
+                provided, or ``new_name`` sanitizes to empty.
             MailAccountNotFoundError: If account doesn't exist.
             MailMailboxNotFoundError: If the source mailbox doesn't exist.
-            MailAppleScriptError: If the rename otherwise fails.
+            MailImapRequiredError: If a move was requested but no IMAP
+                credentials are configured for ``account``.
+            MailAppleScriptError: If a rename-only path otherwise fails.
+            imapclient.exceptions.IMAPClientError: If a move otherwise
+                fails on the IMAP server.
         """
         from .utils import sanitize_mailbox_name
 
-        sanitized_new = sanitize_mailbox_name(new_name)
-        if not sanitized_new:
-            raise ValueError(f"Invalid new_name: {new_name}")
+        if new_name is None and new_parent is None:
+            raise ValueError(
+                "update_mailbox requires at least one of new_name or new_parent"
+            )
 
-        account_clause = applescript_account_clause(account)
-        name_safe = escape_applescript_string(sanitize_input(name))
-        new_name_safe = escape_applescript_string(sanitized_new)
+        sanitized_new_name: str | None = None
+        if new_name is not None:
+            sanitized_new_name = sanitize_mailbox_name(new_name)
+            if not sanitized_new_name:
+                raise ValueError(f"Invalid new_name: {new_name}")
 
-        script = f"""
-        tell application "Mail"
-            set accountRef to {account_clause}
-            try
-                set mb to mailbox "{name_safe}" of accountRef
-            on error
-                error "MAILBOX_NOT_FOUND"
-            end try
-            set name of mb to "{new_name_safe}"
-            return "success"
-        end tell
-        """
+        # ------------------------------------------------------------------
+        # Rename-only path (no parent change) -> AppleScript
+        # ------------------------------------------------------------------
+        if new_parent is None:
+            assert sanitized_new_name is not None  # narrowed by the guard above
+            account_clause = applescript_account_clause(account)
+            name_safe = escape_applescript_string(sanitize_input(name))
+            new_name_safe = escape_applescript_string(sanitized_new_name)
+
+            script = f"""
+            tell application "Mail"
+                set accountRef to {account_clause}
+                try
+                    set mb to mailbox "{name_safe}" of accountRef
+                on error
+                    error "MAILBOX_NOT_FOUND"
+                end try
+                set name of mb to "{new_name_safe}"
+                return "success"
+            end tell
+            """
+
+            try:
+                result = self._run_applescript(script)
+            except MailAppleScriptError as e:
+                if "MAILBOX_NOT_FOUND" in str(e):
+                    raise MailMailboxNotFoundError(
+                        f"mailbox {name!r} not found in account {account!r}"
+                    ) from e
+                raise
+            return result == "success"
+
+        # ------------------------------------------------------------------
+        # Move (with optional rename) -> IMAP RENAME
+        # ------------------------------------------------------------------
+        # Destination path = new_parent + "/" + (new_name or current leaf).
+        leaf = sanitized_new_name if sanitized_new_name else name.rsplit("/", 1)[-1]
+        if new_parent == "":
+            destination = leaf
+        else:
+            destination = f"{new_parent}/{leaf}"
 
         try:
-            result = self._run_applescript(script)
-        except MailAppleScriptError as e:
-            if "MAILBOX_NOT_FOUND" in str(e):
+            host, port, email = self._resolve_imap_config(account)
+            password = get_imap_password(account, email)
+        except (
+            MailKeychainEntryNotFoundError, MailKeychainAccessDeniedError
+        ) as e:
+            raise MailImapRequiredError(
+                f"moving a mailbox requires IMAP credentials for account "
+                f"{account!r}; configure them via the Keychain opt-in flow"
+            ) from e
+
+        imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
+        try:
+            imap.rename_mailbox(name, destination)
+        except IMAPClientError as e:
+            # Map "mailbox doesn't exist" to the typed error; let other
+            # IMAP errors propagate for the server layer to translate.
+            msg = str(e).lower()
+            if "no such" in msg or "doesn't exist" in msg or "doesn't exist" in msg:
                 raise MailMailboxNotFoundError(
                     f"mailbox {name!r} not found in account {account!r}"
                 ) from e
             raise
-        return result == "success"
+        return True
+
+    def delete_mailbox(
+        self,
+        account: str,
+        name: str,
+        delete_messages: bool = False,
+    ) -> int:
+        """Delete a mailbox via IMAP DELETE.
+
+        Mail.app's AppleScript ``delete`` command's handler refuses
+        mailbox specifiers (verified by probe), so this operation is
+        IMAP-only. Requires Keychain credentials per the #73 opt-in
+        flow; raises ``MailImapRequiredError`` otherwise.
+
+        Args:
+            account: Account name or UUID.
+            name: Mailbox name. Slash-separated for nested mailboxes.
+            delete_messages: When False (default), refuse if the mailbox
+                contains messages. When True, cascade-delete the mailbox
+                and its contents.
+
+        Returns:
+            Number of messages that existed at delete time (0 for empty
+            mailbox; positive when ``delete_messages=True`` cascaded).
+
+        Raises:
+            MailAccountNotFoundError: If account doesn't exist.
+            MailMailboxNotFoundError: If the mailbox doesn't exist on
+                the IMAP server.
+            MailMailboxNotEmptyError: If ``delete_messages=False`` and
+                the mailbox is non-empty.
+            MailImapRequiredError: If no Keychain credentials.
+            imapclient.exceptions.IMAPClientError: Other server-side
+                error.
+        """
+        try:
+            host, port, email = self._resolve_imap_config(account)
+            password = get_imap_password(account, email)
+        except (
+            MailKeychainEntryNotFoundError, MailKeychainAccessDeniedError
+        ) as e:
+            raise MailImapRequiredError(
+                f"deleting a mailbox requires IMAP credentials for account "
+                f"{account!r}; configure them via the Keychain opt-in flow"
+            ) from e
+
+        imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
+        try:
+            return imap.delete_mailbox(name, allow_non_empty=delete_messages)
+        except ValueError as e:
+            # ImapConnector raises ValueError on the non-empty refusal.
+            raise MailMailboxNotEmptyError(str(e)) from e
+        except IMAPClientError as e:
+            msg = str(e).lower()
+            if "no such" in msg or "doesn't exist" in msg or "nonexistent" in msg:
+                raise MailMailboxNotFoundError(
+                    f"mailbox {name!r} not found in account {account!r}"
+                ) from e
+            raise
 
     def create_mailbox(
         self,

--- a/src/apple_mail_mcp/security.py
+++ b/src/apple_mail_mcp/security.py
@@ -130,6 +130,7 @@ OPERATION_TIERS: dict[str, str] = {
     "update_message": "expensive_ops",
     "create_mailbox": "expensive_ops",
     "update_mailbox": "expensive_ops",
+    "delete_mailbox": "expensive_ops",
     "delete_messages": "expensive_ops",
     "delete_rule": "expensive_ops",
     "create_rule": "expensive_ops",

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -18,6 +18,8 @@ from .exceptions import (
     MailDraftError,
     MailDraftInvalidIdError,
     MailDraftNotFoundError,
+    MailImapRequiredError,
+    MailMailboxNotEmptyError,
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
     MailRuleNotFoundError,
@@ -1403,33 +1405,40 @@ def create_mailbox(
 def update_mailbox(
     account: str,
     name: str,
-    new_name: str,
+    new_name: str | None = None,
+    new_parent: str | None = None,
 ) -> dict[str, Any]:
-    """Rename an existing mailbox in Apple Mail.
+    """Rename and/or re-parent (move) an existing mailbox.
 
-    v1 ships rename only. Re-parenting (move) and deletion are tracked
-    as IMAP-based follow-ups (#163, #162) — Mail.app's AppleScript
-    dictionary does not expose working primitives for either, so they
-    require a different delivery path.
+    Two delivery paths:
 
-    Caveat (#164): renaming a Gmail system label under ``[Gmail]/``
-    (Drafts, Sent Mail, Trash, etc.) may not stick — Gmail's IMAP
-    server may auto-restore the canonical name. User-created Gmail
-    labels behave normally.
+    - **Rename only** (``new_name`` set, ``new_parent`` is ``None``):
+      AppleScript. Fast, no IMAP credentials needed.
+    - **Move** (``new_parent`` set; optionally combined with rename):
+      IMAP RENAME. Requires IMAP credentials in Keychain (#73 opt-in
+      flow) — returns ``error_type: "imap_required"`` when missing.
+
+    At least one of ``new_name`` / ``new_parent`` must be provided.
+
+    Caveat (#164): renaming Gmail system labels under ``[Gmail]/`` may
+    not stick — Gmail's IMAP server may auto-restore canonical names.
+    User-created Gmail labels behave normally.
 
     Args:
-        account: Mail.app account display name or UUID (from
-            ``list_accounts``).
-        name: Current mailbox name. Slash-separated for nested
-            mailboxes (e.g. "Archive/2024").
-        new_name: Replacement name. Path-traversal characters are
-            stripped via ``sanitize_mailbox_name``; an entirely-stripped
-            value returns a ``validation_error``.
+        account: Mail.app account display name or UUID.
+        name: Current mailbox name. Slash-separated for nested mailboxes
+            (e.g. ``"Archive/2024"``).
+        new_name: Replacement leaf name. ``None`` to keep the current
+            leaf when moving. Path-traversal characters stripped via
+            ``sanitize_mailbox_name``; an entirely-stripped value
+            returns ``validation_error``.
+        new_parent: Destination parent path. ``None`` keeps current
+            parent (rename-only). ``""`` (empty string) moves to
+            top-level. Non-empty string moves under that path.
 
     Returns:
-        ``{"success": True, "account": ..., "name": <old>, "new_name": <new>}``
-        on success, or a structured ``{success: False, error_type, error}``
-        response on failure.
+        ``{success, account, name, new_name, new_parent}`` on success,
+        or structured error response.
     """
     try:
         safety_err = check_test_mode_safety("update_mailbox", account=account)
@@ -1442,30 +1451,40 @@ def update_mailbox(
                 "error": "Mailbox name cannot be empty",
                 "error_type": "validation_error",
             }
-        if not new_name or not new_name.strip():
+        if new_name is None and new_parent is None:
             return {
                 "success": False,
-                "error": "new_name cannot be empty",
+                "error": "At least one of new_name or new_parent is required",
+                "error_type": "validation_error",
+            }
+        if new_name is not None and not new_name.strip():
+            return {
+                "success": False,
+                "error": "new_name cannot be empty (pass None to keep current leaf)",
                 "error_type": "validation_error",
             }
 
         rate_err = check_rate_limit(
             "update_mailbox",
-            {"account": account, "name": name, "new_name": new_name},
+            {"account": account, "name": name, "new_name": new_name,
+             "new_parent": new_parent},
         )
         if rate_err:
             return rate_err
 
         logger.info(
-            f"Renaming mailbox {name!r} -> {new_name!r} in account {account}"
+            f"Updating mailbox {name!r} in {account}: "
+            f"new_name={new_name!r}, new_parent={new_parent!r}"
         )
 
         success = mail.update_mailbox(
-            account=account, name=name, new_name=new_name
+            account=account, name=name,
+            new_name=new_name, new_parent=new_parent,
         )
         operation_logger.log_operation(
             "update_mailbox",
-            {"account": account, "name": name, "new_name": new_name},
+            {"account": account, "name": name,
+             "new_name": new_name, "new_parent": new_parent},
             "success" if success else "failure",
         )
 
@@ -1474,6 +1493,7 @@ def update_mailbox(
             "account": account,
             "name": name,
             "new_name": new_name,
+            "new_parent": new_parent,
         }
 
     except ValueError as e:
@@ -1481,6 +1501,12 @@ def update_mailbox(
             "success": False,
             "error": str(e),
             "error_type": "validation_error",
+        }
+    except MailImapRequiredError as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "imap_required",
         }
     except MailMailboxNotFoundError as e:
         return {
@@ -1503,6 +1529,125 @@ def update_mailbox(
         }
     except Exception as e:
         logger.exception(f"Unexpected error in update_mailbox: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "unknown",
+        }
+
+
+@mcp.tool()
+async def delete_mailbox(
+    account: str,
+    name: str,
+    delete_messages: bool = False,
+    ctx: Context | None = None,
+) -> dict[str, Any]:
+    """Delete a mailbox via IMAP.
+
+    Mail.app's AppleScript dictionary doesn't expose a working delete
+    primitive for mailboxes, so this operation goes through IMAP. Requires
+    IMAP credentials in Keychain (#73 opt-in flow) — returns
+    ``error_type: "imap_required"`` when missing.
+
+    Always elicits user confirmation (destructive). By default refuses
+    non-empty mailboxes to prevent accidental data loss; pass
+    ``delete_messages=True`` to cascade.
+
+    Args:
+        account: Mail.app account display name or UUID.
+        name: Mailbox name. Slash-separated for nested mailboxes.
+        delete_messages: When False (default), refuse if the mailbox
+            contains messages. When True, cascade-delete the mailbox
+            and its contents.
+
+    Returns:
+        ``{success, account, name, deleted_message_count}`` on success.
+    """
+    try:
+        safety_err = check_test_mode_safety("delete_mailbox", account=account)
+        if safety_err:
+            return safety_err
+
+        if not name or not name.strip():
+            return {
+                "success": False,
+                "error": "Mailbox name cannot be empty",
+                "error_type": "validation_error",
+            }
+
+        rate_err = check_rate_limit(
+            "delete_mailbox",
+            {"account": account, "name": name,
+             "delete_messages": delete_messages},
+        )
+        if rate_err:
+            return rate_err
+
+        verb = "delete (cascading messages)" if delete_messages else "delete (refuse if non-empty)"
+        summary = (
+            f"{verb} mailbox?\n\n"
+            f"Account: {account}\n"
+            f"Mailbox: {name}\n\n"
+            f"This is destructive. The mailbox will be removed from the IMAP server."
+        )
+        cancel_err = await _elicit_confirmation(
+            ctx, summary, "delete_mailbox",
+            {"account": account, "name": name,
+             "delete_messages": delete_messages},
+        )
+        if cancel_err:
+            return cancel_err
+
+        count = mail.delete_mailbox(
+            account=account, name=name, delete_messages=delete_messages
+        )
+        operation_logger.log_operation(
+            "delete_mailbox",
+            {"account": account, "name": name,
+             "delete_messages": delete_messages,
+             "deleted_message_count": count},
+            "success",
+        )
+        return {
+            "success": True,
+            "account": account,
+            "name": name,
+            "deleted_message_count": count,
+        }
+
+    except ValueError as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "validation_error",
+        }
+    except MailImapRequiredError as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "imap_required",
+        }
+    except MailMailboxNotEmptyError as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "mailbox_not_empty",
+        }
+    except MailMailboxNotFoundError as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "mailbox_not_found",
+        }
+    except MailAccountNotFoundError:
+        return {
+            "success": False,
+            "error": f"Account {account!r} not found",
+            "error_type": "account_not_found",
+        }
+    except Exception as e:
+        logger.exception(f"Unexpected error in delete_mailbox: {e}")
         return {
             "success": False,
             "error": str(e),

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -38,6 +38,7 @@ EXPECTED_TOOLS = {
     "save_attachments",
     "create_mailbox",
     "update_mailbox",
+    "delete_mailbox",
     "delete_messages",
     # Rule CRUD (#63)
     "create_rule",
@@ -188,6 +189,12 @@ INVOCATION_CASES: list[tuple[str, dict[str, Any], str, Any]] = [
         {"account": "TestAccount", "name": "Old", "new_name": "New"},
         "update_mailbox",
         True,
+    ),
+    (
+        "delete_mailbox",
+        {"account": "TestAccount", "name": "Empty"},
+        "delete_mailbox",
+        0,
     ),
     (
         "delete_messages",

--- a/tests/e2e/test_stdio_transport.py
+++ b/tests/e2e/test_stdio_transport.py
@@ -41,6 +41,7 @@ EXPECTED_TOOLS = {
     "save_attachments",
     "create_mailbox",
     "update_mailbox",
+    "delete_mailbox",
     "delete_messages",
     # Rule CRUD (#63)
     "create_rule",

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -547,6 +547,51 @@ class TestDraftsLifecycleIntegration:
                 return  # success
         pytest.fail("draft still queryable 10s after delete")
 
+    def test_delete_mailbox_via_imap_round_trip(
+        self,
+        connector: AppleMailConnector,
+        test_account: str,
+    ) -> None:
+        """#162: create -> delete via IMAP -> verify gone via direct IMAP query.
+
+        Uses direct IMAP listing for verification because Mail.app's local
+        mailbox-list cache lags IMAP server changes by minutes; the truth
+        is on the server."""
+        import uuid as _uuid
+
+        from imapclient import IMAPClient
+
+        from apple_mail_mcp.keychain import get_imap_password
+
+        fixture = f"ZZZ-AMM-DEL-INT-{_uuid.uuid4().hex[:8]}"
+        assert connector.create_mailbox(account=test_account, name=fixture)
+
+        try:
+            count = connector.delete_mailbox(
+                account=test_account, name=fixture
+            )
+            assert count == 0  # empty fixture
+        except Exception:
+            # Best-effort cleanup if delete itself fails so we don't orphan.
+            try:
+                connector.delete_mailbox(
+                    account=test_account, name=fixture, delete_messages=True
+                )
+            except Exception:
+                pass
+            raise
+
+        # Verify via direct IMAP — Mail.app's view lags
+        host, port, email = connector._resolve_imap_config(test_account)
+        pw = get_imap_password(test_account, email)
+        client = IMAPClient(host, port=port, ssl=True, timeout=30)
+        client.login(email, pw)
+        try:
+            folders = {f[2] for f in client.list_folders()}
+        finally:
+            client.logout()
+        assert fixture not in folders, f"{fixture} still on IMAP server after delete"
+
     def test_update_mailbox_renames_in_place(
         self,
         connector: AppleMailConnector,

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -1200,6 +1200,86 @@ class TestGetAttachments:
 
 
 # ---------------------------------------------------------------------------
+# Mailbox write operations (#162, #163): delete_mailbox / rename_mailbox
+# ---------------------------------------------------------------------------
+
+
+class TestImapDeleteMailbox:
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_delete_empty_mailbox_returns_zero(
+        self, mock_cls: MagicMock
+    ) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.select_folder.return_value = {b"EXISTS": 0}
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").delete_mailbox(
+            "Empty"
+        )
+        assert result == 0
+        client.delete_folder.assert_called_once_with("Empty")
+        client.logout.assert_called_once()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_delete_non_empty_refuses_by_default(
+        self, mock_cls: MagicMock
+    ) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.select_folder.return_value = {b"EXISTS": 5}
+
+        with pytest.raises(ValueError, match="not empty"):
+            ImapConnector("h", 993, "u@e.com", "pw").delete_mailbox(
+                "Big"
+            )
+        # Did not invoke delete_folder.
+        client.delete_folder.assert_not_called()
+        client.logout.assert_called_once()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_delete_non_empty_with_allow_non_empty_cascades(
+        self, mock_cls: MagicMock
+    ) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.select_folder.return_value = {b"EXISTS": 42}
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").delete_mailbox(
+            "Big", allow_non_empty=True
+        )
+        assert result == 42
+        client.delete_folder.assert_called_once_with("Big")
+
+
+class TestImapRenameMailbox:
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_rename_calls_imap_rename(self, mock_cls: MagicMock) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+
+        ImapConnector("h", 993, "u@e.com", "pw").rename_mailbox(
+            "Old", "New"
+        )
+        client.rename_folder.assert_called_once_with("Old", "New")
+        client.logout.assert_called_once()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_rename_with_path_change_passes_through(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Move semantics: dest path with a different parent."""
+        client = MagicMock()
+        mock_cls.return_value = client
+
+        ImapConnector("h", 993, "u@e.com", "pw").rename_mailbox(
+            "OldParent/Child", "NewParent/Child"
+        )
+        client.rename_folder.assert_called_once_with(
+            "OldParent/Child", "NewParent/Child"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Issue #122: Gmail X-GM-THRID dispatch in find_thread_members
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -3875,3 +3875,221 @@ class TestUpdateMailbox:
         script = mock_run.call_args[0][0]
         # applescript_account_clause emits `account id "<UUID>"`.
         assert 'account id "DC5AC137-2F7A-4299-B3D0-4D3E06C18DD5"' in script
+
+    def test_requires_at_least_one_of_new_name_or_new_parent(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            connector.update_mailbox(account="Gmail", name="Old")
+
+
+class TestUpdateMailboxMove:
+    """IMAP-dispatched move path of update_mailbox (#163)."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(
+        AppleMailConnector, "_resolve_imap_config",
+        return_value=("imap.gmail.com", 993, "x@gmail.com"),
+    )
+    def test_move_to_top_uses_imap_rename_with_leaf_only(
+        self,
+        _mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """new_parent="" means top-level — destination is just the leaf."""
+        mock_pw.return_value = "secret"
+        mock_imap = mock_imap_cls.return_value
+        connector.update_mailbox(
+            account="Gmail", name="Archive/2024", new_parent=""
+        )
+        mock_imap.rename_mailbox.assert_called_once_with("Archive/2024", "2024")
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(
+        AppleMailConnector, "_resolve_imap_config",
+        return_value=("imap.gmail.com", 993, "x@gmail.com"),
+    )
+    def test_move_under_new_parent_keeps_leaf(
+        self,
+        _mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_pw.return_value = "secret"
+        mock_imap = mock_imap_cls.return_value
+        connector.update_mailbox(
+            account="Gmail", name="Archive/2024", new_parent="Old"
+        )
+        mock_imap.rename_mailbox.assert_called_once_with(
+            "Archive/2024", "Old/2024"
+        )
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(
+        AppleMailConnector, "_resolve_imap_config",
+        return_value=("imap.gmail.com", 993, "x@gmail.com"),
+    )
+    def test_move_with_rename_combines_in_one_rename(
+        self,
+        _mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_pw.return_value = "secret"
+        mock_imap = mock_imap_cls.return_value
+        connector.update_mailbox(
+            account="Gmail", name="Old/Sub",
+            new_name="Renamed", new_parent="New",
+        )
+        mock_imap.rename_mailbox.assert_called_once_with(
+            "Old/Sub", "New/Renamed"
+        )
+
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(
+        AppleMailConnector, "_resolve_imap_config",
+        return_value=("imap.gmail.com", 993, "x@gmail.com"),
+    )
+    def test_no_keychain_credentials_raises_imap_required(
+        self,
+        _mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        from apple_mail_mcp.exceptions import (
+            MailImapRequiredError,
+            MailKeychainEntryNotFoundError,
+        )
+        mock_pw.side_effect = MailKeychainEntryNotFoundError("no entry")
+        with pytest.raises(MailImapRequiredError):
+            connector.update_mailbox(
+                account="Gmail", name="X", new_parent="Y"
+            )
+
+
+class TestDeleteMailbox:
+    """delete_mailbox via IMAP (#162)."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(
+        AppleMailConnector, "_resolve_imap_config",
+        return_value=("imap.gmail.com", 993, "x@gmail.com"),
+    )
+    def test_delete_empty_mailbox_returns_zero(
+        self,
+        _mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_pw.return_value = "secret"
+        mock_imap = mock_imap_cls.return_value
+        mock_imap.delete_mailbox.return_value = 0
+        result = connector.delete_mailbox(account="Gmail", name="Empty")
+        assert result == 0
+        mock_imap.delete_mailbox.assert_called_once_with(
+            "Empty", allow_non_empty=False
+        )
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(
+        AppleMailConnector, "_resolve_imap_config",
+        return_value=("imap.gmail.com", 993, "x@gmail.com"),
+    )
+    def test_delete_messages_true_passes_through(
+        self,
+        _mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_pw.return_value = "secret"
+        mock_imap = mock_imap_cls.return_value
+        mock_imap.delete_mailbox.return_value = 42
+        result = connector.delete_mailbox(
+            account="Gmail", name="Big", delete_messages=True
+        )
+        assert result == 42
+        mock_imap.delete_mailbox.assert_called_once_with(
+            "Big", allow_non_empty=True
+        )
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(
+        AppleMailConnector, "_resolve_imap_config",
+        return_value=("imap.gmail.com", 993, "x@gmail.com"),
+    )
+    def test_non_empty_refusal_raises_typed_error(
+        self,
+        _mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        from apple_mail_mcp.exceptions import MailMailboxNotEmptyError
+        mock_pw.return_value = "secret"
+        mock_imap = mock_imap_cls.return_value
+        mock_imap.delete_mailbox.side_effect = ValueError(
+            "mailbox 'X' is not empty (5 messages); pass allow_non_empty=True"
+        )
+        with pytest.raises(MailMailboxNotEmptyError):
+            connector.delete_mailbox(account="Gmail", name="X")
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(
+        AppleMailConnector, "_resolve_imap_config",
+        return_value=("imap.gmail.com", 993, "x@gmail.com"),
+    )
+    def test_no_such_mailbox_maps_to_typed_error(
+        self,
+        _mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        from imapclient.exceptions import IMAPClientError
+        mock_pw.return_value = "secret"
+        mock_imap = mock_imap_cls.return_value
+        mock_imap.delete_mailbox.side_effect = IMAPClientError(
+            "DELETE: No such mailbox"
+        )
+        with pytest.raises(MailMailboxNotFoundError):
+            connector.delete_mailbox(account="Gmail", name="Missing")
+
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(
+        AppleMailConnector, "_resolve_imap_config",
+        return_value=("imap.gmail.com", 993, "x@gmail.com"),
+    )
+    def test_no_keychain_raises_imap_required(
+        self,
+        _mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        from apple_mail_mcp.exceptions import (
+            MailImapRequiredError,
+            MailKeychainEntryNotFoundError,
+        )
+        mock_pw.side_effect = MailKeychainEntryNotFoundError("nope")
+        with pytest.raises(MailImapRequiredError):
+            connector.delete_mailbox(account="Gmail", name="X")

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -224,6 +224,7 @@ class TestCheckRateLimit:
             "list_accounts", "list_rules", "list_mailboxes", "get_messages",
             "get_thread", "save_attachments", "search_messages",
             "update_message", "create_mailbox", "update_mailbox",
+            "delete_mailbox",
             "delete_messages", "reply_to_message", "send_email",
             "send_email_with_attachments", "forward_message",
             "delete_rule", "create_rule", "update_rule",

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1673,15 +1673,64 @@ class TestUpdateMailboxTool:
         mock_mail.update_mailbox.return_value = True
         result = update_mailbox(account="Gmail", name="Old", new_name="New")
 
-        assert result == {
-            "success": True,
-            "account": "Gmail",
-            "name": "Old",
-            "new_name": "New",
-        }
+        assert result["success"] is True
+        assert result["account"] == "Gmail"
+        assert result["name"] == "Old"
+        assert result["new_name"] == "New"
+        assert result["new_parent"] is None
         mock_mail.update_mailbox.assert_called_once_with(
-            account="Gmail", name="Old", new_name="New"
+            account="Gmail", name="Old", new_name="New", new_parent=None,
         )
+
+    def test_move_only_success(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """#163: new_parent set, new_name None — pure move via IMAP."""
+        from apple_mail_mcp.server import update_mailbox
+
+        mock_mail.update_mailbox.return_value = True
+        result = update_mailbox(
+            account="Gmail", name="A/B", new_parent="C"
+        )
+        assert result["success"] is True
+        mock_mail.update_mailbox.assert_called_once_with(
+            account="Gmail", name="A/B", new_name=None, new_parent="C",
+        )
+
+    def test_move_to_top_with_empty_string_parent(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.server import update_mailbox
+
+        mock_mail.update_mailbox.return_value = True
+        update_mailbox(account="Gmail", name="A/B", new_parent="")
+        mock_mail.update_mailbox.assert_called_once_with(
+            account="Gmail", name="A/B", new_name=None, new_parent="",
+        )
+
+    def test_imap_required_maps_to_typed_error(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.exceptions import MailImapRequiredError
+        from apple_mail_mcp.server import update_mailbox
+
+        mock_mail.update_mailbox.side_effect = MailImapRequiredError(
+            "no creds"
+        )
+        result = update_mailbox(
+            account="Gmail", name="A/B", new_parent="C"
+        )
+        assert result["error_type"] == "imap_required"
+
+    def test_neither_new_name_nor_parent_validation_error(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.server import update_mailbox
+
+        result = update_mailbox(account="Gmail", name="Old")
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_mail.update_mailbox.assert_not_called()
 
     def test_empty_name_validation_error(
         self, mock_mail: MagicMock, mock_logger: MagicMock
@@ -1763,6 +1812,160 @@ class TestUpdateMailboxTool:
 
         mock_mail.update_mailbox.side_effect = RuntimeError("boom")
         result = update_mailbox(account="Gmail", name="Old", new_name="New")
+        assert result["error_type"] == "unknown"
+
+
+class TestDeleteMailboxTool:
+    """Tests for the delete_mailbox MCP tool (#162, IMAP-dispatched)."""
+
+    @pytest.mark.asyncio
+    async def test_success_default_refuses_non_empty(
+        self,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        from apple_mail_mcp.server import delete_mailbox
+
+        mock_mail.delete_mailbox.return_value = 0
+        result = await delete_mailbox(
+            account="Gmail", name="Empty", ctx=mock_ctx_accept
+        )
+        assert result == {
+            "success": True,
+            "account": "Gmail",
+            "name": "Empty",
+            "deleted_message_count": 0,
+        }
+        mock_mail.delete_mailbox.assert_called_once_with(
+            account="Gmail", name="Empty", delete_messages=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_cascade_with_delete_messages_true(
+        self,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        from apple_mail_mcp.server import delete_mailbox
+
+        mock_mail.delete_mailbox.return_value = 42
+        result = await delete_mailbox(
+            account="Gmail", name="Big",
+            delete_messages=True, ctx=mock_ctx_accept,
+        )
+        assert result["deleted_message_count"] == 42
+
+    @pytest.mark.asyncio
+    async def test_declined_elicitation_blocks_delete(
+        self,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        mock_ctx_decline: MagicMock,
+    ) -> None:
+        from apple_mail_mcp.server import delete_mailbox
+
+        result = await delete_mailbox(
+            account="Gmail", name="X", ctx=mock_ctx_decline
+        )
+        assert result["error_type"] == "cancelled"
+        mock_mail.delete_mailbox.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_name_validation_error(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        from apple_mail_mcp.server import delete_mailbox
+
+        result = await delete_mailbox(account="Gmail", name="")
+        assert result["error_type"] == "validation_error"
+        mock_mail.delete_mailbox.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_imap_required_maps_to_typed_error(
+        self,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        from apple_mail_mcp.exceptions import MailImapRequiredError
+        from apple_mail_mcp.server import delete_mailbox
+
+        mock_mail.delete_mailbox.side_effect = MailImapRequiredError(
+            "no creds"
+        )
+        result = await delete_mailbox(
+            account="Gmail", name="X", ctx=mock_ctx_accept
+        )
+        assert result["error_type"] == "imap_required"
+
+    @pytest.mark.asyncio
+    async def test_non_empty_refusal_maps_to_typed_error(
+        self,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        from apple_mail_mcp.exceptions import MailMailboxNotEmptyError
+        from apple_mail_mcp.server import delete_mailbox
+
+        mock_mail.delete_mailbox.side_effect = MailMailboxNotEmptyError(
+            "not empty"
+        )
+        result = await delete_mailbox(
+            account="Gmail", name="X", ctx=mock_ctx_accept
+        )
+        assert result["error_type"] == "mailbox_not_empty"
+
+    @pytest.mark.asyncio
+    async def test_mailbox_not_found_maps_to_typed_error(
+        self,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        from apple_mail_mcp.exceptions import MailMailboxNotFoundError
+        from apple_mail_mcp.server import delete_mailbox
+
+        mock_mail.delete_mailbox.side_effect = MailMailboxNotFoundError(
+            "no such"
+        )
+        result = await delete_mailbox(
+            account="Gmail", name="Missing", ctx=mock_ctx_accept
+        )
+        assert result["error_type"] == "mailbox_not_found"
+
+    @pytest.mark.asyncio
+    async def test_account_not_found_maps_to_typed_error(
+        self,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        from apple_mail_mcp.server import delete_mailbox
+
+        mock_mail.delete_mailbox.side_effect = MailAccountNotFoundError(
+            "no acct"
+        )
+        result = await delete_mailbox(
+            account="Bogus", name="X", ctx=mock_ctx_accept
+        )
+        assert result["error_type"] == "account_not_found"
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_maps_to_unknown(
+        self,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        from apple_mail_mcp.server import delete_mailbox
+
+        mock_mail.delete_mailbox.side_effect = RuntimeError("boom")
+        result = await delete_mailbox(
+            account="Gmail", name="X", ctx=mock_ctx_accept
+        )
         assert result["error_type"] == "unknown"
 
 


### PR DESCRIPTION
## Summary

Closes #162 and #163. The previous AppleScript-only investigation was incomplete; a thorough re-investigation here (prompted by your "are they blocked?" question) confirmed AppleScript genuinely cannot do this, then implemented the IMAP path.

## Re-investigation findings

| What | Result |
|---|---|
| Mail.sdef inspection | mailbox class's `container` property is `access="r"` — read-only. Re-parent via property assignment is structurally impossible. |
| Mail.app's `delete` / `move` commands | Accept mailbox specifiers syntactically but the command handlers refuse them. |
| UI scripting via System Events | Mail's UI tree dump times out — too slow/brittle to ship. |

So both ops genuinely require IMAP, which the codebase already supports for read operations via Keychain. This PR extends to write ops.

## What ships

- **`ImapConnector.delete_mailbox(name, allow_non_empty=False)`** — SELECT readonly to read EXISTS count; refuse if non-empty unless caller opts in; CLOSE then DELETE.
- **`ImapConnector.rename_mailbox(old, new)`** — IMAP RENAME, also serves as the move primitive (different parent path = re-parent).
- **`AppleMailConnector.delete_mailbox(account, name, delete_messages=False)`** — Keychain credential resolution; raises `MailImapRequiredError` when missing. Maps non-empty refusal to `MailMailboxNotEmptyError`.
- **`AppleMailConnector.update_mailbox`** extended with `new_parent`: pure rename keeps AppleScript path; any move routes through IMAP. `new_parent=""` means top-level.
- **Server tools**: new `delete_mailbox` (always elicits, IMAP-only) + extended `update_mailbox`. Both registered in OPERATION_TIERS.
- **New exceptions**: `MailMailboxNotEmptyError`, `MailImapRequiredError`.

## Bonus cleanup

The previous #102 + #163 design sessions left 7 orphan probe mailboxes in my real Gmail because AppleScript couldn't delete them. The new IMAP delete code cleaned them all up — verified in this session, no orphans remain on the IMAP server.

## Test plan

- [x] **Unit**: 5 new ImapConnector tests + 19 connector-layer tests + extensive server-tool tests covering both new tools and the extended update_mailbox.
- [x] **Integration**: 1 new test for end-to-end IMAP delete round-trip (verifies via direct IMAP query because Mail.app's local mailbox cache lags).
- [x] **E2E**: `delete_mailbox` and the extended `update_mailbox` shape added to EXPECTED_TOOLS + invocation cases.
- [x] **`make check-all`** clean (lint, mypy strict, complexity ≤ 20, version-sync, parity).
- [x] 858 unit + e2e tests pass; 90.04% coverage.
- [x] **Real-Mail smoke**: create → IMAP delete works; create + create + IMAP move (parent path change) works server-side.

## Documented caveats

- Mail.app's local mailbox-list cache lags IMAP server changes by minutes. Truth lives on the server; callers can verify via `list_mailboxes` after a refresh.
- Gmail system labels (`[Gmail]/Drafts`, etc.) may auto-restore canonical names after rename — tracked as #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)