### PR TITLE
fix(#179): scope post_bash.sh CI watcher to the pushed commit

### DIFF
--- a/scripts/hooks/post_bash.sh
+++ b/scripts/hooks/post_bash.sh
@@ -17,10 +17,21 @@ if ! command -v gh &> /dev/null; then
     exit 0
 fi
 
+# Resolve the SHA that was just pushed so the run lookup below can be
+# scoped to it. Without this, `gh run list --limit 1` would return the
+# most recent run repo-wide — potentially an unrelated run on another
+# branch — and the hook would misreport its status as the result of
+# this push. (#179)
+PUSHED_SHA=$(git rev-parse HEAD 2>/dev/null)
+if [ -z "$PUSHED_SHA" ]; then
+    echo "Could not resolve pushed commit SHA; skipping CI watch." >&2
+    exit 0
+fi
+
 echo "Git push detected. Waiting for CI to start..." >&2
 sleep 10
 
-RUN_ID=$(gh run list --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null)
+RUN_ID=$(gh run list --commit "$PUSHED_SHA" --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null)
 
 if [ -n "$RUN_ID" ]; then
     echo "Watching CI run #$RUN_ID..." >&2
@@ -35,7 +46,7 @@ if [ -n "$RUN_ID" ]; then
     fi
     echo "CI passed." >&2
 else
-    echo "No CI run found. Check manually." >&2
+    echo "No CI run found for $PUSHED_SHA (workflows may not fire on branch pushes; check after opening the PR)." >&2
 fi
 
 exit 0


### PR DESCRIPTION
## Summary

- `scripts/hooks/post_bash.sh` previously called `gh run list --limit 1` after a successful `git push` — globally scoped, ignoring which commit was just pushed.
- When the push didn't trigger any workflow (this repo's workflows fire on `pull_request`, not branch push), the hook silently latched onto whatever the most recent unrelated repo-wide run happened to be and reported its exit status as the result of the current push.
- Now resolve the just-pushed SHA via `git rev-parse HEAD` and pass it as `gh run list --commit "$PUSHED_SHA"`. False positives become impossible; "no CI run found" is now a normal outcome with a message that points the user to check after opening the PR.

## Why this matters

Hit twice in this session before the fix:
- After pushing the #149 branch, the hook surfaced the failed v0.7.0 release run from 17 hours earlier and emitted a fake "CI failed" system reminder. Convincing enough that the only way to disprove it was to re-query `gh run list` directly.
- After pushing the #177 branch, the hook was quiet — but only because the latest repo-wide run had happened to pass. Same bug, opposite sign.

## Implementation notes

- `git rev-parse HEAD` covers the common case (push the current branch; HEAD is the tip that went up). Edge cases (`git push origin some-branch:some-branch`, tag pushes where HEAD isn't on the tag's commit) gracefully degrade to "no CI run found" — false negative, not false positive. False negatives are visible (user opens the Actions tab); false positives mid-LLM-conversation are not.
- Comment block explains the bug so the next reader doesn't "simplify" it back.

## Test plan

- [x] Verified `gh run list --commit SHA` is a documented flag and returns empty for SHAs with no associated runs.
- [x] Synthetic-input smoke test against the fixed hook: piped a fake push event in, hook resolved HEAD, scoped lookup found the run from PR #180's merge, reported "CI passed" correctly.
- [x] Self-test: pushing this branch with the fixed hook in place — no fake "CI failed" notification fired (this branch has no PR yet, so no workflow was triggered, and the hook correctly fell through to "no run found" cleanly).
- [x] `make test` (908 unit tests) passes on the branch.

Closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)