### PR TITLE
feat(#127): register atexit hook for ImapConnectionPool.close()

### DIFF
--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -3,6 +3,7 @@ FastMCP server for Apple Mail integration.
 """
 
 import argparse
+import atexit
 import logging
 import tempfile
 from pathlib import Path
@@ -69,7 +70,18 @@ def _build_imap_pool() -> ImapConnectionPool | None:
     return None
 
 
-mail = AppleMailConnector(imap_pool=_build_imap_pool())
+def _register_pool_atexit(pool: ImapConnectionPool | None) -> None:
+    """Register ``pool.close()`` as an atexit hook so cached IMAP sessions
+    get a clean LOGOUT on process exit instead of an abnormal disconnect
+    (#127). No-op when ``pool`` is ``None`` (the default — pool is opt-in
+    via ``APPLE_MAIL_MCP_IMAP_POOL=1``)."""
+    if pool is not None:
+        atexit.register(pool.close)
+
+
+_imap_pool = _build_imap_pool()
+_register_pool_atexit(_imap_pool)
+mail = AppleMailConnector(imap_pool=_imap_pool)
 
 
 async def _elicit_confirmation(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -76,6 +76,44 @@ def mock_ctx_decline() -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
+# atexit pool-close hook (#127)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterPoolAtexit:
+    """Issue #127: when an IMAP connection pool is built, register its
+    close() as an atexit hook so cached sessions get a clean LOGOUT on
+    process exit instead of an abnormal disconnect."""
+
+    def test_register_pool_atexit_registers_close_when_pool_set(self) -> None:
+        from apple_mail_mcp.server import _register_pool_atexit
+
+        pool = MagicMock()
+        with patch("apple_mail_mcp.server.atexit") as mock_atexit:
+            _register_pool_atexit(pool)
+        mock_atexit.register.assert_called_once_with(pool.close)
+
+    def test_register_pool_atexit_noop_when_pool_none(self) -> None:
+        from apple_mail_mcp.server import _register_pool_atexit
+
+        with patch("apple_mail_mcp.server.atexit") as mock_atexit:
+            _register_pool_atexit(None)
+        mock_atexit.register.assert_not_called()
+
+    def test_registered_handler_invokes_pool_close(self) -> None:
+        """The registered callable, when invoked at exit time, calls
+        pool.close() exactly once."""
+        from apple_mail_mcp.server import _register_pool_atexit
+
+        pool = MagicMock()
+        with patch("apple_mail_mcp.server.atexit") as mock_atexit:
+            _register_pool_atexit(pool)
+        registered = mock_atexit.register.call_args.args[0]
+        registered()
+        pool.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # 0. list_accounts
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

When `APPLE_MAIL_MCP_IMAP_POOL=1` is set, the pool's cached IMAP sessions now get a clean LOGOUT round trip on process exit instead of dying when the socket closes. Some IMAP servers log the latter as an abnormal disconnect.

Closes #127.

## Change

- Hoist `_build_imap_pool()` result into a named `_imap_pool` module-level variable.
- Add `_register_pool_atexit(pool)` helper that calls `atexit.register(pool.close)` when pool is non-None. Helper exists so the test suite can exercise the registration path without reloading `server.py`.
- Pool is still opt-in (default off per #75) — when the env var isn't set, `_build_imap_pool` returns `None` and the atexit registration short-circuits.

## Test plan

- [x] **Unit**: 3 new tests covering both branches and a verification that the registered callable actually invokes `pool.close()`.
- [x] `make check-all` clean (lint, mypy strict, complexity, version-sync, parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)