### PR TITLE
feat(#101): benchmark Gmail-mode operations separately

### DIFF
--- a/docs/guides/BENCHMARKING.md
+++ b/docs/guides/BENCHMARKING.md
@@ -26,6 +26,15 @@ make benchmark-baseline
 
 Both targets set `MAIL_TEST_MODE=true` automatically. The test account is whatever `MAIL_TEST_ACCOUNT` resolves to — default `iCloud`.
 
+To also run the **Gmail-variant** benchmarks (#101), set `MAIL_TEST_ACCOUNT_GMAIL` to the Mail.app account name of a configured Gmail account:
+
+```bash
+MAIL_TEST_ACCOUNT_GMAIL=Gmail make benchmark
+MAIL_TEST_ACCOUNT_GMAIL=Gmail make benchmark-baseline
+```
+
+When `MAIL_TEST_ACCOUNT_GMAIL` is unset, Gmail variants skip cleanly with a clear message; the standard (iCloud) benchmarks still run.
+
 ## Test data requirements
 
 Benchmarks measure real Mail.app behavior, so they need real data:
@@ -35,8 +44,19 @@ Benchmarks measure real Mail.app behavior, so they need real data:
 | `search_messages_*` | At least 1 message in INBOX, Archive, or Sent Messages |
 | `save_attachments_*` | At least 1 message with an attachment in those mailboxes |
 | `mark_as_read_50_msgs` | At least 50 messages across those mailboxes |
+| `search_messages_*_gmail` | A Gmail account configured in Mail.app + Keychain IMAP credentials (#73 opt-in) |
+| `move_messages_50_msgs_gmail` | Same as above. Exercises the `gmail_mode=True` copy+delete path |
 
 If a precondition isn't met, the benchmark skips with a clear message rather than failing. This is by design — running a smaller bulk benchmark on 5 messages would defeat the point (the scaling signal is what matters).
+
+### Gmail-variant fixtures use synthetic data
+
+Unlike the iCloud benchmarks (which find a real mailbox with ≥50 messages and shuttle real messages), the Gmail variants populate two dedicated mailboxes via IMAP `APPEND`:
+
+- `[apple-mail-mcp-bench-gmail-source]` — holds 50 synthetic RFC 5322 messages (subject `ZZZ-AMM-BENCH Synthetic Message NNN`). Created and populated once per test session; idempotent (re-runs only append what's missing).
+- `[apple-mail-mcp-bench-gmail]` — the move-target. Populated per-test from the source via `move_messages(... gmail_mode=True)`; drained back on teardown.
+
+Your real Gmail INBOX is never touched. Both fixture mailboxes persist across runs (cheaper than re-creating per-run, and easy to spot from the prefix). Use `delete_mailbox` to clean them up if desired.
 
 ## Bulk benchmarks (mark_as_read, move_messages) currently skip
 

--- a/tests/benchmarks/baseline.json
+++ b/tests/benchmarks/baseline.json
@@ -3,8 +3,12 @@
   "imap_repeat_5_calls_pooled": 6.33,
   "mark_as_read_50_msgs": 3.65,
   "move_messages_50_msgs": 17.167,
+  "move_messages_50_msgs_gmail": 3.099,
   "save_attachments_one_file": 0.432,
   "search_messages_no_filter": 2.526,
+  "search_messages_no_filter_gmail": 1.579,
   "search_messages_with_sender_filter": 2.691,
-  "search_messages_with_zero_matches": 144.304
+  "search_messages_with_sender_filter_gmail": 2.848,
+  "search_messages_with_zero_matches": 144.304,
+  "search_messages_with_zero_matches_gmail": 4.554
 }

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -37,6 +37,13 @@ BASELINE_PATH = Path(__file__).parent / "baseline.json"
 BENCH_MAILBOX_NAME = "[apple-mail-mcp-bench]"
 BULK_SIZE = 50
 
+# Gmail variant fixtures (#101): benchmarks against a Gmail account use a
+# pair of dedicated mailboxes populated with synthetic IMAP APPEND data so
+# the user's real INBOX is never touched. Source holds the 50-msg pool;
+# bench is the move-target. Both persist across runs (fixture is idempotent).
+GMAIL_BENCH_MAILBOX_NAME = "[apple-mail-mcp-bench-gmail]"
+GMAIL_BENCH_SOURCE_NAME = "[apple-mail-mcp-bench-gmail-source]"
+
 
 # ---------------------------------------------------------------------------
 # Skip-unless-flag gate
@@ -331,6 +338,170 @@ def bench_messages(
     # IDs change on move (IMAP UID semantics). Re-fetch.
     in_bench = connector.search_messages(
         account=test_account, mailbox=bench_mailbox, limit=BULK_SIZE
+    )
+    bench_ids = [m["id"] for m in in_bench[:BULK_SIZE]]
+
+    try:
+        yield bench_ids
+    finally:
+        _drain_bench_to_source()
+
+
+# ---------------------------------------------------------------------------
+# Gmail-account fixtures (#101)
+#
+# Synthetic-data approach: instead of touching the user's real Gmail INBOX
+# (the iCloud benchmarks do that for iCloud), Gmail benchmarks operate on
+# a dedicated pair of mailboxes populated via IMAP APPEND with 50 synthetic
+# messages. Real INBOX is never touched; mailboxes are clearly prefixed.
+#
+# Skip cleanly when MAIL_TEST_ACCOUNT_GMAIL is unset.
+# ---------------------------------------------------------------------------
+
+
+def _make_synthetic_message(i: int) -> bytes:
+    """RFC 5322 synthetic message for IMAP APPEND. Distinguishable subject
+    so a human inspecting Gmail can see what these are."""
+    return (
+        f"From: bench-sender-{i}@example.com\r\n"
+        f"To: bench@example.com\r\n"
+        f"Subject: ZZZ-AMM-BENCH Synthetic Message {i:03d}\r\n"
+        f"Message-ID: <bench-{i}@example.invalid>\r\n"
+        f"Date: Thu, 01 May 2026 12:00:00 +0000\r\n"
+        f"\r\n"
+        f"Synthetic benchmark message #{i} for issue #101. "
+        f"If you see this in your inbox, the apple-mail-mcp benchmark "
+        f"fixture leaked.\r\n"
+    ).encode()
+
+
+@pytest.fixture(scope="session")
+def test_account_gmail() -> str:
+    """Gmail account name from MAIL_TEST_ACCOUNT_GMAIL. Skip when unset."""
+    name = os.getenv("MAIL_TEST_ACCOUNT_GMAIL")
+    if not name:
+        pytest.skip(
+            "MAIL_TEST_ACCOUNT_GMAIL not set. Configure to enable Gmail "
+            "benchmarks. See docs/guides/BENCHMARKING.md."
+        )
+    return name
+
+
+@pytest.fixture(scope="session")
+def gmail_bench_source(
+    connector: AppleMailConnector, test_account_gmail: str
+) -> str:
+    """Create [apple-mail-mcp-bench-gmail-source] (if missing) and ensure
+    it holds at least BULK_SIZE synthetic messages via IMAP APPEND.
+
+    Idempotent: only appends what's missing if the mailbox already has
+    some messages from a prior run. Session-scoped so the populate cost
+    is paid once per test run."""
+    from imapclient import IMAPClient
+
+    from apple_mail_mcp.keychain import get_imap_password
+
+    mailboxes = connector.list_mailboxes(test_account_gmail)
+    names = {mb["name"] for mb in mailboxes}
+    if GMAIL_BENCH_SOURCE_NAME not in names:
+        connector.create_mailbox(
+            account=test_account_gmail, name=GMAIL_BENCH_SOURCE_NAME
+        )
+
+    host, port, email = connector._resolve_imap_config(test_account_gmail)
+    pw = get_imap_password(test_account_gmail, email)
+    client = IMAPClient(host, port=port, ssl=True, timeout=60)
+    client.login(email, pw)
+    try:
+        info = client.select_folder(GMAIL_BENCH_SOURCE_NAME)
+        existing = int(info.get(b"EXISTS", 0))
+        if existing < BULK_SIZE:
+            client.unselect_folder()
+            for i in range(existing, BULK_SIZE):
+                client.append(
+                    GMAIL_BENCH_SOURCE_NAME, _make_synthetic_message(i)
+                )
+    finally:
+        client.logout()
+
+    return GMAIL_BENCH_SOURCE_NAME
+
+
+@pytest.fixture(scope="session")
+def gmail_bench_mailbox(
+    connector: AppleMailConnector, test_account_gmail: str
+) -> str:
+    """Ensure [apple-mail-mcp-bench-gmail] exists in the Gmail account."""
+    mailboxes = connector.list_mailboxes(test_account_gmail)
+    names = {mb["name"] for mb in mailboxes}
+    if GMAIL_BENCH_MAILBOX_NAME not in names:
+        connector.create_mailbox(
+            account=test_account_gmail, name=GMAIL_BENCH_MAILBOX_NAME
+        )
+    return GMAIL_BENCH_MAILBOX_NAME
+
+
+@pytest.fixture
+def gmail_bench_messages(
+    connector: AppleMailConnector,
+    test_account_gmail: str,
+    gmail_bench_source: str,
+    gmail_bench_mailbox: str,
+) -> Iterator[list[str]]:
+    """Move BULK_SIZE synthetic messages from gmail_bench_source to
+    gmail_bench_mailbox; yield IDs; drain back on teardown.
+
+    Mirror of bench_messages but for the Gmail account with synthetic
+    data — uses ``gmail_mode=True`` for moves to exercise the copy+delete
+    path that the benchmarks here measure."""
+
+    def _drain_bench_to_source() -> None:
+        while True:
+            leftover = connector.search_messages(
+                account=test_account_gmail,
+                mailbox=gmail_bench_mailbox,
+                limit=BULK_SIZE,
+            )
+            if not leftover:
+                break
+            try:
+                connector.move_messages(
+                    [m["id"] for m in leftover],
+                    destination_mailbox=gmail_bench_source,
+                    account=test_account_gmail,
+                    source_mailbox=gmail_bench_mailbox,
+                    gmail_mode=True,
+                )
+            except Exception:
+                break
+
+    _drain_bench_to_source()
+
+    source_msgs = connector.search_messages(
+        account=test_account_gmail,
+        mailbox=gmail_bench_source,
+        limit=BULK_SIZE,
+    )
+    if len(source_msgs) < BULK_SIZE:
+        pytest.skip(
+            f"gmail_bench_source has {len(source_msgs)} messages; need "
+            f"{BULK_SIZE}. The synthetic-data setup may have failed mid-way."
+        )
+    try:
+        connector.move_messages(
+            [m["id"] for m in source_msgs],
+            destination_mailbox=gmail_bench_mailbox,
+            account=test_account_gmail,
+            source_mailbox=gmail_bench_source,
+            gmail_mode=True,
+        )
+    except MailAppleScriptError as e:
+        pytest.skip(f"gmail_bench_messages setup failed: {e}")
+
+    in_bench = connector.search_messages(
+        account=test_account_gmail,
+        mailbox=gmail_bench_mailbox,
+        limit=BULK_SIZE,
     )
     bench_ids = [m["id"] for m in in_bench[:BULK_SIZE]]
 

--- a/tests/benchmarks/test_bulk_ops.py
+++ b/tests/benchmarks/test_bulk_ops.py
@@ -115,3 +115,57 @@ def test_move_messages_50_msgs(
     # 3 runs (not 5) — each run is two moves on 50 messages.
     result: BenchmarkResult = measure_median(run, name=name, runs=3)
     assert_within_baseline(name, result, baselines, capture_mode)
+
+
+def test_move_messages_50_msgs_gmail(
+    connector: AppleMailConnector,
+    test_account_gmail: str,
+    gmail_bench_source: str,
+    gmail_bench_mailbox: str,
+    gmail_bench_messages: list[str],
+    baselines: dict[str, float],
+    capture_mode: bool,
+) -> None:
+    """Gmail variant (#101): bulk-move 50 synthetic messages with
+    ``gmail_mode=True`` (Gmail's IMAP doesn't natively support MOVE for
+    label-backed folders, so the connector falls back to copy+delete in
+    two AppleScript steps — that path is what this baseline measures).
+
+    Same shape as ``test_move_messages_50_msgs`` but the source and
+    destination mailboxes are dedicated synthetic-data fixtures, never
+    the user's real INBOX."""
+    name = "move_messages_50_msgs_gmail"
+
+    current_ids = list(gmail_bench_messages)
+
+    def run() -> None:
+        connector.move_messages(
+            current_ids,
+            destination_mailbox=gmail_bench_source,
+            account=test_account_gmail,
+            source_mailbox=gmail_bench_mailbox,
+            gmail_mode=True,
+        )
+        in_source = connector.search_messages(
+            account=test_account_gmail,
+            mailbox=gmail_bench_source,
+            limit=len(current_ids),
+        )
+        moved_ids = [m["id"] for m in in_source[: len(current_ids)]]
+
+        connector.move_messages(
+            moved_ids,
+            destination_mailbox=gmail_bench_mailbox,
+            account=test_account_gmail,
+            source_mailbox=gmail_bench_source,
+            gmail_mode=True,
+        )
+        in_bench = connector.search_messages(
+            account=test_account_gmail,
+            mailbox=gmail_bench_mailbox,
+            limit=len(current_ids),
+        )
+        current_ids[:] = [m["id"] for m in in_bench[: len(current_ids)]]
+
+    result: BenchmarkResult = measure_median(run, name=name, runs=3)
+    assert_within_baseline(name, result, baselines, capture_mode)

--- a/tests/benchmarks/test_search.py
+++ b/tests/benchmarks/test_search.py
@@ -115,3 +115,76 @@ def test_search_messages_with_zero_matches(
         name=name,
     )
     assert_within_baseline(name, result, baselines, capture_mode)
+
+
+# ---------------------------------------------------------------------------
+# Gmail variants (#101). Search the synthetic-data source mailbox so the
+# user's real Gmail INBOX is untouched. 50 synthetic messages is a smaller
+# corpus than the iCloud INBOX search runs against, but it's a controlled
+# baseline for tracking Gmail-side regressions over time.
+# ---------------------------------------------------------------------------
+
+
+def test_search_messages_no_filter_gmail(
+    connector: AppleMailConnector,
+    test_account_gmail: str,
+    gmail_bench_source: str,
+    baselines: dict[str, float],
+    capture_mode: bool,
+) -> None:
+    """Gmail variant of ``test_search_messages_no_filter``."""
+    name = "search_messages_no_filter_gmail"
+    result: BenchmarkResult = measure_median(
+        lambda: connector.search_messages(
+            account=test_account_gmail,
+            mailbox=gmail_bench_source,
+            limit=10,
+        ),
+        name=name,
+    )
+    assert_within_baseline(name, result, baselines, capture_mode)
+
+
+def test_search_messages_with_sender_filter_gmail(
+    connector: AppleMailConnector,
+    test_account_gmail: str,
+    gmail_bench_source: str,
+    baselines: dict[str, float],
+    capture_mode: bool,
+) -> None:
+    """Gmail variant of ``test_search_messages_with_sender_filter``.
+    Filter is permissive (``@`` in sender), so all 50 synthetic messages
+    match — exercises the per-message AppleScript IF-filter path."""
+    name = "search_messages_with_sender_filter_gmail"
+    result: BenchmarkResult = measure_median(
+        lambda: connector.search_messages(
+            account=test_account_gmail,
+            mailbox=gmail_bench_source,
+            sender_contains="@",
+            limit=10,
+        ),
+        name=name,
+    )
+    assert_within_baseline(name, result, baselines, capture_mode)
+
+
+def test_search_messages_with_zero_matches_gmail(
+    connector: AppleMailConnector,
+    test_account_gmail: str,
+    gmail_bench_source: str,
+    baselines: dict[str, float],
+    capture_mode: bool,
+) -> None:
+    """Gmail variant of ``test_search_messages_with_zero_matches``."""
+    name = "search_messages_with_zero_matches_gmail"
+    sentinel = "zzzz_apple_mail_mcp_no_match_sentinel_qqqq"
+    result: BenchmarkResult = measure_median(
+        lambda: connector.search_messages(
+            account=test_account_gmail,
+            mailbox=gmail_bench_source,
+            subject_contains=sentinel,
+            limit=10,
+        ),
+        name=name,
+    )
+    assert_within_baseline(name, result, baselines, capture_mode)


### PR DESCRIPTION
## Summary

Closes #101. Adds 4 Gmail-variant benchmarks so future perf work on the `gmail_mode` code paths has regression detection.

| New benchmark | Baseline (this machine) |
|---|---:|
| `search_messages_no_filter_gmail` | 1.579s |
| `search_messages_with_sender_filter_gmail` | 2.848s |
| `search_messages_with_zero_matches_gmail` | 4.554s |
| `move_messages_50_msgs_gmail` | 3.099s |

## Synthetic data, no INBOX touch

Per your suggestion, the Gmail fixtures populate two dedicated mailboxes via IMAP APPEND with 50 synthetic RFC 5322 messages — your real Gmail INBOX is never touched:

- `[apple-mail-mcp-bench-gmail-source]` — the 50-msg pool. Session-scoped fixture; idempotent (only appends what's missing on re-runs).
- `[apple-mail-mcp-bench-gmail]` — the move-target. Per-test fixture moves the 50 from source via `gmail_mode=True` and drains back on teardown.

Both mailboxes persist across runs (cheaper than re-creating per-run, matches the existing `[apple-mail-mcp-bench]` convention). Easy to spot from the prefix; clean up later via `delete_mailbox`.

## Skip behavior

When `MAIL_TEST_ACCOUNT_GMAIL` is unset, the new tests skip cleanly with a clear message; the standard iCloud benchmarks still run normally.

## Test plan

- [x] **Baseline capture**: `MAIL_TEST_ACCOUNT_GMAIL=Gmail make benchmark-baseline` ran clean against real Gmail; 4 keys merged into `tests/benchmarks/baseline.json` alongside existing iCloud entries.
- [x] **Sanity**: standard benchmarks still collect and would skip Gmail variants when `MAIL_TEST_ACCOUNT_GMAIL` is unset.
- [x] `make check-all` clean (lint, mypy strict, complexity, version-sync, parity).
- [x] **Doc updates**: BENCHMARKING.md gained an env-var section + a coverage table row + a "Gmail-variant fixtures use synthetic data" subsection explaining the IMAP APPEND approach and what mailboxes get created.

## Out of scope

- `save_attachments_*` and `mark_as_read_50_msgs` Gmail variants — no Gmail-specific code paths in those.
- Pool benchmarks (`imap_repeat_5_calls_*`) — account-agnostic.
- Refactoring iCloud benchmarks to use synthetic data too — possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)