### PR TITLE
feat(#164): refuse Gmail system label paths in update/delete_mailbox

### DIFF
--- a/src/apple_mail_mcp/exceptions.py
+++ b/src/apple_mail_mcp/exceptions.py
@@ -28,6 +28,19 @@ class MailMailboxNotEmptyError(MailError):
     pass
 
 
+class MailUnsupportedGmailSystemLabelError(MailError):
+    """Operation targets a Gmail system label (the ``[Gmail]`` parent or
+    any ``[Gmail]/...`` child path).
+
+    Gmail's IMAP server does not support normal RENAME/DELETE semantics
+    for these paths — renames may silently revert and deletes are
+    refused. Tracked in #164; future Gmail-label-CRUD tools (sub-feature
+    2 of #164) will provide a proper alternative.
+    """
+
+    pass
+
+
 class MailImapRequiredError(MailError):
     """The requested operation requires IMAP credentials and the user
     hasn't opted in (no Keychain entry, or entry is unreachable). Surfaces

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -27,6 +27,7 @@ from .exceptions import (
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
     MailRuleNotFoundError,
+    MailUnsupportedGmailSystemLabelError,
     MailUnsupportedRuleActionError,
 )
 from .imap_connector import ImapConnectionPool, ImapConnector
@@ -2357,6 +2358,10 @@ class AppleMailConnector:
         Raises:
             ValueError: If neither ``new_name`` nor ``new_parent`` was
                 provided, or ``new_name`` sanitizes to empty.
+            MailUnsupportedGmailSystemLabelError: If the source ``name``
+                or the resulting destination is a Gmail system label
+                (``[Gmail]`` / ``[Gmail]/...``). Pre-flight refusal —
+                no AppleScript or IMAP traffic. See #164.
             MailAccountNotFoundError: If account doesn't exist.
             MailMailboxNotFoundError: If the source mailbox doesn't exist.
             MailImapRequiredError: If a move was requested but no IMAP
@@ -2365,11 +2370,18 @@ class AppleMailConnector:
             imapclient.exceptions.IMAPClientError: If a move otherwise
                 fails on the IMAP server.
         """
-        from .utils import sanitize_mailbox_name
+        from .utils import is_gmail_system_label, sanitize_mailbox_name
 
         if new_name is None and new_parent is None:
             raise ValueError(
                 "update_mailbox requires at least one of new_name or new_parent"
+            )
+
+        if is_gmail_system_label(name):
+            raise MailUnsupportedGmailSystemLabelError(
+                f"cannot update Gmail system label {name!r}; Gmail's IMAP "
+                f"server does not support normal RENAME for these paths "
+                f"(see #164)"
             )
 
         sanitized_new_name: str | None = None
@@ -2419,6 +2431,13 @@ class AppleMailConnector:
             destination = leaf
         else:
             destination = f"{new_parent}/{leaf}"
+
+        if is_gmail_system_label(destination):
+            raise MailUnsupportedGmailSystemLabelError(
+                f"cannot move mailbox {name!r} to {destination!r}; the "
+                f"destination would land in Gmail's system-label namespace "
+                f"(see #164)"
+            )
 
         try:
             host, port, email = self._resolve_imap_config(account)
@@ -2470,6 +2489,9 @@ class AppleMailConnector:
             mailbox; positive when ``delete_messages=True`` cascaded).
 
         Raises:
+            MailUnsupportedGmailSystemLabelError: If ``name`` is a Gmail
+                system label (``[Gmail]`` / ``[Gmail]/...``). Pre-flight
+                refusal — no IMAP traffic. See #164.
             MailAccountNotFoundError: If account doesn't exist.
             MailMailboxNotFoundError: If the mailbox doesn't exist on
                 the IMAP server.
