### PR TITLE
refactor(#148): dual-emit rfc_message_id alongside id on read-tool rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+**Dual-emit `rfc_message_id` field on read-tool rows (#148):** Every row returned by `search_messages`, `get_messages`, and `get_thread` now carries an additional `rfc_message_id: str | null` field alongside the existing `id` field. The `id` field is still path-native (Mail.app internal numeric on the AppleScript path, RFC 5322 Message-ID on the IMAP path); `rfc_message_id` is always RFC 5322 (bracketless), or `null` when the message lacks a Message-ID header (drafts, malformed mail). Closes the loop on #147's original motivation: callers whose read happened to fall back to AppleScript (returning an internal numeric `id`) can now feed `rfc_message_id` to the IMAP fast paths from #149 / #150 / #151 / #152, triggering them automatically without having to know which path produced the row. AppleScript-path cost is sub-second per mailbox (per-row direct property read, confirmed in #147's bench); IMAP-path cost is zero (already extracted for `id`). `get_thread` previously emitted `rfc_message_id` to its tell script for graph-walking but stripped it before returning; now keeps it.
+
 ### Fixed
 
 **Flag color labels in `update_message(flag_color=...)` (#185):** The map from color name to AppleScript flag index in [`utils.py:get_flag_index`](src/apple_mail_mcp/utils.py) had two pairs of swapped labels. Empirical testing (Gmail/Mail.app, 2026-05-12) confirmed that callers passing certain colors got a different color in Mail.app's UI than they asked for:

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -72,6 +72,7 @@ When the call commits to the AppleScript path **and** a body/text filter is set,
   "messages": [
     {
       "id": "12345",
+      "rfc_message_id": "CABc123@example.com",
       "subject": "Meeting Tomorrow",
       "sender": "john@example.com",
       "date_received": "Mon Jan 15 2024 10:30:00",
@@ -82,6 +83,10 @@ When the call commits to the AppleScript path **and** a body/text filter is set,
   "count": 1
 }
 ```
+
+**Row fields:**
+- `id` — path-native: Mail.app internal numeric id when the AppleScript path runs, RFC 5322 Message-ID when the IMAP path runs. Fast for downstream same-path operations.
+- `rfc_message_id` — RFC 5322 Message-ID (bracketless), or `null` when the message lacks a Message-ID header. Always present, regardless of which path produced the row. Accepted by the IMAP fast paths in `update_message` / `delete_messages` (#149 / #150 / #151 / #152) — the dual-emit means cross-path consumers don't need to know which path generated their input.
 
 **Examples:**
 
@@ -158,6 +163,7 @@ For accounts configured with IMAP (via `apple-mail-mcp setup-imap --account <nam
   "messages": [
     {
       "id": "12345",
+      "rfc_message_id": "CABc123@example.com",
       "subject": "Meeting Tomorrow",
       "sender": "john@example.com",
       "date_received": "Mon Jan 15 2024 10:30:00",
@@ -169,6 +175,8 @@ For accounts configured with IMAP (via `apple-mail-mcp setup-imap --account <nam
   "count": 1
 }
 ```
+
+Row fields include both `id` (path-native — see `search_messages` for details) and `rfc_message_id` (always RFC 5322 bracketless, or `null` when the message lacks a Message-ID header). The dual-emit (#148) lets cross-path consumers hand the right id to the right tool without needing to know which path produced the row.
 
 **Examples:**
 
@@ -208,14 +216,18 @@ Return all messages in the thread containing the given anchor message, sorted by
 {
   "success": true,
   "thread": [
-    {"id": "100", "subject": "Q3 Report", "sender": "alice@x.com",
+    {"id": "100", "rfc_message_id": "anchor@x.com",
+     "subject": "Q3 Report", "sender": "alice@x.com",
      "date_received": "Mon Jan 1 2024 10:00:00", "read_status": true, "flagged": false},
-    {"id": "101", "subject": "Re: Q3 Report", "sender": "bob@x.com",
+    {"id": "101", "rfc_message_id": "reply1@x.com",
+     "subject": "Re: Q3 Report", "sender": "bob@x.com",
      "date_received": "Mon Jan 1 2024 14:30:00", "read_status": true, "flagged": false}
   ],
   "count": 2
 }
 ```
+
+Row fields include both `id` (path-native — see `search_messages` for details) and `rfc_message_id` (always RFC 5322 bracketless, or `null` when the message lacks a Message-ID header). See `search_messages` for the dual-emit (#148) rationale.
 
 Uses the connector's tiered IMAP threading dispatch (Tier 1 X-GM-THRID for Gmail per #122, Tier 3 header-search BFS fallback) when IMAP is configured; falls back to AppleScript otherwise.
 

--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -475,8 +475,16 @@ def _envelope_to_dict(
         date_str = date.isoformat()
     else:
         date_str = _decode(date)
+    # On the IMAP path, `id` and `rfc_message_id` are intentionally the
+    # same value — both are the RFC 5322 Message-ID (bracketless). The
+    # dual-emit (#148) lets cross-path consumers (e.g., callers feeding
+    # this row to an AppleScript-only tool) always have an RFC id
+    # available; on the AppleScript path the two diverge (`id` is the
+    # Mail.app internal numeric id, `rfc_message_id` is the RFC form).
+    rfc_id = _strip_brackets(_decode(envelope.message_id))
     return {
-        "id": _strip_brackets(_decode(envelope.message_id)),
+        "id": rfc_id,
+        "rfc_message_id": rfc_id,
         "subject": _decode(envelope.subject),
         "sender": _format_sender(envelope),
         "date_received": date_str,

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -1348,7 +1348,7 @@ class AppleMailConnector:
                 set includeThis to true
                 {filter_block}
                 if includeThis then{attachments_clause}
-                    set msgRecord to {{|id|:(id of msg as text), |subject|:(subject of msg), |sender|:(sender of msg), |date_received|:(date received of msg as text), |read_status|:(read status of msg), |flagged|:(flagged status of msg){attachments_field}}}
+                    set msgRecord to {{|id|:(id of msg as text), |rfc_message_id|:(message id of msg), |subject|:(subject of msg), |sender|:(sender of msg), |date_received|:(date received of msg as text), |read_status|:(read status of msg), |flagged|:(flagged status of msg){attachments_field}}}
                     set end of resultData to msgRecord
                     set matchCount to matchCount + 1
                 end if
@@ -1498,7 +1498,7 @@ class AppleMailConnector:
                         set msg to first message of mb whose id is "{message_id_safe}"
                         {content_clause}
 {attachments_clause}
-                        set resultData to {{|id|:(id of msg as text), |subject|:(subject of msg), |sender|:(sender of msg), |date_received|:(date received of msg as text), |read_status|:(read status of msg), |flagged|:(flagged status of msg), |content|:msgContent{attachments_field}}}
+                        set resultData to {{|id|:(id of msg as text), |rfc_message_id|:(message id of msg), |subject|:(subject of msg), |sender|:(sender of msg), |date_received|:(date received of msg as text), |read_status|:(read status of msg), |flagged|:(flagged status of msg), |content|:msgContent{attachments_field}}}
                         exit repeat
                     end try
                 end repeat
@@ -2278,6 +2278,9 @@ class AppleMailConnector:
             )
             thread.append({
                 "id": cast(str, anchor.get("internal_id") or ""),
+                "rfc_message_id": cast(
+                    "str | None", anchor.get("rfc_message_id")
+                ),
                 "subject": anchor["subject"],
                 "sender": "",
                 "date_received": "",
@@ -2290,9 +2293,11 @@ class AppleMailConnector:
         # strings; lexicographic sort is a close-enough proxy within a thread.
         thread.sort(key=lambda m: m.get("date_received") or "")
 
-        # Drop threading internals from output rows (search-shape only).
+        # Drop threading-internal scratch fields from output rows. Per
+        # #148 we KEEP rfc_message_id alongside id (dual-emit), so
+        # callers can hand it to the IMAP fast paths from #149/#150/
+        # #151/#152 even when get_thread fell back to AppleScript.
         for m in thread:
-            m.pop("rfc_message_id", None)
             m.pop("in_reply_to", None)
             m.pop("references_raw", None)
             m.pop("references_parsed", None)

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -991,6 +991,100 @@ class TestDraftsLifecycleIntegration:
             except Exception:
                 pass
 
+    def test_search_messages_returns_rfc_message_id_via_applescript(
+        self,
+        connector: AppleMailConnector,
+        test_account: str,
+    ) -> None:
+        """#148: AppleScript search rows carry both `id` (Mail.app
+        internal numeric) and `rfc_message_id` (RFC 5322, bracketless)
+        — verified end-to-end against real Mail.app.
+
+        Cost should be sub-second per mailbox per #147's probe (the
+        `message id of msg` direct-property read is cheap)."""
+        import uuid as _uuid
+        from datetime import datetime, timezone
+        from email.utils import format_datetime
+
+        from imapclient import IMAPClient
+
+        from apple_mail_mcp.keychain import get_imap_password
+
+        suffix = _uuid.uuid4().hex[:8]
+        src = f"ZZZ-AMM-DUAL-EMIT-{suffix}"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+        bracketed = f"<{msg_id_local}>"
+
+        host, port, email = connector._resolve_imap_config(test_account)
+        pw = get_imap_password(test_account, email)
+
+        assert connector.create_mailbox(account=test_account, name=src)
+
+        try:
+            now = format_datetime(datetime.now(tz=timezone.utc))
+            raw = (
+                f"From: sender@apple-mail-mcp-test.invalid\r\n"
+                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"Subject: AMM #148 dual-emit test\r\n"
+                f"Date: {now}\r\n"
+                f"Message-ID: {bracketed}\r\n"
+                f"\r\n"
+                f"body\r\n"
+            ).encode()
+
+            append_client = IMAPClient(host, port=port, ssl=True, timeout=30)
+            append_client.login(email, pw)
+            try:
+                append_client.append(src, raw, flags=[])
+            finally:
+                append_client.logout()
+
+            # Force the AppleScript path so we exercise the dual-emit
+            # we just added (IMAP path's dual-emit is identical-id and
+            # already covered by unit tests).
+            connector._imap_failure_until[test_account] = (
+                __import__("time").monotonic() + 60
+            )
+
+            # Mail.app's IMAP sync may lag the APPEND. Poll up to ~30s.
+            import time as _time
+            for _ in range(10):
+                rows = connector.search_messages(
+                    account=test_account, mailbox=src, limit=10,
+                )
+                match = [
+                    r for r in rows
+                    if r.get("rfc_message_id") == msg_id_local
+                ]
+                if match:
+                    break
+                _time.sleep(3)
+            else:
+                raise AssertionError(
+                    "Mail.app never surfaced the APPENDed message via "
+                    "AppleScript search within 30s"
+                )
+
+            row = match[0]
+            assert "id" in row, "missing path-native `id`"
+            assert "rfc_message_id" in row, "missing dual-emit `rfc_message_id`"
+            assert row["rfc_message_id"] == msg_id_local, (
+                f"rfc_message_id wrong: {row['rfc_message_id']!r}"
+            )
+            # AppleScript path: `id` is Mail.app's internal numeric id,
+            # NOT equal to the RFC id.
+            assert row["id"] != row["rfc_message_id"], (
+                "AppleScript path should yield divergent id and "
+                "rfc_message_id; got equal values"
+            )
+        finally:
+            try:
+                connector.delete_mailbox(
+                    account=test_account, name=src, delete_messages=True
+                )
+            except Exception:
+                pass
+
     def test_update_mailbox_renames_in_place(
         self,
         connector: AppleMailConnector,

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -415,6 +415,25 @@ class TestEnvelopeTranslation:
         assert msg["id"] == "abc@example.com"
 
     @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_emits_both_id_and_rfc_message_id_dual_emit(self, mock_cls):
+        """#148: every IMAP-path row carries `rfc_message_id` alongside
+        `id`. On this path the two are intentionally identical (both
+        are the RFC 5322 Message-ID, bracketless)."""
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.search.return_value = [1]
+        mock_client.fetch.return_value = {
+            1: {
+                b"ENVELOPE": _fake_envelope(message_id=b"<dual@example.com>"),
+                b"FLAGS": (),
+            }
+        }
+        [msg] = ImapConnector("h", 993, "u@e.com", "pw").search_messages()
+        assert msg["id"] == "dual@example.com"
+        assert msg["rfc_message_id"] == "dual@example.com"
+        assert msg["id"] == msg["rfc_message_id"]
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
     def test_empty_sender_returns_empty_string(self, mock_cls):
         mock_client = MagicMock()
         mock_cls.return_value = mock_client

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -4036,17 +4036,21 @@ class TestAppleMailConnector:
         result = connector._get_thread_applescript("100")
         assert len(result) == 3
         assert [m["id"] for m in result] == ["100", "101", "102"]
-        # Response rows match search_messages shape (6 fields).
+        # Response rows match search_messages shape (7 fields including
+        # the dual-emit rfc_message_id from #148).
         for m in result:
             assert set(m.keys()) == {
-                "id", "subject", "sender", "date_received", "read_status", "flagged",
+                "id", "rfc_message_id", "subject", "sender",
+                "date_received", "read_status", "flagged",
             }
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_get_thread_drops_threading_internals_from_output(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """Response rows must NOT leak rfc_message_id / in_reply_to / references_raw."""
+        """Response rows must NOT leak in_reply_to / references_raw /
+        references_parsed (threading-internal scratch fields). They
+        DO carry rfc_message_id alongside id (dual-emit from #148)."""
         mock_run.side_effect = [
             '{"account":"Gmail","rfc_message_id":"<anchor@x>",'
             '"subject":"Q3","in_reply_to":"","references_raw":""}',
@@ -4056,7 +4060,7 @@ class TestAppleMailConnector:
         ]
         result = connector._get_thread_applescript("100")
         for m in result:
-            assert "rfc_message_id" not in m
+            assert "rfc_message_id" in m
             assert "in_reply_to" not in m
             assert "references_raw" not in m
             assert "references_parsed" not in m
@@ -4093,6 +4097,112 @@ class TestAppleMailConnector:
         # Base subject strips all Re: prefixes.
         assert 'subject contains "Q3 Report"' in candidate_script
         assert 'subject contains "Re:' not in candidate_script
+
+
+class TestDualEmitRfcMessageId:
+    """#148: every read-tool row carries an `rfc_message_id` field
+    alongside the existing `id` field. On the AppleScript path, `id`
+    is Mail.app's internal numeric id and `rfc_message_id` is the
+    RFC 5322 Message-ID. Missing-Message-ID cases serialize as None.
+
+    Cross-path consumers (e.g., callers feeding an AppleScript-path
+    row to one of the IMAP fast paths from #149/#150/#151/#152) can
+    use `rfc_message_id` regardless of which path produced the row."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_applescript_emits_rfc_message_id_in_script(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """The emitted AppleScript record includes the
+        `|rfc_message_id|:(message id of msg)` field."""
+        mock_run.return_value = "[]"
+        connector._search_messages_applescript("Gmail", "INBOX", limit=10)
+        script = mock_run.call_args[0][0]
+        assert "|rfc_message_id|:(message id of msg)" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_applescript_includes_rfc_message_id_in_rows(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """The parsed result rows carry `rfc_message_id`."""
+        mock_run.return_value = (
+            '[{"id": "100", "rfc_message_id": "rfc-100@example.com",'
+            '"subject": "Hi", "sender": "a@x", "date_received": "Mon",'
+            '"read_status": false, "flagged": false}]'
+        )
+        result = connector._search_messages_applescript("Gmail", "INBOX")
+        assert result[0]["id"] == "100"
+        assert result[0]["rfc_message_id"] == "rfc-100@example.com"
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_message_applescript_emits_rfc_message_id_in_script(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """The emitted AppleScript record for get_message also
+        includes the dual-emit field."""
+        mock_run.return_value = (
+            '{"id": "100", "rfc_message_id": "rfc-100@example.com",'
+            '"subject": "Hi", "sender": "a@x", "date_received": "Mon",'
+            '"read_status": false, "flagged": false, "content": ""}'
+        )
+        connector._get_message_applescript("100", include_content=True)
+        script = mock_run.call_args[0][0]
+        assert "|rfc_message_id|:(message id of msg)" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_message_applescript_includes_rfc_message_id_in_row(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = (
+            '{"id": "100", "rfc_message_id": "rfc-100@example.com",'
+            '"subject": "Hi", "sender": "a@x", "date_received": "Mon",'
+            '"read_status": false, "flagged": false, "content": "body"}'
+        )
+        result = connector._get_message_applescript("100", include_content=True)
+        assert result["rfc_message_id"] == "rfc-100@example.com"
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_missing_message_id_serializes_as_none(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """A message without a Message-ID header (drafts, malformed
+        mail) yields `rfc_message_id: null` from AppleScript →
+        `None` in the Python row. Mocked here at the parsed-JSON
+        layer; the AppleScript-side missing-value coercion is handled
+        by NSJSONSerialization in `_wrap_as_json_script`."""
+        mock_run.return_value = (
+            '[{"id": "200", "rfc_message_id": null,'
+            '"subject": "draft", "sender": "", "date_received": "Tue",'
+            '"read_status": false, "flagged": false}]'
+        )
+        result = connector._search_messages_applescript("Gmail", "INBOX")
+        assert result[0]["rfc_message_id"] is None
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_thread_applescript_preserves_rfc_message_id_in_output(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """get_thread now KEEPS rfc_message_id in output rows
+        (previously stripped). Threading-internal scratch fields
+        (in_reply_to / references_raw / references_parsed) are still
+        dropped."""
+        mock_run.side_effect = [
+            '{"account": "Gmail", "rfc_message_id": "anchor@x",'
+            '"subject": "Q3", "in_reply_to": "", "references_raw": ""}',
+            '[{"id": "100", "rfc_message_id": "anchor@x", "in_reply_to": "",'
+            '"references_raw": "", "subject": "Q3", "sender": "a@x",'
+            '"date_received": "Mon", "read_status": false, "flagged": false}]'
+        ]
+        result = connector._get_thread_applescript("100")
+        assert len(result) == 1
+        assert result[0]["rfc_message_id"] == "anchor@x"
+        # Threading scratch fields still stripped.
+        for scratch in ("in_reply_to", "references_raw", "references_parsed"):
+            assert scratch not in result[0]
 
 
 class TestMessageIdAppleScriptInjection:


### PR DESCRIPTION
## Summary

Every row returned by `search_messages`, `get_messages`, and `get_thread` now carries an additional **`rfc_message_id: str | null`** field alongside the existing `id` field.

- `id` is still path-native: Mail.app internal numeric on the AppleScript path, RFC 5322 Message-ID on the IMAP path. Fast for downstream same-path operations.
- `rfc_message_id` is always RFC 5322 (bracketless), or `null` for messages without a Message-ID header (drafts, malformed mail). Accepted by the IMAP fast paths from #149/#150/#151/#152.

**Closes the loop on #147's original motivation:** callers whose read happened to fall back to AppleScript (returning an internal numeric `id`) can now hand `rfc_message_id` to the IMAP fast paths without having to know which path produced the row.

## Implementation notes

- **IMAP path:** [`_envelope_to_dict`](src/apple_mail_mcp/imap_connector.py) — emit `rfc_message_id` alongside `id` (intentionally identical values; `id` is already the RFC ID on this path).
- **AppleScript path — `search_messages` and `get_message`:** insert `|rfc_message_id|:(message id of msg)` into the tell scripts' record literals. Per #147's probe this property is sub-second to read per row. NSJSONSerialization coerces `missing value` to JSON `null` automatically — no try/error wrapping needed.
- **AppleScript path — `get_thread`:** the tell script already emitted `rfc_message_id` for graph-walking, but the Python post-processing actively *stripped* it before returning. Now we keep it; only the internal scratch fields (`in_reply_to`, `references_raw`, `references_parsed`) are still dropped.

## Test plan

- [x] **7 new unit tests** — 1 in IMAP path (`test_emits_both_id_and_rfc_message_id_dual_emit`), 6 in AppleScript paths (search/get/thread script-emission + parsed-row inclusion + null handling for missing Message-ID).
- [x] **2 existing tests updated**:
  - `test_get_thread_returns_anchor_plus_replies_sorted` — added `"rfc_message_id"` to expected key set.
  - `test_get_thread_drops_threading_internals_from_output` — inverted the assertion: `rfc_message_id` MUST now be in output.
- [x] **1 new integration test** — `test_search_messages_returns_rfc_message_id_via_applescript`: APPENDs a synthetic message with known Message-ID via direct IMAP, forces the AppleScript search path (opens the IMAP breaker), polls for Mail.app sync, asserts the row has both fields and that they DIVERGE (id is numeric, rfc_message_id is the RFC ID).
- [x] **`make check-all` passes**: lint, mypy strict, 987 unit tests, complexity gate, version sync, parity.

## Non-goals

- No deprecation of `id` — backwards-compatible additive change.
- No automatic ID-form translation in mutation tools — the dual-emit makes the right id naturally available without translation.

Closes #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)