### PR TITLE
fix(#173): wrap sender clause in sanitize_input + escape_applescript_string

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -3151,11 +3151,16 @@ class AppleMailConnector:
             else None
         )
 
-        # Sender clause.
+        # Sender clause. Apply the SECURITY_CHECKLIST two-step idiom
+        # (sanitize_input then escape_applescript_string) even though the
+        # resolver pulls from Mail.app's own account list — the convention
+        # exists so we don't have to risk-assess each site individually,
+        # and the Display-Name <email> form from #158 broadened what
+        # characters can appear here. (#173)
         sender_clause = ""
         if from_account is not None:
             sender_email = self._resolve_account_to_sender(from_account)
-            sender_safe = escape_applescript_string(sender_email)
+            sender_safe = escape_applescript_string(sanitize_input(sender_email))
             sender_clause = f'set sender of theMessage to "{sender_safe}"'
 
         # Recipient blocks: AppleScript fragments that, when included,

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -3844,6 +3844,32 @@ class TestCreateDraft:
         assert 'set sender of theMessage to "me@x.com"' in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
+    def test_new_with_from_account_sanitizes_sender_null_bytes(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """#173: sender string is run through sanitize_input before
+        escape_applescript_string, so embedded null bytes (which would
+        otherwise truncate or confuse the AppleScript at runtime) are
+        stripped per the SECURITY_CHECKLIST two-step convention."""
+        mock_run.return_value = "1"
+        with patch.object(
+            connector, "_resolve_account_to_sender",
+            return_value="Alice\x00Smith <me@x.com>",
+        ):
+            connector.create_draft(
+                seed="new",
+                to=["a@example.com"],
+                subject="hi",
+                body="x",
+                from_account="Gmail",
+            )
+        script = mock_run.call_args[0][0]
+        assert "\x00" not in script
+        assert (
+            'set sender of theMessage to "AliceSmith <me@x.com>"' in script
+        )
+
+    @patch.object(AppleMailConnector, "_run_applescript")
     def test_new_with_attachments_includes_paths(
         self, mock_run: MagicMock, connector: AppleMailConnector, tmp_path: Any
     ) -> None:


### PR DESCRIPTION
## Summary

- The `from_account` sender clause in `create_draft` / `update_draft` was missing the `sanitize_input` step before `escape_applescript_string`. Per the [SECURITY_CHECKLIST](docs/guides/SECURITY_CHECKLIST.md), both are required at every AppleScript-interpolation site.
- Applied the standard two-step idiom at the call site (not in `_resolve_account_to_sender` itself — that's the wrong layer; the resolver returns a logical sender string, AppleScript concerns belong at the boundary).
- Added a regression test that mocks the resolver to return a sender containing a null byte; asserts the byte is stripped before reaching the script.

## Risk assessment

Low practical risk — `_resolve_account_to_sender` pulls from Mail.app's own account list, not direct user input. But the convention exists precisely so we don't have to risk-assess each interpolation site individually. The `"Display Name <email>"` format from #158 broadened what characters can appear in the sender string, making the convention more relevant than it was pre-#158.

## Test plan

- [x] New `test_new_with_from_account_sanitizes_sender_null_bytes` reproduces the bug (red before fix, green after).
- [x] Existing `test_new_with_from_account_sets_display_name_sender` and `test_new_with_from_account_bare_email_passthrough` still pass — `sanitize_input` is a no-op on their clean inputs.
- [x] `make check-all` passes: lint, mypy strict, 909 unit tests, complexity gate, version sync, parity.

Closes #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)