### PR TITLE
fix(#185): correct flag_color → flag_index map (orange↔red, blue↔green swap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**Flag color labels in `update_message(flag_color=...)` (#185):** The map from color name to AppleScript flag index in [`utils.py:get_flag_index`](src/apple_mail_mcp/utils.py) had two pairs of swapped labels. Empirical testing (Gmail/Mail.app, 2026-05-12) confirmed that callers passing certain colors got a different color in Mail.app's UI than they asked for:
+
+- `flag_color="orange"` previously rendered as **red**; now renders as **orange**.
+- `flag_color="red"` previously rendered as **orange**; now renders as **red**.
+- `flag_color="blue"` previously rendered as **green**; now renders as **blue**.
+- `flag_color="green"` previously rendered as **blue**; now renders as **green**.
+- `yellow`, `purple`, `gray`, `none` were correctly labeled and unchanged.
+
+The AppleScript-path default for `update_message(flagged=True)` (no `flag_color`) was also adjusted from `get_flag_index('orange')` to `get_flag_index('red')` so the no-color rendering remains red (matching #152's IMAP fast path which sets bare `\Flagged`). Net behavior: `update_message(flagged=True)` still produces a red flag, regardless of which path runs.
+
+Callers who were relying on the buggy mapping should update their calls to use the color name they actually want.
+
 ### Performance
 
 **IMAP fast path for flag-only `update_message` (#152):** When `update_message` is called with only `flagged` set (no `flag_color`, `read_status`, or `destination_mailbox`) plus `account` + `source_mailbox`, the flag/unflag mutation now runs server-side via IMAP `UID STORE +/-FLAGS (\Flagged)` — single round-trip after Message-ID resolution. `\Flagged` is base IMAP (RFC 3501), universal across all servers; no capability check, no fallback variants. Verified empirically (Gmail/Mail.app, 2026-05-12) that bare `\Flagged` produces identical visual state to today's AppleScript path's `set flag index = 0` — no UI difference. Color-specifying calls (`flag_color="red"` etc.) still route through AppleScript since Mail.app's color encoding (`$MailFlagBit*` user keywords) is out of IMAP scope. **This closes the IMAP-fast-paths-for-mutations arc** (#149 move, #150 delete, #151 read, #152 flag) — every single-field mutation on `update_message` and `delete_messages` now has an IMAP path on the common path.

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -301,7 +301,7 @@ Patch one or more messages: change read state, flag color, and/or move to anothe
 |-----------|------|----------|---------|-------------|
 | `message_ids` | list[string] | Yes | - | Up to 100 message IDs to update |
 | `read_status` | boolean \| null | No | null | `True` marks read, `False` marks unread, `null` leaves unchanged |
-| `flagged` | boolean \| null | No | null | `True` flags (orange if no `flag_color` given), `False` clears, `null` leaves unchanged |
+| `flagged` | boolean \| null | No | null | `True` flags (red if no `flag_color` given — Mail.app's default flag color), `False` clears, `null` leaves unchanged |
 | `flag_color` | string \| null | No | null | One of `orange`, `red`, `yellow`, `blue`, `green`, `purple`, `gray`, `none`. `"none"` clears the flag. Implies `flagged=True` for non-`none` values. |
 | `destination_mailbox` | string \| null | No | null | Target mailbox name to move to. Requires `account`. |
 | `account` | string \| null | No | null | Account name (required when `destination_mailbox` is set; also unlocks the IMAP narrow-path optimization) |

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -2546,8 +2546,9 @@ class AppleMailConnector:
             message_ids: List of message ids to update.
             read_status: When set, mark as read (True) / unread (False).
             flagged: When set, set flag presence. ``True`` without
-                ``flag_color`` defaults to orange. ``False`` clears the
-                flag.
+                ``flag_color`` defaults to red (Mail.app's default flag
+                color, matching the IMAP fast path's bare ``\\Flagged``
+                rendering). ``False`` clears the flag.
             flag_color: Color name (orange, red, yellow, blue, green,
                 purple, gray, none). Implies ``flagged=True`` unless
                 "none". Validated.
@@ -2658,8 +2659,11 @@ class AppleMailConnector:
             flagged_status = "true" if flag_color != "none" else "false"
             actions.append(f"set flagged status of msg to {flagged_status}")
         elif flagged is True:
-            # No color → default orange (matches existing flag_message default).
-            actions.append(f"set flag index of msg to {get_flag_index('orange')}")
+            # No color → default red. flag index 0 (red) sets bare \\Flagged
+            # on the IMAP server with no $MailFlagBit* keyword — same state
+            # the #152 IMAP fast path produces, ensuring path-independent
+            # rendering in Mail.app.
+            actions.append(f"set flag index of msg to {get_flag_index('red')}")
             actions.append("set flagged status of msg to true")
 
         # Move (always last — IMAP STORE requires source folder).

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -1028,7 +1028,7 @@ def update_message(
         message_ids: List of message IDs to update.
         read_status: True to mark as read, False to mark as unread,
             None to leave unchanged.
-        flagged: True to flag (default orange if no `flag_color` set),
+        flagged: True to flag (default red if no `flag_color` set),
             False to clear the flag, None to leave unchanged.
         flag_color: Color name (orange, red, yellow, blue, green,
             purple, gray, none). Implies `flagged=True` unless "none".

--- a/src/apple_mail_mcp/utils.py
+++ b/src/apple_mail_mcp/utils.py
@@ -316,17 +316,21 @@ def get_flag_index(color: str) -> int:
 
     Example:
         >>> get_flag_index("red")
-        1
+        0
         >>> get_flag_index("none")
         -1
     """
+    # Mapping verified empirically against Mail.app's rendering
+    # (Gmail/Mail.app, 2026-05-12 — see #185). The codebase previously
+    # had orange↔red and blue↔green swapped, so callers asking for
+    # "orange" got red, "red" got orange, etc.
     color_map = {
         "none": -1,
-        "orange": 0,
-        "red": 1,
+        "red": 0,
+        "orange": 1,
         "yellow": 2,
-        "blue": 3,
-        "green": 4,
+        "green": 3,
+        "blue": 4,
         "purple": 5,
         "gray": 6,
     }

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -9,6 +9,7 @@ from apple_mail_mcp.utils import (
     applescript_account_clause,
     escape_applescript_string,
     format_applescript_list,
+    get_flag_index,
     is_account_uuid,
     is_gmail_system_label,
     normalize_subject,
@@ -405,3 +406,35 @@ class TestIsGmailSystemLabel:
     ) -> None:
         # Path traversal/spoof attempt: only the exact prefix counts.
         assert is_gmail_system_label("Archive/[Gmail]/Drafts") is False
+
+
+class TestGetFlagIndex:
+    """Issue #185: lock in the empirically-verified color → flag index
+    mapping. Originally the codebase had orange↔red and blue↔green swapped
+    relative to what Mail.app actually rendered (verified Gmail/Mail.app
+    2026-05-12). No tests existed on get_flag_index before this fix —
+    that is how the bug went undetected."""
+
+    @pytest.mark.parametrize("color,expected_index", [
+        ("none", -1),
+        ("red", 0),
+        ("orange", 1),
+        ("yellow", 2),
+        ("green", 3),
+        ("blue", 4),
+        ("purple", 5),
+        ("gray", 6),
+    ])
+    def test_returns_correct_index_for_each_color(
+        self, color: str, expected_index: int
+    ) -> None:
+        assert get_flag_index(color) == expected_index
+
+    def test_raises_on_unknown_color(self) -> None:
+        with pytest.raises(ValueError, match="Invalid flag color"):
+            get_flag_index("magenta")
+
+    def test_case_insensitive(self) -> None:
+        assert get_flag_index("RED") == 0
+        assert get_flag_index("Red") == 0
+        assert get_flag_index("oRaNgE") == 1


### PR DESCRIPTION
## Summary

- [`get_flag_index`](src/apple_mail_mcp/utils.py) had two pairs of swapped labels relative to Mail.app's actual rendering. Callers asking for `flag_color="orange"` got red; asking for `"red"` got orange; `"blue"` got green; `"green"` got blue. (Yellow, purple, gray, none were correct.)
- Fixed the map and locked the corrected indices in with new `TestGetFlagIndex` parametrized tests.
- Adjusted the AppleScript no-color default from `get_flag_index('orange')` to `get_flag_index('red')` so `update_message(flagged=True)` continues to produce a red flag — matches #152's IMAP fast path (bare `\Flagged`).
- Updated docstrings in `mail_connector.py` + `server.py` + the `update_message` parameter row in `TOOLS.md` from "default orange" to "default red".

## Empirical evidence

Captured during #152's design discussion (screenshot: 7 messages, each with `set flag index of msg to N` via AppleScript, where N = 0..6, observed in Mail.app's UI). Server-side `\$MailFlagBit*` keyword pattern confirmed the bit-positional encoding. Bug went undetected because no tests on `get_flag_index` existed.

## Behavior change for callers

Anyone passing the four affected color names will get a different visual outcome:

| `flag_color=` | Before | After |
|---|---|---|
| `"orange"` | red flag | orange flag |
| `"red"` | orange flag | red flag |
| `"blue"` | green flag | blue flag |
| `"green"` | blue flag | green flag |
| `"yellow"` / `"purple"` / `"gray"` / `"none"` | unchanged | unchanged |
| `flagged=True` (no color) | red flag | red flag (preserved via the default-default flip) |

The labels were always wrong — this is the fix. Callers depending on the buggy mapping should update to use the color name they actually want.

## Test plan

- [x] New `TestGetFlagIndex` with parametrized assertions for all 8 mappings + raise-on-unknown + case-insensitive.
- [x] Red → green transition confirmed (4 parametrized cases + case-insensitive failed before the map fix, passed after).
- [x] No existing test asserts specific `flag index` values, so no regression in `update_message` / `flag_message` tests.
- [x] `make check-all` passes: lint, mypy strict, all unit tests, complexity gate, version sync, parity.

Closes #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)