### PR TITLE
fix(#175): close test-mode safety gap on implicit-reply send_now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+**Test-mode safety gap on implicit-reply `send_now` (#175):** In test mode (`MAIL_TEST_MODE=true`), `create_draft(reply_to=X, send_now=True)` and the analogous `update_draft` path bypassed the reserved-domain safety check when no explicit `to`/`cc`/`bcc` overrides were supplied — Mail.app derived recipients from the original message at send time, so the server's pre-flight gate (which only fired on non-empty recipient lists) was skipped. The gap let test-mode replies target real addresses without surfacing as safety violations. Fixed at two layers: server-tool wrappers now always call `check_test_mode_safety` on `send_now=True` (even with empty recipients), and `check_test_mode_safety` itself now treats empty/None recipients on a `SEND_OPERATIONS` call in test mode as a `safety_violation`. The fix forces explicit recipients for any test-mode send. Surfaced during the v0.7.0 release-review documentation pass; analog of the v0.6 `reply_to_message` hardcoded block that was dropped when the drafts lifecycle (#134) replaced the four old send tools.
+
 **Flag color labels in `update_message(flag_color=...)` (#185):** The map from color name to AppleScript flag index in [`utils.py:get_flag_index`](src/apple_mail_mcp/utils.py) had two pairs of swapped labels. Empirical testing (Gmail/Mail.app, 2026-05-12) confirmed that callers passing certain colors got a different color in Mail.app's UI than they asked for:
 
 - `flag_color="orange"` previously rendered as **red**; now renders as **orange**.

--- a/src/apple_mail_mcp/security.py
+++ b/src/apple_mail_mcp/security.py
@@ -419,8 +419,21 @@ def check_test_mode_safety(
                 f"{rule_name!r}.",
             )
 
-    # Send operations: verify every recipient is on a reserved test domain
-    if operation in SEND_OPERATIONS and recipients is not None:
+    # Send operations: verify every recipient is on a reserved test domain.
+    if operation in SEND_OPERATIONS:
+        # #175: empty recipients in test mode is unsafe — an implicit-reply
+        # send_now path (no explicit to/cc/bcc) lets Mail.app derive
+        # recipients at send time, bypassing the reserved-domain gate.
+        # Force explicit recipients so the safety check has something to
+        # validate. Catches the v0.7.0 analog of the v0.6 reply_to_message
+        # block that was dropped in #134's drafts-lifecycle consolidation.
+        if not recipients:
+            return _safety_error(
+                operation,
+                f"Test mode: {operation} requires explicit recipients for "
+                f"send (implicit-reply targets cannot be safety-verified "
+                f"before send).",
+            )
         bad = [r for r in recipients if not _is_reserved_test_domain(r)]
         if bad:
             return _safety_error(

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -2267,12 +2267,15 @@ async def create_draft(
         # ----------------------------------------------------------------
         if send_now:
             all_recipients = (to or []) + (cc or []) + (bcc or [])
-            if all_recipients:
-                safety_err = check_test_mode_safety(
-                    "create_draft", recipients=all_recipients
-                )
-                if safety_err:
-                    return safety_err
+            # #175: always call the gate when send_now=True — even with an
+            # empty recipients list — so the implicit-reply path doesn't
+            # silently bypass the reserved-domain check. The gate itself
+            # rejects empty recipients in test mode.
+            safety_err = check_test_mode_safety(
+                "create_draft", recipients=all_recipients
+            )
+            if safety_err:
+                return safety_err
             rate_err = check_rate_limit(
                 "create_draft", {"subject": subject, "to": to}
             )
@@ -2482,12 +2485,14 @@ async def update_draft(
             all_recipients = (
                 (final_to or []) + (final_cc or []) + (final_bcc or [])
             )
-            if all_recipients:
-                safety_err = check_test_mode_safety(
-                    "update_draft", recipients=all_recipients
-                )
-                if safety_err:
-                    return safety_err
+            # #175: always call the gate when send_now=True — same reasoning
+            # as create_draft. Empty-recipients reject in test mode lives
+            # inside check_test_mode_safety.
+            safety_err = check_test_mode_safety(
+                "update_draft", recipients=all_recipients
+            )
+            if safety_err:
+                return safety_err
             rate_err = check_rate_limit(
                 "update_draft",
                 {"draft_id": draft_id, "subject": final_subject},

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -453,6 +453,70 @@ class TestCheckTestModeSafety:
         assert result["error_type"] == "safety_violation"
         assert "real@person.com" in result["error"]
 
+    def test_send_blocked_when_recipients_none_in_test_mode(
+        self, monkeypatch: Any
+    ) -> None:
+        """#175: implicit-reply path (no explicit to/cc/bcc, Mail.app
+        derives at send time) reaches the gate with recipients=None.
+        Must reject — the safety check has nothing to verify."""
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+
+        result = check_test_mode_safety("create_draft", recipients=None)
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+        assert "explicit recipients" in result["error"]
+
+    def test_send_blocked_when_recipients_empty_in_test_mode(
+        self, monkeypatch: Any
+    ) -> None:
+        """#175: same as above but with explicit empty list."""
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+
+        result = check_test_mode_safety("create_draft", recipients=[])
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+        assert "explicit recipients" in result["error"]
+
+    def test_send_blocked_for_update_draft_empty_recipients(
+        self, monkeypatch: Any
+    ) -> None:
+        """#175: same gap applies to update_draft's send path."""
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+
+        result = check_test_mode_safety("update_draft", recipients=[])
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+        assert "update_draft" in result["error"]
+
+    def test_send_empty_recipients_passes_outside_test_mode(
+        self, monkeypatch: Any
+    ) -> None:
+        """#175: regression guard — the empty-recipients reject is
+        scoped to test mode. Outside test mode, the gate early-returns
+        None and the new branch is never reached."""
+        monkeypatch.delenv("MAIL_TEST_MODE", raising=False)
+
+        assert check_test_mode_safety("create_draft", recipients=None) is None
+        assert check_test_mode_safety("create_draft", recipients=[]) is None
+
+    def test_non_send_operation_with_empty_recipients_unchanged(
+        self, monkeypatch: Any
+    ) -> None:
+        """#175: regression guard — the new empty-recipients reject
+        only fires for operations in SEND_OPERATIONS. Other ops with
+        empty recipients (which is meaningless for them anyway) are
+        unaffected."""
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+        monkeypatch.setenv("MAIL_TEST_ACCOUNT", "TestAccount")
+
+        # delete_messages isn't a send op — the new branch shouldn't fire.
+        assert (
+            check_test_mode_safety("delete_messages", recipients=None) is None
+        )
+        assert (
+            check_test_mode_safety("delete_messages", recipients=[]) is None
+        )
+
     def test_non_gated_operation_returns_none(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("MAIL_TEST_MODE", "true")
         monkeypatch.setenv("MAIL_TEST_ACCOUNT", "TestAccount")

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -3132,6 +3132,82 @@ class TestDraftToolErrorPaths:
         mock_mail.create_draft.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_create_draft_send_now_implicit_reply_blocked_in_test_mode(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        monkeypatch: Any,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        """#175: implicit-reply send_now (no explicit to/cc/bcc) in test
+        mode is now blocked. Without the fix, the server would skip
+        check_test_mode_safety entirely (recipients list was empty);
+        the new server-side guard removal + security-side empty-recipients
+        reject combine to close the gap."""
+        from apple_mail_mcp.security import (
+            check_test_mode_safety as real_check,
+        )
+        from apple_mail_mcp.server import create_draft
+
+        # Restore the real check_test_mode_safety (the class-level
+        # autouse `stub_security` fixture replaced it with a no-op).
+        monkeypatch.setattr(
+            "apple_mail_mcp.server.check_test_mode_safety", real_check
+        )
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+        monkeypatch.setenv("MAIL_TEST_ACCOUNT", "TestAccount")
+
+        # No to / cc / bcc — Mail.app would derive from reply_to at
+        # send time, potentially targeting a real address.
+        result = await create_draft(
+            reply_to="some-msg-id",
+            body="x", send_now=True, ctx=mock_ctx_accept,
+        )
+        assert result["error_type"] == "safety_violation"
+        assert "explicit recipients" in result["error"]
+        mock_mail.create_draft.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_draft_send_now_implicit_reply_blocked_in_test_mode(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        monkeypatch: Any,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        """#175: same gap on update_draft's send path — closed by the
+        same fix."""
+        from apple_mail_mcp.security import (
+            check_test_mode_safety as real_check,
+        )
+        from apple_mail_mcp.server import update_draft
+
+        # Restore the real check_test_mode_safety (the class-level
+        # autouse `stub_security` fixture replaced it with a no-op).
+        monkeypatch.setattr(
+            "apple_mail_mcp.server.check_test_mode_safety", real_check
+        )
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+        monkeypatch.setenv("MAIL_TEST_ACCOUNT", "TestAccount")
+
+        # No to / cc / bcc and the existing draft has none either —
+        # implicit-reply send path.
+        mock_mail.get_draft_state.return_value = {
+            "id": "draft-1", "to": [], "cc": [], "bcc": [],
+            "subject": "Re: hi", "body": "stub",
+            "attachments": [], "seed_kind": "reply",
+        }
+        result = await update_draft(
+            draft_id="draft-1", body="x", send_now=True,
+            ctx=mock_ctx_accept,
+        )
+        assert result["error_type"] == "safety_violation"
+        assert "explicit recipients" in result["error"]
+        mock_mail.update_draft.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_create_draft_send_now_rate_limit_blocks(
         self,
         isolated_drafts: Any,


### PR DESCRIPTION
## Summary

In test mode (`MAIL_TEST_MODE=true`), `create_draft(reply_to=X, send_now=True)` and `update_draft(send_now=True)` bypassed the reserved-domain safety check when no explicit `to`/`cc`/`bcc` overrides were supplied — Mail.app derived recipients from the original message at send time, so the server's pre-flight gate (which only fired on non-empty recipient lists) was skipped. This let test-mode replies target real addresses without surfacing as safety violations.

## Why both layers

The issue body suggested "either layer is sufficient." On closer reading of the current code, both are needed:

- **Layer 1 alone** (server always calls gate with `recipients=[]`): `check_test_mode_safety`'s inner `bad = [r for r in recipients if not _reserved]; if bad: ...` no-ops on an empty list. Returns None. Gap stays open.
- **Layer 2 alone** (security rejects empty recipients): the server's `if all_recipients:` guard never lets the call reach the gate. Fix never runs.

So both: server always calls the gate on `send_now=True`, AND the gate rejects empty recipients for SEND_OPERATIONS in test mode.

## Implementation notes

- `server.py`: dropped the `if all_recipients:` guard in both `create_draft` (~L2268) and `update_draft` (~L2481) send-only blocks.
- `security.py`: added an explicit empty-recipients reject branch in `check_test_mode_safety`'s `SEND_OPERATIONS` block, before the per-recipient domain check. New error message: "Test mode: \<operation\> requires explicit recipients for send (implicit-reply targets cannot be safety-verified before send)."
- No behavior change outside test mode — the function early-returns when `_is_test_mode_enabled()` is False.

## Test plan

- [x] **5 new security unit tests**: empty/None recipients reject for both `create_draft` and `update_draft` in test mode; passes outside test mode (regression guard); non-send ops with empty recipients unaffected (regression guard).
- [x] **2 new server unit tests**: implicit-reply `send_now` (no explicit to/cc/bcc) blocked for both `create_draft` and `update_draft` in test mode. Both restore the real `check_test_mode_safety` since the class-level autouse `stub_security` fixture in `TestDraftToolErrorPaths` no-ops it by default.
- [x] `make check-all` passes: lint, mypy strict, all unit tests, complexity gate, version sync, parity.

Closes #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)