### PR TITLE
feat(#125,#123): Tier 1.5 + Tier 2 in find_thread_members IMAP dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ If IMAP is working, the call returns in ~1 second. If it logs a WARNING about fa
 - **iCloud:** the IMAP server accepts `@icloud.com` / `@me.com` aliases as LOGIN username, not the Apple ID email. The server (and `setup-imap`) reads `email addresses of account` from Mail.app for that reason.
 - **Yahoo:** app passwords have been progressively deprecated; the option may not be available for all accounts. If Yahoo's account-security page doesn't show the option, IMAP setup isn't possible for that account and AppleScript is the only path.
 - **Gmail:** requires 2-Step Verification enabled. If your Google Workspace admin has disabled app passwords at the tenant level, IMAP setup isn't possible for that account.
+- **Gmail thread retrieval — All Mail visibility tradeoff.** `find_thread_members` (used internally by thread-aware queries) is fastest when `[Gmail]/All Mail` is exposed over IMAP — that path is ~5 round-trips, mailbox-count-independent. Many users hide All Mail (Gmail Settings → Forwarding and POP/IMAP → Folder size limits → "Do not show in IMAP") because it duplicates every message. When hidden, the connector falls back to a per-mailbox X-GM-THRID iteration (still ~6× faster than the universal BFS, but proportional to your label count — ~25s on a 92-label account). Expose All Mail if you want the headline speed; keep it hidden if you prefer the cleaner IMAP folder list.
 
 **Write operations** (`send_email`, `reply_to_message`, `forward_message`) always use AppleScript regardless of IMAP configuration — these need Mail.app's compose UI.
 

--- a/docs/research/imap-thread-strategies.md
+++ b/docs/research/imap-thread-strategies.md
@@ -153,10 +153,11 @@ The universal fallback when neither extension is advertised. Stays as-is. **iClo
 
 ## Follow-up issues filed
 
-- **#122 — `[perf] Use X-GM-THRID for get_thread on Gmail accounts`** — implements Tier 1.
-- **#123 — `[perf] Use RFC 5256 THREAD for get_thread when server advertises capability`** — implements Tier 2.
+- **#122 — `[perf] Use X-GM-THRID for get_thread on Gmail accounts`** — implements Tier 1. **Shipped.**
+- **#125 — `[perf] X-GM-THRID per-mailbox iteration when [Gmail]/All Mail is hidden from IMAP`** — implements Tier 1.5. **Shipped.** Smoke-verified against real Gmail (92 folders): 25.5s vs ~100s for Tier 3 BFS, ~4× win. Triggered when `X-GM-EXT-1` is advertised but the `\\All` SPECIAL-USE flag is not present in the folder listing.
+- **#123 — `[perf] Use RFC 5256 THREAD for get_thread when server advertises capability`** — implements Tier 2. **Shipped.** Unit-tested only (no Fastmail/Dovecot account configured for live verification — first real-server use will surface any quirks). Triggered when `THREAD=REFERENCES` or `THREAD=REFS` is advertised.
 
-Both are independent of each other and of the current iCloud path. iCloud users get no benefit from either; their best win remains improving the BFS itself (e.g. parallelizing across mailboxes, bounding by `\\Trash` / `\\Junk` mailbox skip lists, or accepting partial coverage on huge accounts) — but that's a separate research question and is **not** the same as the THREAD/X-GM-THRID question this doc answers.
+All three tiers are now in production for the connector's `find_thread_members`. iCloud users get no benefit from any of them; their best win remains improving the BFS itself (e.g. parallelizing across mailboxes, bounding by `\\Trash` / `\\Junk` mailbox skip lists, or accepting partial coverage on huge accounts) — but that's a separate research question and is **not** the same as the THREAD/X-GM-THRID question this doc answers.
 
 ## Provenance
 

--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -275,6 +275,42 @@ def _strip_brackets(s: str) -> str:
     return s
 
 
+def _flatten_thread_clusters(tree: Any) -> Iterator[set[int]]:
+    """Yield each top-level cluster of a THREAD result as a flat set of UIDs.
+
+    IMAPClient's ``client.thread()`` returns nested tuples per RFC 5256 —
+    each top-level element is one thread, with possibly-nested replies
+    representing the reply tree. For dispatch (#123 Tier 2) we don't care
+    about the tree shape; we just need to know which UIDs belong to which
+    cluster so we can intersect with the anchor's relevant_uids.
+
+    Edge cases:
+    - The result may be ``None`` if the server returned an empty THREAD
+      response — we yield nothing.
+    - Each leaf may be an int or a string-coerced int depending on the
+      IMAP server / IMAPClient version; we coerce to int.
+    """
+    if not tree:
+        return
+    for top in tree:
+        out: set[int] = set()
+        _flatten_one(top, out)
+        if out:
+            yield out
+
+
+def _flatten_one(node: Any, out: set[int]) -> None:
+    """Recursive walk of a THREAD nested-tuple node, adding UIDs to ``out``."""
+    if isinstance(node, (tuple, list)):
+        for child in node:
+            _flatten_one(child, out)
+    else:
+        try:
+            out.add(int(node))
+        except (TypeError, ValueError):
+            pass
+
+
 def _format_sender(envelope: Envelope) -> str:
     from_ = envelope.from_ or ()
     if not from_:
@@ -720,36 +756,47 @@ class ImapConnector:
     ) -> list[dict[str, Any]]:
         """Return all messages in the anchor's thread across the account.
 
-        Tiered, capability-detected dispatch (issue #122):
+        Tiered, capability-detected dispatch:
 
-        - **Tier 1 (Gmail X-GM-THRID)** — when ``X-GM-EXT-1`` is in the
-          server's CAPABILITY list, look the conversation up by Gmail's
-          64-bit thread ID against ``[Gmail]/All Mail`` (resolved via
-          ``\\All`` SPECIAL-USE flag, which is localization-safe). Five
-          round-trips total, mailbox-count-independent — replaces a
-          ~1100-round-trip BFS on a 91-label Gmail account with ~5.
+        - **Tier 1 (Gmail X-GM-THRID via All Mail)** (#122) — when
+          ``X-GM-EXT-1`` is advertised AND ``[Gmail]/All Mail`` is
+          visible (``\\All`` SPECIAL-USE flag), look the conversation
+          up by Gmail's 64-bit thread ID. ~5 round-trips,
+          mailbox-count-independent.
+
+        - **Tier 1.5 (Gmail X-GM-THRID per-mailbox)** (#125) — when
+          ``X-GM-EXT-1`` is advertised but All Mail is hidden over IMAP
+          (per-folder-size opt-out in Gmail Settings — common). Find
+          the anchor's UID + X-GM-THRID in INBOX or Sent, then search
+          every selectable folder by X-GM-THRID. ~2+M*2 round-trips
+          (~186 on a 92-folder account vs ~1100 for BFS).
+
+        - **Tier 2 (RFC 5256 THREAD)** (#123) — when ``THREAD=REFERENCES``
+          or ``THREAD=REFS`` is advertised (Fastmail, some Dovecot;
+          NOT Gmail typically, NOT iCloud). Per mailbox: a single
+          THREAD command returns nested UID tuples representing the
+          full thread structure; walk to find clusters containing
+          relevant UIDs. ~M*2-4 round-trips depending on anchor
+          locality.
 
         - **Tier 3 (header-search BFS)** — universal fallback. Iterates
-          every mailbox on the server; searches Message-ID / In-Reply-To /
-          References for every known thread ID. Used on iCloud, Fastmail,
-          and any provider that doesn't advertise the X-GM-EXT-1 path.
-          Also used when Tier 1 advertises but rejects mid-flight (server
-          lied about its capabilities).
+          every mailbox; searches Message-ID / In-Reply-To /
+          References for every known thread ID. Used on iCloud and
+          any provider not covered above. Also used when a higher tier
+          advertises but rejects mid-flight (server lied about its
+          capabilities).
 
-        Tier 2 (RFC 5256 THREAD) is reserved for #123 — slot in another
-        capability check between Tier 1 and Tier 3 there.
-
-        A single ``_session()`` covers all tiers, so a Tier 1 → Tier 3
-        fall-through doesn't pay a second connect+login. With the pool
-        (#75), both tiers share the cached connection.
+        A single ``_session()`` covers all tiers, so fall-through
+        doesn't pay a second connect+login. With the pool (#75),
+        all tiers share the cached connection.
 
         Args:
             anchor_rfc_message_id: RFC 5322 Message-ID of the thread anchor,
                 bracketless (as returned by _strip_brackets).
             anchor_references: List of Message-IDs from the anchor's
                 References header, bracketless, order preserved. Used by
-                Tier 3; Tier 1 doesn't need them (X-GM-THRID is the
-                authoritative grouping).
+                Tier 2 + Tier 3; Tier 1 / 1.5 don't need them
+                (X-GM-THRID is the authoritative grouping).
 
         Returns:
             List of message dicts in the same shape as search_messages
@@ -758,12 +805,29 @@ class ImapConnector:
             chronologically ascending.
         """
         with self._session() as client:
