### PR TITLE
docs(#172): clarify Tier 2 THREAD abort-on-rejection rationale

### DIFF
--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -1497,12 +1497,28 @@ class ImapConnector:
                     "Falling through to Tier 3.",
                     folder_name, exc,
                 )
-                # Mid-flight rejection — server lied about advertised cap.
-                # Surface as None so the dispatcher falls through to BFS,
-                # which produces a *complete* thread by re-walking. We
-                # intentionally discard any partial `collected` from
-                # earlier mailboxes here: incomplete data would be worse
-                # than the BFS round-trip cost.
+                # Mid-flight rejection — fall through to Tier 3 BFS,
+                # which produces a *complete* thread by re-walking via
+                # header search.
+                #
+                # Why THREAD-failure aborts and SELECT/search/fetch-
+                # failures just `continue` (#172):
+                #
+                # - SELECT/search/fetch failures are bounded to one
+                #   mailbox. Skipping that mailbox loses a few known-
+                #   relevant UIDs but doesn't cast doubt on data
+                #   already collected from earlier mailboxes.
+                # - THREAD failure indicates capability-level
+                #   unreliability: the server advertised THREAD but
+                #   can't actually perform it on at least some
+                #   mailboxes. That means THREAD output from earlier
+                #   mailboxes may also have been silently wrong
+                #   (truncated trees, missing references). Falling
+                #   through to Tier 3 BFS re-validates the whole
+                #   thread.
+                #
+                # We intentionally discard any partial `collected`
+                # from earlier mailboxes here.
                 return None
             cluster_uids: set[int] = set()
             for cluster in _flatten_thread_clusters(tree):

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -2772,7 +2772,14 @@ class TestFindThreadMembersImapThread:
         self, mock_cls: MagicMock
     ) -> None:
         """If client.thread() raises mid-flight (server lied about
-        THREAD capability), Tier 2 returns None → BFS runs."""
+        THREAD capability), Tier 2 returns None → BFS runs.
+
+        #172: this abort-and-fall-through behavior is intentional
+        even though the other per-mailbox error paths (SELECT /
+        search / fetch) just ``continue``. THREAD failure casts doubt
+        on earlier mailboxes' THREAD output in a way that local
+        search/fetch failures don't. See the inline comment in
+        ``_thread_via_imap_thread`` for the asymmetry rationale."""
         client = MagicMock()
         mock_cls.return_value = client
         client.capabilities.return_value = _fastmail_caps_with_thread()


### PR DESCRIPTION
## Summary

Comment-only change. Issue #172 raised the inconsistency in `_thread_via_imap_thread`: `client.thread()` failure aborts and falls through to Tier 3 BFS, while the other per-mailbox error paths (SELECT / search / fetch) just `continue`. The inline comment didn't explain the asymmetry well — this PR expands it.

## The asymmetry (now in the comment)

- **SELECT / search / fetch failures** are bounded to one mailbox. Skipping it loses a few known-relevant UIDs but doesn't cast doubt on data already collected from earlier mailboxes.
- **THREAD failure** indicates capability-level unreliability: the server advertised THREAD but can't actually perform it on at least some mailboxes. That means THREAD output from earlier mailboxes may also have been silently wrong (truncated trees, missing references). Falling through to Tier 3 BFS re-validates the whole thread.

The status quo is correct; the comment just makes that explicit so future readers don't try to "fix" the inconsistency.

## Test plan

- [x] Existing `test_thread_command_rejection_falls_through_to_bfs` still passes — no behavior change.
- [x] Its docstring extended with the same #172 rationale so the link is discoverable from both directions.
- [x] `make check-all` passes.

Closes #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)