### PR TITLE
fix(#177): use --notes-file in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,20 +25,21 @@ jobs:
         id: changelog
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          # Extract section between ## [VERSION] and next ## [
-          NOTES=$(awk "/^## \[$VERSION\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
-          if [ -z "$NOTES" ]; then
-            NOTES="Release $VERSION"
+          # Extract section between ## [VERSION] and next ## [ to a workspace
+          # file. Writing to a file (vs a step output consumed by --notes)
+          # avoids shell-interpolating CHANGELOG content — backticks in
+          # markdown code spans like `update_message` would otherwise be
+          # parsed as command substitution by bash on the next step. (#177)
+          awk "/^## \[$VERSION\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "Release $VERSION" > release-notes.md
           fi
-          echo "notes<<EOF" >> $GITHUB_OUTPUT
-          echo "$NOTES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         run: |
           gh release create "$GITHUB_REF_NAME" \
             --title "Release $GITHUB_REF_NAME" \
-            --notes "${{ steps.changelog.outputs.notes }}"
+            --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary

- Switch the release workflow from `--notes "${{ steps.changelog.outputs.notes }}"` to `--notes-file release-notes.md`.
- `${{ ... }}` is interpolated by GitHub Actions before bash parses the line, so backticks in markdown code spans (e.g. `` `update_message` ``) become shell command substitution — bash tries to execute `update_message`, `search_messages`, etc. as commands and the step exits 127. v0.7.0 hit this; the release was patched manually.
- `--notes-file` reads file contents literally, never going through shell interpolation. Backticks (and any other metacharacter) pass through unchanged.

## Implementation notes

- Changelog step now writes `release-notes.md` in the workspace (replaces the `notes` step output). Empty-section fallback (`echo "Release $VERSION" > release-notes.md`) preserves today's behavior for tags without a CHANGELOG entry.
- The two steps share the runner workspace, so the file written in one step is readable by the next.
- Inline comment on the changelog step documents the why (so the next person doesn't "simplify" it back to `--notes`).

## Test plan

- [x] Local dry-run of the awk extraction against the current CHANGELOG.md — confirmed `[Unreleased]`, `[0.7.0]`, and `[99.99.99]` (empty-fallback) paths all produce the expected file contents.
- [x] Backticks preserved verbatim in the extracted file.
- [x] `make test` (908 unit tests) passes on the branch.
- [ ] End-to-end exercise happens on the next real release (v0.8.0 cut). The next CHANGELOG section will contain backticks (already does — see [Unreleased] block); if the workflow succeeds, the bug is fixed.

Can't pre-flight against a real `v*` tag without making a real release. The tag filter `'!v*-rc*'` excludes RC tags, so no throwaway pre-release option without temporarily widening the filter — not worth it for a 9-line YAML diff with prior art.

Closes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)