-            # Tier 1: Gmail X-GM-THRID — fastest, mailbox-count-independent.
+            # Tier 1: Gmail X-GM-THRID via [Gmail]/All Mail
             if self._has_capability(client, b"X-GM-EXT-1"):
                 tier1 = self._thread_via_xgm_thrid(client, anchor_rfc_message_id)
                 if tier1 is not None:
                     return tier1
-                # Else fall through to Tier 3 in the same session.
+
+                # Tier 1.5: Gmail X-GM-THRID per-mailbox (when All Mail hidden)
+                tier_1_5 = self._thread_via_xgm_per_mailbox(
+                    client, anchor_rfc_message_id
+                )
+                if tier_1_5 is not None:
+                    return tier_1_5
+
+            # Tier 2: RFC 5256 THREAD (Fastmail, Dovecot)
+            if (
+                self._has_capability(client, b"THREAD=REFERENCES")
+                or self._has_capability(client, b"THREAD=REFS")
+            ):
+                tier2 = self._thread_via_imap_thread(
+                    client, anchor_rfc_message_id, anchor_references
+                )
+                if tier2 is not None:
+                    return tier2
 
             # Tier 3: header-search BFS — universal fallback.
             return self._find_thread_members_bfs(
@@ -863,6 +927,19 @@ class ImapConnector:
                 return cast(str, name)
         return None
 
+    @staticmethod
+    def _find_sent_folder(client: IMAPClient) -> str | None:
+        """Return the Sent folder name via the ``\\Sent`` SPECIAL-USE flag,
+        or None if not found. Used by Tier 1.5 (#125) as the second
+        anchor-lookup target after INBOX — covers the common case of a
+        thread anchored at a sent message."""
+        for flags, _delim, name in client.list_folders():
+            if b"\\Sent" in flags:
+                if isinstance(name, (bytes, bytearray)):
+                    return name.decode("utf-8", errors="replace")
+                return cast(str, name)
+        return None
+
     def _thread_via_xgm_thrid(
         self,
         client: IMAPClient,
@@ -921,6 +998,225 @@ class ImapConnector:
                 continue
             flags = tuple(fetch_entry.get(b"FLAGS", ()) or ())
             collected[clean_msgid] = _envelope_to_dict(envelope, flags)
+
+        return sorted(
+            collected.values(),
+            key=lambda m: m.get("date_received") or "",
+        )
+
+    def _thread_via_xgm_per_mailbox(
+        self,
+        client: IMAPClient,
+        anchor_rfc_message_id: str,
+    ) -> list[dict[str, Any]] | None:
+        """Tier 1.5 (Gmail X-GM-THRID per-mailbox, #125).
+
+        Used when ``X-GM-EXT-1`` is advertised but ``[Gmail]/All Mail`` is
+        hidden over IMAP (Gmail Settings → Forwarding and POP/IMAP →
+        Folder size limits). The per-mailbox X-GM-THRID search covers
+        the same conversation-grouping the All Mail path would, just with
+        ~M*2 round-trips instead of ~5.
+
+        Returns ``None`` (not raise) when the strategy can't find the
+        anchor or the X-GM-THRID query gets rejected — dispatcher then
+        falls through to Tier 2 / Tier 3.
+        """
+        # Step 1: locate the anchor's UID. Try INBOX first, then \\Sent.
+        bracketed = f"<{anchor_rfc_message_id}>"
+        anchor_uid: int | None = None
+        for folder_name in self._anchor_lookup_folders(client):
+            try:
+                client.select_folder(folder_name, readonly=True)
+            except IMAPClientError:
+                continue
+            try:
+                uids = client.search(["HEADER", "Message-ID", bracketed])
+            except IMAPClientError:
+                continue
+            if uids:
+                anchor_uid = uids[0]
+                break
+
+        if anchor_uid is None:
+            # Anchor not in INBOX or Sent → fall through to Tier 2 / Tier 3.
+            return None
+
+        # Step 2: get the anchor's X-GM-THRID.
+        try:
+            thrid_fetch = client.fetch([anchor_uid], [b"X-GM-THRID"])
+        except IMAPClientError:
+            return None
+        thrid_entry: dict[bytes, Any] = next(iter(thrid_fetch.values()), {})
+        thrid = thrid_entry.get(b"X-GM-THRID")
+        if thrid is None:
+            return None
+
+        # Step 3: iterate every selectable folder, collect cluster UIDs by
+        # X-GM-THRID, FETCH ENVELOPE+FLAGS for matches.
+        collected: dict[str, dict[str, Any]] = {}
+        thrid_str = str(thrid)
+        for flags, _delim, raw_name in client.list_folders():
+            if b"\\Noselect" in flags:
+                continue
+            if isinstance(raw_name, (bytes, bytearray)):
+                folder_name = raw_name.decode("utf-8", errors="replace")
+            else:
+                folder_name = cast(str, raw_name)
+            try:
+                client.select_folder(folder_name, readonly=True)
+            except IMAPClientError as exc:
+                logger.debug(
+                    "Tier 1.5: skipping mailbox %s (SELECT rejected): %s",
+                    folder_name, exc,
+                )
+                continue
+            try:
+                uids = client.search(["X-GM-THRID", thrid_str])
+            except IMAPClientError as exc:
+                logger.debug(
+                    "Tier 1.5: skipping mailbox %s (X-GM-THRID search "
+                    "rejected): %s",
+                    folder_name, exc,
+                )
+                continue
+            if not uids:
+                continue
+            try:
+                fetched = client.fetch(uids, [b"ENVELOPE", b"FLAGS"])
+            except IMAPClientError:
+                continue
+            for fetch_entry in fetched.values():
+                envelope = fetch_entry.get(b"ENVELOPE")
+                if envelope is None:
+                    continue
+                raw_msgid = getattr(envelope, "message_id", None)
+                if not raw_msgid:
+                    continue
+                clean_msgid = _strip_brackets(_decode(raw_msgid))
+                if clean_msgid in collected:
+                    continue
+                fetch_flags = tuple(fetch_entry.get(b"FLAGS", ()) or ())
+                collected[clean_msgid] = _envelope_to_dict(
+                    envelope, fetch_flags
+                )
+
+        return sorted(
+            collected.values(),
+            key=lambda m: m.get("date_received") or "",
+        )
+
+    def _anchor_lookup_folders(
+        self, client: IMAPClient
+    ) -> Iterator[str]:
+        """Yield folder names to try in order when looking up the
+        anchor's UID for Tier 1.5: INBOX first, then ``\\Sent`` (if
+        distinct). Covers ~95% of cases per #125."""
+        yield "INBOX"
+        sent = self._find_sent_folder(client)
+        if sent and sent != "INBOX":
+            yield sent
+
+    def _thread_via_imap_thread(
+        self,
+        client: IMAPClient,
+        anchor_rfc_message_id: str,
+        anchor_references: list[str],
+    ) -> list[dict[str, Any]] | None:
+        """Tier 2 (RFC 5256 THREAD, #123).
+
+        Used when the server advertises ``THREAD=REFERENCES`` or
+        ``THREAD=REFS`` (Fastmail, some Dovecot deployments). Per
+        mailbox: SELECT, narrow-search for any UID containing the
+        anchor's Message-ID or referencing it, then THREAD on the
+        full mailbox to collect the cluster(s) those UIDs belong to,
+        then FETCH ENVELOPE+FLAGS.
+
+        Returns ``None`` (not raise) when THREAD gets rejected
+        mid-flight — dispatcher then falls through to Tier 3.
+        """
+        bracketed = f"<{anchor_rfc_message_id}>"
+        # Pick the algorithm name the server actually advertises.
+        if self._has_capability(client, b"THREAD=REFERENCES"):
+            algo = "REFERENCES"
+        elif self._has_capability(client, b"THREAD=REFS"):
+            algo = "REFS"
+        else:
+            return None
+
+        collected: dict[str, dict[str, Any]] = {}
+        for flags, _delim, raw_name in client.list_folders():
+            if b"\\Noselect" in flags:
+                continue
+            if isinstance(raw_name, (bytes, bytearray)):
+                folder_name = raw_name.decode("utf-8", errors="replace")
+            else:
+                folder_name = cast(str, raw_name)
+            try:
+                client.select_folder(folder_name, readonly=True)
+            except IMAPClientError as exc:
+                logger.debug(
+                    "Tier 2: skipping mailbox %s (SELECT rejected): %s",
+                    folder_name, exc,
+                )
+                continue
+            # Narrow-search: anchor UID + sibling-replies in this mailbox.
+            try:
+                anchor_uids = client.search(
+                    ["HEADER", "Message-ID", bracketed]
+                )
+                ref_uids = client.search(
+                    ["HEADER", "References", bracketed]
+                )
+            except IMAPClientError:
+                continue
+            relevant_uids = set(anchor_uids) | set(ref_uids)
+            if not relevant_uids:
+                continue
+            # Run THREAD; walk tree for clusters intersecting relevant_uids.
+            try:
+                tree = client.thread(
+                    algorithm=algo, criteria="ALL", charset="UTF-8"
+                )
+            except IMAPClientError as exc:
+                logger.debug(
+                    "Tier 2: THREAD rejected on mailbox %s: %s. "
+                    "Falling through to Tier 3.",
+                    folder_name, exc,
+                )
+                # Mid-flight rejection — server lied about advertised cap.
+                # Surface as None so the dispatcher falls through.
+                return None
+            cluster_uids: set[int] = set()
+            for cluster in _flatten_thread_clusters(tree):
+                if cluster & relevant_uids:
+                    cluster_uids |= cluster
+            if not cluster_uids:
+                continue
+            try:
+                fetched = client.fetch(
+                    sorted(cluster_uids), [b"ENVELOPE", b"FLAGS"]
+                )
+            except IMAPClientError:
+                continue
+            for fetch_entry in fetched.values():
+                envelope = fetch_entry.get(b"ENVELOPE")
+                if envelope is None:
+                    continue
+                raw_msgid = getattr(envelope, "message_id", None)
+                if not raw_msgid:
+                    continue
+                clean_msgid = _strip_brackets(_decode(raw_msgid))
+                if clean_msgid in collected:
+                    continue
+                fetch_flags = tuple(fetch_entry.get(b"FLAGS", ()) or ())
+                collected[clean_msgid] = _envelope_to_dict(
+                    envelope, fetch_flags
+                )
+
+        if not collected:
+            # No mailbox in the account had any matching message — Tier 2
+            # didn't help. Fall through.
+            return None
 
         return sorted(
             collected.values(),

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -1583,3 +1583,333 @@ class TestFindThreadMembersGmail:
         )
 
         assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #125: Gmail X-GM-THRID per-mailbox iteration (Tier 1.5)
+# ---------------------------------------------------------------------------
+
+
+def _gmail_folder_listing_no_all_with_sent() -> list:
+    """Gmail-style listing where [Gmail]/All Mail is hidden (per-folder
+    IMAP opt-out). \\Sent is still visible. This is the configuration
+    Tier 1.5 (#125) is designed for."""
+    return [
+        ((b"\\HasNoChildren",), b"/", "INBOX"),
+        ((b"\\HasNoChildren", b"\\Drafts"), b"/", "[Gmail]/Drafts"),
+        ((b"\\HasNoChildren", b"\\Sent"), b"/", "[Gmail]/Sent Mail"),
+        ((b"\\HasNoChildren", b"\\Trash"), b"/", "[Gmail]/Trash"),
+        ((b"\\HasNoChildren",), b"/", "Receipts"),
+        ((b"\\HasNoChildren",), b"/", "Newsletters"),
+    ]
+
+
+class TestFindThreadMembersGmailPerMailbox:
+    """Tier 1.5 (Gmail X-GM-THRID per-mailbox, #125) dispatch.
+
+    Triggered when X-GM-EXT-1 is advertised but \\All is not in the
+    folder listing. Anchor lookup tries INBOX then \\Sent; per-mailbox
+    SEARCH X-GM-THRID collects siblings."""
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_uses_per_mailbox_when_all_mail_hidden(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """X-GM-EXT-1 advertised, no \\All folder → Tier 1 returns None,
+        Tier 1.5 fires: SELECT INBOX, SEARCH for anchor, FETCH X-GM-THRID,
+        then iterate all selectable folders SEARCHing X-GM-THRID."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_no_all_with_sent()
+
+        # Searches in order:
+        # 1. INBOX HEADER Message-ID anchor → [42]
+        # 2-7. Per-folder X-GM-THRID search (6 folders)
+        client.search.side_effect = [
+            [42],         # anchor in INBOX
+            [42, 43],     # INBOX X-GM-THRID
+            [],           # Drafts: empty
+            [101],        # Sent Mail: 1 hit
+            [],           # Trash: empty
+            [],           # Receipts: empty
+            [],           # Newsletters: empty
+        ]
+        # FETCHes:
+        # 1. X-GM-THRID for the anchor UID
+        # 2. ENVELOPE+FLAGS for INBOX hits
+        # 3. ENVELOPE+FLAGS for Sent hit
+        client.fetch.side_effect = [
+            {42: {b"X-GM-THRID": 9876543210987654321}},
+            _fake_fetch_result([42, 43]),
+            _fake_fetch_result([101]),
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        # Anchor SELECTed INBOX, then per-mailbox iteration SELECTed each.
+        select_paths = [
+            call.args[0] for call in client.select_folder.call_args_list
+        ]
+        assert select_paths[0] == "INBOX"  # anchor lookup
+        assert "[Gmail]/Sent Mail" in select_paths
+        # Three messages collected (deduped: anchor's UID 42 appears once).
+        assert len(result) == 3
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_falls_back_to_sent_when_anchor_not_in_inbox(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """If INBOX SEARCH returns no anchor UID, Tier 1.5 SELECTs the
+        \\Sent folder and tries again. Anchor found there → continue."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_no_all_with_sent()
+
+        client.search.side_effect = [
+            [],         # INBOX anchor SEARCH: not here
+            [55],       # Sent anchor SEARCH: found
+            [55],       # INBOX X-GM-THRID
+            [],         # Drafts
+            [55],       # Sent X-GM-THRID
+            [],         # Trash
+            [],         # Receipts
+            [],         # Newsletters
+        ]
+        client.fetch.side_effect = [
+            {55: {b"X-GM-THRID": 1111}},
+            _fake_fetch_result([55]),  # INBOX
+            _fake_fetch_result([55]),  # Sent (deduped by msg-id)
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        select_paths = [
+            call.args[0] for call in client.select_folder.call_args_list
+        ]
+        assert select_paths[0] == "INBOX"
+        assert select_paths[1] == "[Gmail]/Sent Mail"
+        # Single result (deduped from INBOX+Sent).
+        assert len(result) == 1
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_returns_none_when_anchor_in_neither_inbox_nor_sent(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Anchor SEARCH returns [] in both INBOX and Sent → Tier 1.5
+        returns None → dispatcher falls through to BFS (Tier 3)."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_no_all_with_sent()
+
+        client.search.return_value = []  # blanket empty
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        # No FETCH X-GM-THRID was issued (anchor never found).
+        for call in client.fetch.call_args_list:
+            data = call[0][1]
+            assert b"X-GM-THRID" not in data, (
+                "Tier 1.5 should not FETCH X-GM-THRID after failed anchor lookup"
+            )
+        # Tier 3 (BFS) ran with empty results.
+        assert result == []
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_xgm_thrid_query_rejection_per_mailbox_continues(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """A single folder's X-GM-THRID search rejection is logged DEBUG
+        and skipped; doesn't tank the whole strategy."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_no_all_with_sent()
+
+        client.search.side_effect = [
+            [42],                            # anchor in INBOX
+            [42],                            # INBOX X-GM-THRID OK
+            IMAPClientError("rejected"),     # Drafts rejects
+            [101],                           # Sent Mail OK
+            [],                              # Trash
+            [],                              # Receipts
+            [],                              # Newsletters
+        ]
+        client.fetch.side_effect = [
+            {42: {b"X-GM-THRID": 1111}},
+            _fake_fetch_result([42]),
+            _fake_fetch_result([101]),
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        assert len(result) == 2  # INBOX + Sent (Drafts skipped)
+
+
+# ---------------------------------------------------------------------------
+# Issue #123: RFC 5256 THREAD dispatch (Tier 2)
+# ---------------------------------------------------------------------------
+
+
+def _fastmail_caps_with_thread() -> set[bytes]:
+    """Capability list for a Fastmail-like server: THREAD=REFERENCES
+    advertised, no X-GM-EXT-1."""
+    return {
+        b"IMAP4REV1", b"UNSELECT", b"IDLE", b"NAMESPACE", b"QUOTA",
+        b"ID", b"UIDPLUS", b"ENABLE", b"CONDSTORE", b"ESEARCH",
+        b"SPECIAL-USE", b"THREAD=REFERENCES",
+    }
+
+
+def _caps_with_thread_refs_alias() -> set[bytes]:
+    """Capability set advertising the THREAD=REFS alias (RFC 5256)."""
+    return {
+        b"IMAP4REV1", b"UNSELECT", b"IDLE", b"NAMESPACE",
+        b"UIDPLUS", b"ENABLE", b"THREAD=REFS",
+    }
+
+
+def _fastmail_folder_listing() -> list:
+    """A small folder listing for THREAD-dispatch tests."""
+    return [
+        ((b"\\HasNoChildren",), b"/", "INBOX"),
+        ((b"\\HasNoChildren", b"\\Sent"), b"/", "Sent"),
+        ((b"\\HasNoChildren",), b"/", "Archive"),
+    ]
+
+
+class TestFindThreadMembersImapThread:
+    """Tier 2 (RFC 5256 THREAD, #123) dispatch."""
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_uses_imap_thread_when_capability_advertised(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """THREAD=REFERENCES advertised → Tier 2 fires: per mailbox, narrow
+        SEARCH for anchor + sibling refs, then THREAD command, then walk
+        tree for matching clusters."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _fastmail_caps_with_thread()
+        client.list_folders.return_value = _fastmail_folder_listing()
+
+        # Per-mailbox: 2 SEARCHes (anchor MsgID, References) + (if any
+        # match) THREAD + FETCH.
+        client.search.side_effect = [
+            [7],   # INBOX HEADER Message-ID
+            [],    # INBOX HEADER References
+            [],    # Sent HEADER Message-ID
+            [],    # Sent HEADER References
+            [],    # Archive HEADER Message-ID
+            [99],  # Archive HEADER References (sibling reply)
+        ]
+        # THREAD response: nested tuples per RFC 5256.
+        client.thread.side_effect = [
+            ((7, 8, 9),),                  # INBOX cluster contains anchor
+            ((99, (100,)),),               # Archive cluster contains sibling
+        ]
+        client.fetch.side_effect = [
+            _fake_fetch_result([7, 8, 9]),
+            _fake_fetch_result([99, 100]),
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        # THREAD called twice (INBOX + Archive); not on Sent.
+        assert client.thread.call_count == 2
+        for thread_call in client.thread.call_args_list:
+            assert thread_call.kwargs.get("algorithm") == "REFERENCES"
+        assert len(result) == 5
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_accepts_thread_refs_alias(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """THREAD=REFS (Gmail's shorter form) also triggers Tier 2;
+        algorithm passed to client.thread() is 'REFS' not 'REFERENCES'."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _caps_with_thread_refs_alias()
+        client.list_folders.return_value = _fastmail_folder_listing()
+        client.search.side_effect = [
+            [1],   # INBOX MsgID
+            [],    # INBOX References
+            [],    # Sent MsgID
+            [],    # Sent References
+            [],    # Archive MsgID
+            [],    # Archive References
+        ]
+        client.thread.return_value = ((1,),)
+        client.fetch.return_value = _fake_fetch_result([1])
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        algos = [
+            c.kwargs.get("algorithm") for c in client.thread.call_args_list
+        ]
+        assert all(a == "REFS" for a in algos)
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_skips_when_capability_missing(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """No THREAD=* in caps → Tier 2 helper never invoked."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _generic_caps_no_xgm()
+        client.list_folders.return_value = _generic_folder_listing_no_all()
+        client.search.return_value = []  # BFS finds nothing → fast exit
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        assert client.thread.call_count == 0
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_thread_command_rejection_falls_through_to_bfs(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """If client.thread() raises mid-flight (server lied about
+        THREAD capability), Tier 2 returns None → BFS runs."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _fastmail_caps_with_thread()
+        client.list_folders.return_value = _fastmail_folder_listing()
+
+        client.search.side_effect = [
+            [1],   # INBOX MsgID
+            [],    # INBOX References
+        ] + [[]] * 100  # plenty for BFS to fast-exit
+        client.thread.side_effect = IMAPClientError("THREAD rejected")
+        client.fetch.return_value = {}
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        # Tier 2 only made 2 SEARCHes (first folder, until THREAD raised).
+        # BFS then ran more SEARCHes — assert the count exceeds Tier 2's.
+        assert client.search.call_count > 2

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -1759,6 +1759,261 @@ class TestFindThreadMembersGmailPerMailbox:
 
         assert len(result) == 2  # INBOX + Sent (Drafts skipped)
 
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_anchor_select_rejection_in_inbox_falls_through_to_sent(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """SELECT INBOX raises during anchor lookup → Tier 1.5 moves on
+        to \\Sent. Same SELECT failure during the per-mailbox loop is
+        also caught and the folder is skipped silently."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_no_all_with_sent()
+
+        def select(folder: str, **_kw: Any) -> dict[bytes, int]:
+            if folder == "INBOX":
+                raise IMAPClientError("INBOX SELECT rejected")
+            return {b"EXISTS": 0}
+        client.select_folder.side_effect = select
+
+        # Anchor SEARCH only runs once — in Sent, after INBOX SELECT failed.
+        # Then the per-mailbox loop SELECTs each folder; INBOX raises again
+        # and is skipped before SEARCH would have run for it.
+        client.search.side_effect = [
+            [55],   # Sent anchor SEARCH
+            [],     # [Gmail]/Drafts X-GM-THRID
+            [55],   # [Gmail]/Sent Mail X-GM-THRID
+            [],     # [Gmail]/Trash
+            [],     # Receipts
+            [],     # Newsletters
+        ]
+        client.fetch.side_effect = [
+            {55: {b"X-GM-THRID": 1111}},
+            _fake_fetch_result([55]),
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        select_paths = [c.args[0] for c in client.select_folder.call_args_list]
+        assert select_paths[0] == "INBOX"          # tried first, rejected
+        assert "[Gmail]/Sent Mail" in select_paths  # fall-through worked
+        assert len(result) == 1
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_anchor_search_rejection_in_inbox_falls_through_to_sent(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """SELECT INBOX succeeds but the anchor SEARCH raises — Tier 1.5
+        treats the folder as a miss and tries \\Sent."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_no_all_with_sent()
+
+        client.search.side_effect = [
+            IMAPClientError("INBOX search rejected"),  # anchor INBOX
+            [55],                                       # anchor Sent: found
+            [],                                         # INBOX X-GM-THRID
+            [],                                         # Drafts
+            [55],                                       # Sent
+            [],                                         # Trash
+            [],                                         # Receipts
+            [],                                         # Newsletters
+        ]
+        client.fetch.side_effect = [
+            {55: {b"X-GM-THRID": 1111}},
+            _fake_fetch_result([55]),
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        assert len(result) == 1
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_thrid_fetch_rejection_falls_through_to_bfs(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """FETCH X-GM-THRID raises after the anchor was located → Tier 1.5
+        returns None → BFS picks up."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_no_all_with_sent()
+
+        client.search.side_effect = [[55]] + [[]] * 100
+        client.fetch.side_effect = [IMAPClientError("BAD X-GM-THRID")] + [{}] * 10
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        assert result == []
+        # BFS ran (more SELECTs than the single INBOX anchor SELECT).
+        assert client.select_folder.call_count > 1
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_thrid_missing_from_fetch_falls_through_to_bfs(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """FETCH succeeds but the response dict lacks the X-GM-THRID key
+        (server inconsistency) → Tier 1.5 returns None → BFS runs."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_no_all_with_sent()
+
+        client.search.side_effect = [[55]] + [[]] * 100
+        client.fetch.side_effect = [{55: {}}] + [{}] * 10  # no X-GM-THRID key
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        assert result == []
+        assert client.select_folder.call_count > 1
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_noselect_folders_skipped_in_per_mailbox_loop(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """A folder marked \\Noselect (e.g. Gmail's `[Gmail]` category
+        parent) is skipped without a SELECT attempt."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\Noselect", b"\\HasChildren"), b"/", "[Gmail]"),
+            ((b"\\HasNoChildren", b"\\Sent"), b"/", "[Gmail]/Sent Mail"),
+        ]
+        client.search.side_effect = [
+            [42],   # anchor INBOX
+            [42],   # INBOX X-GM-THRID
+            [42],   # Sent X-GM-THRID
+        ]
+        client.fetch.side_effect = [
+            {42: {b"X-GM-THRID": 1111}},
+            _fake_fetch_result([42]),
+            _fake_fetch_result([42]),
+        ]
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        select_paths = [c.args[0] for c in client.select_folder.call_args_list]
+        assert "[Gmail]" not in select_paths
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_bytes_folder_name_decoded_in_per_mailbox_loop(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """`list_folders()` returning a bytes folder name (some servers do
+        this when names contain non-ASCII) is decoded before SELECT."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\HasNoChildren",), b"/", b"Receipts"),  # bytes name
+        ]
+        client.search.side_effect = [
+            [42],   # anchor INBOX
+            [42],   # INBOX X-GM-THRID
+            [],     # Receipts X-GM-THRID
+        ]
+        client.fetch.side_effect = [
+            {42: {b"X-GM-THRID": 1111}},
+            _fake_fetch_result([42]),
+        ]
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        select_paths = [c.args[0] for c in client.select_folder.call_args_list]
+        assert "Receipts" in select_paths
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_envelope_fetch_rejection_in_loop_skips_mailbox(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """A FETCH ENVELOPE+FLAGS rejection on a single folder is silently
+        skipped — other folders' results still surface."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = _gmail_folder_listing_no_all_with_sent()
+
+        client.search.side_effect = [
+            [42],   # anchor INBOX
+            [42],   # INBOX X-GM-THRID OK
+            [99],   # Drafts X-GM-THRID OK (FETCH fails below)
+            [],     # Sent
+            [],     # Trash
+            [],     # Receipts
+            [],     # Newsletters
+        ]
+        client.fetch.side_effect = [
+            {42: {b"X-GM-THRID": 1111}},
+            _fake_fetch_result([42]),                   # INBOX OK
+            IMAPClientError("Drafts FETCH rejected"),   # Drafts FETCH fails
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@gmail.com",
+            anchor_references=[],
+        )
+
+        assert len(result) == 1  # INBOX surfaces, Drafts skipped
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_envelope_none_or_missing_msgid_is_skipped(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Defensive: FETCH entries lacking ENVELOPE, or whose envelope has
+        no Message-ID, are skipped rather than crashing the loop."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _gmail_caps_with_xgm()
+        client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+        ]
+        client.search.side_effect = [
+            [42],            # anchor INBOX
+            [42, 43, 44],    # INBOX X-GM-THRID — 43 has no envelope, 44 has no msgid
+        ]
+        client.fetch.side_effect = [
+            {42: {b"X-GM-THRID": 1111}},
+            {
+                42: {
+                    b"ENVELOPE": _fake_envelope(message_id=b"<a@gmail.com>"),
+                    b"FLAGS": (),
+                },
+                43: {b"ENVELOPE": None, b"FLAGS": ()},
+                44: {b"ENVELOPE": _fake_envelope(message_id=b""), b"FLAGS": ()},
+            },
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="a@gmail.com",
+            anchor_references=[],
+        )
+
+        assert len(result) == 1
+        assert result[0]["id"] == "a@gmail.com"
+
 
 # ---------------------------------------------------------------------------
 # Issue #123: RFC 5256 THREAD dispatch (Tier 2)
@@ -1913,3 +2168,295 @@ class TestFindThreadMembersImapThread:
         # Tier 2 only made 2 SEARCHes (first folder, until THREAD raised).
         # BFS then ran more SEARCHes — assert the count exceeds Tier 2's.
         assert client.search.call_count > 2
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_returns_none_when_called_without_thread_capability(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Defensive: if Tier 2 is invoked when neither THREAD=REFERENCES
+        nor THREAD=REFS is advertised, return None rather than guessing
+        an algorithm name. (Dispatcher gates on capability, but the helper
+        defends against direct misuse.)"""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _generic_caps_no_xgm()  # no THREAD
+
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        result = conn._thread_via_imap_thread(
+            client,
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        assert result is None
+        # No THREAD command was issued.
+        assert client.thread.call_count == 0
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_noselect_folders_skipped_in_tier2_loop(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """\\Noselect folders are skipped before any SELECT attempt."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _fastmail_caps_with_thread()
+        client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\Noselect", b"\\HasChildren"), b"/", "Folders"),
+            ((b"\\HasNoChildren",), b"/", "Archive"),
+        ]
+        client.search.side_effect = [
+            [7],   # INBOX MsgID
+            [],    # INBOX References
+            [],    # Archive MsgID
+            [],    # Archive References
+        ]
+        client.thread.return_value = ((7,),)
+        client.fetch.return_value = _fake_fetch_result([7])
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        select_paths = [c.args[0] for c in client.select_folder.call_args_list]
+        assert "Folders" not in select_paths
+        assert "INBOX" in select_paths and "Archive" in select_paths
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_bytes_folder_name_decoded_in_tier2_loop(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Bytes folder names from list_folders() are decoded before SELECT."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _fastmail_caps_with_thread()
+        client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\HasNoChildren",), b"/", b"Archive"),  # bytes name
+        ]
+        client.search.side_effect = [
+            [7],   # INBOX MsgID
+            [],    # INBOX References
+            [],    # Archive MsgID
+            [],    # Archive References
+        ]
+        client.thread.return_value = ((7,),)
+        client.fetch.return_value = _fake_fetch_result([7])
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        select_paths = [c.args[0] for c in client.select_folder.call_args_list]
+        assert "Archive" in select_paths
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_select_rejection_in_tier2_loop_continues(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """A single folder's SELECT rejection is logged DEBUG and the loop
+        moves on — non-empty results from other folders still surface."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _fastmail_caps_with_thread()
+        client.list_folders.return_value = _fastmail_folder_listing()
+
+        def select(folder: str, **_kw: Any) -> dict[bytes, int]:
+            if folder == "Sent":
+                raise IMAPClientError("Sent SELECT rejected")
+            return {b"EXISTS": 0}
+        client.select_folder.side_effect = select
+
+        client.search.side_effect = [
+            [7],   # INBOX MsgID
+            [],    # INBOX References
+            [],    # Archive MsgID
+            [],    # Archive References
+        ]
+        client.thread.return_value = ((7,),)
+        client.fetch.return_value = _fake_fetch_result([7])
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        # Tier 2 still returned a non-empty result (so BFS didn't run);
+        # Sent was attempted but skipped.
+        assert len(result) == 1
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_search_rejection_in_tier2_loop_continues(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """An IMAPClientError on either narrow SEARCH (anchor MsgID or
+        References) skips the folder and lets others contribute."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _fastmail_caps_with_thread()
+        client.list_folders.return_value = _fastmail_folder_listing()
+
+        client.search.side_effect = [
+            IMAPClientError("INBOX MsgID search rejected"),
+            # next iteration: Sent
+            [],   # Sent MsgID
+            [],   # Sent References
+            [7],  # Archive MsgID
+            [],   # Archive References
+        ]
+        client.thread.return_value = ((7,),)
+        client.fetch.return_value = _fake_fetch_result([7])
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        assert len(result) == 1
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_thread_with_no_intersecting_clusters_continues(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """SEARCH found UIDs but THREAD response's clusters don't actually
+        contain them (server inconsistency) — skip the folder, don't fetch."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _fastmail_caps_with_thread()
+        client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\HasNoChildren",), b"/", "Archive"),
+        ]
+        client.search.side_effect = [
+            [7],    # INBOX MsgID
+            [],     # INBOX References
+            [],     # Archive MsgID
+            [99],   # Archive References (sibling reply)
+        ]
+        client.thread.side_effect = [
+            ((1, 2, 3),),       # INBOX clusters: no overlap with {7}
+            ((99, (100,)),),    # Archive cluster overlaps {99}
+        ]
+        client.fetch.return_value = _fake_fetch_result([99, 100])
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        assert client.fetch.call_count == 1  # INBOX skipped pre-FETCH
+        assert len(result) == 2
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_envelope_fetch_rejection_in_tier2_loop_continues(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """A FETCH ENVELOPE+FLAGS rejection on a single folder is silently
+        skipped; other folders still contribute."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _fastmail_caps_with_thread()
+        client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\HasNoChildren",), b"/", "Archive"),
+        ]
+        client.search.side_effect = [
+            [7],    # INBOX MsgID
+            [],     # INBOX References
+            [],     # Archive MsgID
+            [99],   # Archive References
+        ]
+        client.thread.side_effect = [
+            ((7,),),
+            ((99,),),
+        ]
+        client.fetch.side_effect = [
+            IMAPClientError("INBOX FETCH rejected"),
+            _fake_fetch_result([99]),
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        assert len(result) == 1  # Archive surfaced; INBOX skipped
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_envelope_none_or_missing_msgid_is_skipped(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Defensive: FETCH entries with ENVELOPE=None or empty Message-ID
+        are skipped without crashing the loop. Duplicate Message-IDs across
+        folders are deduped by the collected dict."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _fastmail_caps_with_thread()
+        client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\HasNoChildren",), b"/", "Archive"),
+        ]
+        client.search.side_effect = [
+            [7],   # INBOX MsgID
+            [],    # INBOX References
+            [],    # Archive MsgID
+            [99],  # Archive References
+        ]
+        client.thread.side_effect = [
+            ((7, 8, 9),),
+            ((99,),),
+        ]
+        client.fetch.side_effect = [
+            {
+                7: {
+                    b"ENVELOPE": _fake_envelope(message_id=b"<a@example.com>"),
+                    b"FLAGS": (),
+                },
+                8: {b"ENVELOPE": None, b"FLAGS": ()},
+                9: {b"ENVELOPE": _fake_envelope(message_id=b""), b"FLAGS": ()},
+            },
+            {
+                # Duplicate Message-ID across folders → dedup.
+                99: {
+                    b"ENVELOPE": _fake_envelope(message_id=b"<a@example.com>"),
+                    b"FLAGS": (),
+                },
+            },
+        ]
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="a@example.com",
+            anchor_references=[],
+        )
+
+        # Three messages total in fetches but only one unique Message-ID
+        # (and two skipped for missing data) → 1 result.
+        assert len(result) == 1
+        assert result[0]["id"] == "a@example.com"
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_empty_collected_falls_through_to_bfs(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """If no folder contributed any members (all narrow SEARCHes
+        empty), Tier 2 returns None and BFS runs."""
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = _fastmail_caps_with_thread()
+        client.list_folders.return_value = _fastmail_folder_listing()
+
+        # All SEARCHes (Tier 2 narrow + BFS per-id-per-header) return [].
+        client.search.return_value = []
+
+        ImapConnector("h", 993, "u@e.com", "pw").find_thread_members(
+            anchor_rfc_message_id="anchor@example.com",
+            anchor_references=[],
+        )
+
+        # Tier 2 never invoked THREAD (no UIDs to intersect against).
+        assert client.thread.call_count == 0
+        # Tier 2 made 2 SEARCHes per folder × 3 folders = 6.
+        # BFS adds 3 SEARCHes (1 id × 3 headers) per folder.
+        assert client.search.call_count > 6


### PR DESCRIPTION
## Summary

Two new tiers in the `find_thread_members` capability-detected dispatcher.

Closes #125. Closes #123.

## New tiers

| Tier | Capability gate | Cost | Status |
|---|---|---|---|
| **1.5** (#125) | `X-GM-EXT-1` AND no `\\All` | ~2 + M*2 RTs | Verified against your real Gmail (92 folders, 25.5s) |
| **2** (#123) | `THREAD=REFERENCES` or `THREAD=REFS` | ~M*2-4 RTs | Unit-tested only (no Fastmail/Dovecot configured) |

Updated dispatch chain: **Tier 1** (All Mail X-GM-THRID) → **Tier 1.5** (per-mailbox X-GM-THRID, Gmail-only) → **Tier 2** (RFC 5256 THREAD) → **Tier 3** (header-search BFS, universal fallback).

## Tier 1.5 (#125) — your Gmail's exact configuration

You have `[Gmail]/All Mail` hidden over IMAP, so Tier 1 falls through. Smoke-tested:
- 92 folders, single-message thread → **25.5s** (vs ~100s for Tier 3 BFS).
- Anchor lookup tries INBOX first, then `\\Sent`. Falls through cleanly to Tier 3 if anchor isn't in either.

## Tier 2 (#123) — for Fastmail / Dovecot

Per-mailbox: SELECT → narrow-SEARCH (anchor MsgID + References) → THREAD REFERENCES UTF-8 ALL → walk nested-tuple tree for clusters → FETCH ENVELOPE FLAGS. Mid-flight `client.thread()` rejection (server lied about advertised capability) → returns None → dispatcher falls through to Tier 3.

## Test plan

- [x] **Unit**: 8 new tests covering both tiers (happy path, fallback chains, capability detection, mid-flight rejection).
- [x] **Real-Mail smoke**: Tier 1.5 verified end-to-end against your 92-folder Gmail.
- [x] `make check-all` clean (lint, mypy strict, complexity ≤ 20, version-sync, parity).
- [x] 869 unit + e2e tests pass.

## Doc updates

- README: "Gmail thread retrieval — All Mail visibility tradeoff" note in the IMAP section explaining the per-folder-size opt-out and what each path costs.
- `docs/research/imap-thread-strategies.md`: marked #125 and #123 as shipped with the verified perf numbers.

## Risk

Tier 2 is unverified against a real `THREAD=*`-capable server (you don't have one configured). Unit tests cover the dispatch + tree-walk + cap-rejection logic. If a real Fastmail/Dovecot user surfaces a quirk, the graceful fall-through to Tier 3 keeps correctness intact while we iterate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)