@@ -2479,6 +2501,14 @@ class AppleMailConnector:
             imapclient.exceptions.IMAPClientError: Other server-side
                 error.
         """
+        from .utils import is_gmail_system_label
+
+        if is_gmail_system_label(name):
+            raise MailUnsupportedGmailSystemLabelError(
+                f"cannot delete Gmail system label {name!r}; Gmail's IMAP "
+                f"server does not support DELETE for these paths (see #164)"
+            )
+
         try:
             host, port, email = self._resolve_imap_config(account)
             password = get_imap_password(account, email)

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -29,6 +29,7 @@ from .exceptions import (
     MailTemplateInvalidNameError,
     MailTemplateMissingVariableError,
     MailTemplateNotFoundError,
+    MailUnsupportedGmailSystemLabelError,
     MailUnsupportedRuleActionError,
 )
 from .imap_connector import ImapConnectionPool
@@ -1432,9 +1433,12 @@ def update_mailbox(
 
     At least one of ``new_name`` / ``new_parent`` must be provided.
 
-    Caveat (#164): renaming Gmail system labels under ``[Gmail]/`` may
-    not stick — Gmail's IMAP server may auto-restore canonical names.
-    User-created Gmail labels behave normally.
+    Refused (#164): operations targeting the bare ``[Gmail]`` parent or
+    any ``[Gmail]/...`` child path return ``error_type:
+    "unsupported_gmail_system_label"``. Applies to both the source
+    ``name`` and the resulting destination (``new_parent`` join). Gmail's
+    IMAP server doesn't support normal RENAME semantics for these paths;
+    user-created Gmail labels (``Newsletters``, etc.) behave normally.
 
     Args:
         account: Mail.app account display name or UUID.
@@ -1539,6 +1543,12 @@ def update_mailbox(
             "error": str(e),
             "error_type": "applescript_error",
         }
+    except MailUnsupportedGmailSystemLabelError as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "unsupported_gmail_system_label",
+        }
     except Exception as e:
         logger.exception(f"Unexpected error in update_mailbox: {e}")
         return {
@@ -1565,6 +1575,11 @@ async def delete_mailbox(
     Always elicits user confirmation (destructive). By default refuses
     non-empty mailboxes to prevent accidental data loss; pass
     ``delete_messages=True`` to cascade.
+
+    Refused (#164): targeting the bare ``[Gmail]`` parent or any
+    ``[Gmail]/...`` child path returns ``error_type:
+    "unsupported_gmail_system_label"``. Gmail's IMAP server doesn't
+    support DELETE for these paths.
 
     Args:
         account: Mail.app account display name or UUID.
@@ -1657,6 +1672,12 @@ async def delete_mailbox(
             "success": False,
             "error": f"Account {account!r} not found",
             "error_type": "account_not_found",
+        }
+    except MailUnsupportedGmailSystemLabelError as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "unsupported_gmail_system_label",
         }
     except Exception as e:
         logger.exception(f"Unexpected error in delete_mailbox: {e}")

--- a/src/apple_mail_mcp/utils.py
+++ b/src/apple_mail_mcp/utils.py
@@ -267,6 +267,20 @@ def sanitize_mailbox_name(name: str) -> str:
     return name
 
 
+def is_gmail_system_label(name: str) -> bool:
+    """Return True if ``name`` is the bare Gmail system parent
+    (``[Gmail]``) or any ``[Gmail]/...`` child path.
+
+    Used by update_mailbox / delete_mailbox to refuse operations on
+    Gmail's IMAP-system labels (Drafts, Sent Mail, Trash, Spam,
+    Important, Starred, etc.). Localized Gmail prefixes such as
+    ``[Google Mail]/`` are not detected — proper localization handling
+    requires an IMAP session for SPECIAL-USE flag enumeration; tracked
+    as a follow-up to #164.
+    """
+    return name == "[Gmail]" or name.startswith("[Gmail]/")
+
+
 def validate_flag_color(color: str) -> bool:
     """
     Validate flag color name.

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -13,6 +13,7 @@ from apple_mail_mcp.exceptions import (
     MailTemplateInvalidNameError,
     MailTemplateMissingVariableError,
     MailTemplateNotFoundError,
+    MailUnsupportedGmailSystemLabelError,
     MailUnsupportedRuleActionError,
 )
 
@@ -75,3 +76,16 @@ class TestTemplateExceptions:
     def test_missing_variable_can_be_raised_and_caught(self):
         with pytest.raises(MailTemplateMissingVariableError):
             raise MailTemplateMissingVariableError("missing: due_date")
+
+
+class TestMailboxExceptions:
+    def test_unsupported_gmail_system_label_is_mail_error(self):
+        assert issubclass(MailUnsupportedGmailSystemLabelError, MailError)
+
+    def test_unsupported_gmail_system_label_can_be_raised_and_caught(self):
+        with pytest.raises(MailUnsupportedGmailSystemLabelError):
+            raise MailUnsupportedGmailSystemLabelError("[Gmail]/Drafts")
+
+    def test_unsupported_gmail_system_label_can_be_caught_as_mail_error(self):
+        with pytest.raises(MailError):
+            raise MailUnsupportedGmailSystemLabelError("[Gmail]/Sent Mail")

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -3882,6 +3882,36 @@ class TestUpdateMailbox:
         with pytest.raises(ValueError, match="at least one"):
             connector.update_mailbox(account="Gmail", name="Old")
 
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_gmail_system_label_source_refused_before_applescript(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Pre-flight: source name like ``[Gmail]/Drafts`` raises
+        ``MailUnsupportedGmailSystemLabelError`` before any AppleScript
+        runs (#164). Renames of Gmail system labels don't stick anyway."""
+        from apple_mail_mcp.exceptions import (
+            MailUnsupportedGmailSystemLabelError,
+        )
+        with pytest.raises(MailUnsupportedGmailSystemLabelError):
+            connector.update_mailbox(
+                account="Gmail", name="[Gmail]/Drafts", new_name="MyDrafts",
+            )
+        mock_run.assert_not_called()
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_bare_gmail_parent_source_also_refused(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """The bare ``[Gmail]`` parent (a \\Noselect folder) is also refused."""
+        from apple_mail_mcp.exceptions import (
+            MailUnsupportedGmailSystemLabelError,
+        )
+        with pytest.raises(MailUnsupportedGmailSystemLabelError):
+            connector.update_mailbox(
+                account="Gmail", name="[Gmail]", new_name="Whatever",
+            )
+        mock_run.assert_not_called()
+
 
 class TestUpdateMailboxMove:
     """IMAP-dispatched move path of update_mailbox (#163)."""
@@ -3976,6 +4006,78 @@ class TestUpdateMailboxMove:
             connector.update_mailbox(
                 account="Gmail", name="X", new_parent="Y"
             )
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_gmail_system_label_source_refused_before_imap_session(
+        self,
+        mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """Move source ``[Gmail]/Sent Mail`` raises before the IMAP
+        credential lookup runs (#164)."""
+        from apple_mail_mcp.exceptions import (
+            MailUnsupportedGmailSystemLabelError,
+        )
+        with pytest.raises(MailUnsupportedGmailSystemLabelError):
+            connector.update_mailbox(
+                account="Gmail", name="[Gmail]/Sent Mail", new_parent="Archive",
+            )
+        # No IMAP session opened, no credentials looked up.
+        mock_cfg.assert_not_called()
+        mock_pw.assert_not_called()
+        mock_imap_cls.assert_not_called()
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_gmail_system_label_destination_parent_refused(
+        self,
+        mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """Moving a regular folder INTO ``[Gmail]/Subfolder`` is also
+        refused — the resulting destination would land in Gmail's
+        system-label namespace (#164)."""
+        from apple_mail_mcp.exceptions import (
+            MailUnsupportedGmailSystemLabelError,
+        )
+        with pytest.raises(MailUnsupportedGmailSystemLabelError):
+            connector.update_mailbox(
+                account="Gmail", name="Archive",
+                new_parent="[Gmail]/Subfolder",
+            )
+        mock_cfg.assert_not_called()
+        mock_pw.assert_not_called()
+        mock_imap_cls.assert_not_called()
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_bare_gmail_parent_destination_refused(
+        self,
+        mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """``new_parent="[Gmail]"`` produces a destination of
+        ``[Gmail]/<leaf>`` — also a system-label path; refused (#164)."""
+        from apple_mail_mcp.exceptions import (
+            MailUnsupportedGmailSystemLabelError,
+        )
+        with pytest.raises(MailUnsupportedGmailSystemLabelError):
+            connector.update_mailbox(
+                account="Gmail", name="Archive", new_parent="[Gmail]",
+            )
+        mock_cfg.assert_not_called()
+        mock_pw.assert_not_called()
+        mock_imap_cls.assert_not_called()
 
 
 class TestDeleteMailbox:
@@ -4093,3 +4195,44 @@ class TestDeleteMailbox:
         mock_pw.side_effect = MailKeychainEntryNotFoundError("nope")
         with pytest.raises(MailImapRequiredError):
             connector.delete_mailbox(account="Gmail", name="X")
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_gmail_system_label_refused_before_credential_lookup(
+        self,
+        mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """Pre-flight: deleting ``[Gmail]/Trash`` raises before the IMAP
+        credential lookup runs (#164)."""
+        from apple_mail_mcp.exceptions import (
+            MailUnsupportedGmailSystemLabelError,
+        )
+        with pytest.raises(MailUnsupportedGmailSystemLabelError):
+            connector.delete_mailbox(account="Gmail", name="[Gmail]/Trash")
+        mock_cfg.assert_not_called()
+        mock_pw.assert_not_called()
+        mock_imap_cls.assert_not_called()
+
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password")
+    @patch.object(AppleMailConnector, "_resolve_imap_config")
+    def test_bare_gmail_parent_refused(
+        self,
+        mock_cfg: MagicMock,
+        mock_pw: MagicMock,
+        mock_imap_cls: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """The bare ``[Gmail]`` parent is also refused (#164)."""
+        from apple_mail_mcp.exceptions import (
+            MailUnsupportedGmailSystemLabelError,
+        )
+        with pytest.raises(MailUnsupportedGmailSystemLabelError):
+            connector.delete_mailbox(account="Gmail", name="[Gmail]")
+        mock_cfg.assert_not_called()
+        mock_pw.assert_not_called()
+        mock_imap_cls.assert_not_called()

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1852,6 +1852,47 @@ class TestUpdateMailboxTool:
         result = update_mailbox(account="Gmail", name="Old", new_name="New")
         assert result["error_type"] == "unknown"
 
+    def test_gmail_system_label_maps_to_typed_error(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """#164: source path under ``[Gmail]/`` returns
+        ``error_type: "unsupported_gmail_system_label"``."""
+        from apple_mail_mcp.exceptions import (
+            MailUnsupportedGmailSystemLabelError,
+        )
+        from apple_mail_mcp.server import update_mailbox
+
+        mock_mail.update_mailbox.side_effect = (
+            MailUnsupportedGmailSystemLabelError(
+                "cannot update Gmail system label '[Gmail]/Drafts'"
+            )
+        )
+        result = update_mailbox(
+            account="Gmail", name="[Gmail]/Drafts", new_name="MyDrafts",
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "unsupported_gmail_system_label"
+        assert "Gmail" in result["error"]
+
+    def test_gmail_system_label_destination_maps_to_typed_error(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """#164: destination under ``[Gmail]/`` (via new_parent) maps too."""
+        from apple_mail_mcp.exceptions import (
+            MailUnsupportedGmailSystemLabelError,
+        )
+        from apple_mail_mcp.server import update_mailbox
+
+        mock_mail.update_mailbox.side_effect = (
+            MailUnsupportedGmailSystemLabelError(
+                "destination would land in Gmail's system-label namespace"
+            )
+        )
+        result = update_mailbox(
+            account="Gmail", name="Archive", new_parent="[Gmail]/Backup",
+        )
+        assert result["error_type"] == "unsupported_gmail_system_label"
+
 
 class TestDeleteMailboxTool:
     """Tests for the delete_mailbox MCP tool (#162, IMAP-dispatched)."""
@@ -2005,6 +2046,32 @@ class TestDeleteMailboxTool:
             account="Gmail", name="X", ctx=mock_ctx_accept
         )
         assert result["error_type"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_gmail_system_label_maps_to_typed_error(
+        self,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        """#164: deleting a ``[Gmail]/`` path returns
+        ``error_type: "unsupported_gmail_system_label"``."""
+        from apple_mail_mcp.exceptions import (
+            MailUnsupportedGmailSystemLabelError,
+        )
+        from apple_mail_mcp.server import delete_mailbox
+
+        mock_mail.delete_mailbox.side_effect = (
+            MailUnsupportedGmailSystemLabelError(
+                "cannot delete Gmail system label '[Gmail]/Trash'"
+            )
+        )
+        result = await delete_mailbox(
+            account="Gmail", name="[Gmail]/Trash", ctx=mock_ctx_accept,
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "unsupported_gmail_system_label"
+        assert "Gmail" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,6 +10,7 @@ from apple_mail_mcp.utils import (
     escape_applescript_string,
     format_applescript_list,
     is_account_uuid,
+    is_gmail_system_label,
     normalize_subject,
     parse_applescript_json,
     parse_applescript_list,
@@ -368,3 +369,39 @@ class TestAppleScriptAccountClause:
             "dc5ac137-2f7a-4299-b3d0-4d3e06c18dd5"
         )
         assert result == 'account id "dc5ac137-2f7a-4299-b3d0-4d3e06c18dd5"'
+
+
+class TestIsGmailSystemLabel:
+    """Tests for is_gmail_system_label — used by update_mailbox /
+    delete_mailbox to refuse operations on Gmail's IMAP-system labels."""
+
+    def test_bare_gmail_parent_is_system_label(self) -> None:
+        assert is_gmail_system_label("[Gmail]") is True
+
+    def test_gmail_drafts_is_system_label(self) -> None:
+        assert is_gmail_system_label("[Gmail]/Drafts") is True
+
+    def test_gmail_sent_mail_is_system_label(self) -> None:
+        assert is_gmail_system_label("[Gmail]/Sent Mail") is True
+
+    def test_gmail_all_mail_is_system_label(self) -> None:
+        assert is_gmail_system_label("[Gmail]/All Mail") is True
+
+    def test_localized_google_mail_prefix_is_not_detected(self) -> None:
+        # Italian Gmail; explicit defer per #164 follow-up notes.
+        assert is_gmail_system_label("[Google Mail]/Tutta la posta") is False
+
+    def test_user_folder_is_not_system_label(self) -> None:
+        assert is_gmail_system_label("Newsletters") is False
+
+    def test_word_gmail_without_brackets_is_not_system_label(self) -> None:
+        assert is_gmail_system_label("Gmail") is False
+
+    def test_empty_string_is_not_system_label(self) -> None:
+        assert is_gmail_system_label("") is False
+
+    def test_gmail_substring_in_middle_of_path_is_not_system_label(
+        self,
+    ) -> None:
+        # Path traversal/spoof attempt: only the exact prefix counts.
+        assert is_gmail_system_label("Archive/[Gmail]/Drafts") is False


### PR DESCRIPTION
## Summary

- Pre-flight refusal: `update_mailbox` / `delete_mailbox` raise `MailUnsupportedGmailSystemLabelError` (mapped to `error_type: \"unsupported_gmail_system_label\"`) when the target path is the bare `[Gmail]` parent or any `[Gmail]/...` child — no AppleScript or IMAP session opened.
- For `update_mailbox`, **both** the source `name` and the resulting destination (`new_parent` join) are checked, so moving a regular folder into Gmail's system namespace is also refused.
- New pure helper `is_gmail_system_label` in `utils.py`; new typed exception in `exceptions.py`. Localized Gmail prefixes (e.g. `[Google Mail]/`) are intentionally not detected — needs IMAP-session SPECIAL-USE enumeration; will file a follow-up.

Closes #164.

## Test plan
- [x] `make lint` — clean
- [x] `make typecheck` — clean (mypy strict)
- [x] `make test` — 889 passed (was 867; +22 new tests across exceptions / utils / connector / server)
- [x] `make coverage` — 90.43% (gate: 90%); `exceptions.py` 100%, `utils.py` 95%
- [x] `make check-all` — full gate green (complexity, version-sync, parity)
- [ ] Manual MCP-tool sanity once merged: `delete_mailbox(name=\"[Gmail]/Drafts\")`, `update_mailbox(name=\"[Gmail]/Sent Mail\", new_name=\"X\")`, `update_mailbox(name=\"Archive\", new_parent=\"[Gmail]\")` → all return the typed refusal; `update_mailbox(name=\"Archive\", new_parent=\"Backups\")` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)