### PR TITLE
fix(#171): serialize ImapConnectionPool.close() with in-flight session() callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+**`ImapConnectionPool.close()` no longer races in-flight `session()` callers (#171):** `close()` previously snapshotted cached entries under the cache lock, then called `logout()` on each client without holding the per-entry lock. A thread inside a `session()` block would have its IMAP client logged out mid-operation. Latent today (FastMCP is single-threaded), but a real correctness hazard for any future threading and for the #127 atexit hook firing at interpreter shutdown alongside daemon threads. Fix: acquire each entry's lock before calling `logout()`, mirroring the pattern already used by `session()`'s invalidation path.
+
 **Complexity gate now enforces CC ≤ 20 (#174):** `scripts/check_complexity.sh` was filtering radon's JSON output via `-n F`, which limits to functions with CC ≥ 41. Functions in the dangerous CC 21–40 range silently passed the gate. Switched the filter to `-n D` (CC ≥ 21) so the threshold is actually meaningful, and added a per-function allowlist with per-entry CC ceilings: documented exceptions stay green at their current levels, new code over CC 20 fails the gate, and any allowlisted function that creeps higher than its ceiling fails as a regression. Five long-standing exceptions are listed in the allowlist pending dedicated refactor PRs: `server.py::create_draft` (36), `server.py::update_draft` (34), `mail_connector.py::AppleMailConnector.create_draft` (25), and the two threading helpers `_thread_via_xgm_per_mailbox` and `_thread_via_imap_thread` (21 each). See [`docs/guides/COMPLEXITY.md`](docs/guides/COMPLEXITY.md) for the allowlist mechanism and ratchet semantics.
 
 

--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -180,15 +180,27 @@ class ImapConnectionPool:
                 entry.last_used = time.monotonic()
 
     def close(self) -> None:
-        """Log out all cached clients. Safe to call multiple times."""
+        """Log out all cached clients. Safe to call multiple times.
+
+        Acquires each entry's per-connection lock before issuing
+        ``logout()`` so an in-flight ``session()``-holder finishes its
+        operation before we drop the connection underneath it (#171).
+        Latent today because FastMCP is single-threaded, but the
+        pool's per-entry locks are designed for future thread-safety
+        and the atexit hook (#127) fires ``close()`` at interpreter
+        shutdown when daemon threads may still be alive.
+        """
         with self._cache_lock:
             entries = list(self._cache.values())
             self._cache.clear()
         for entry in entries:
-            try:
-                entry.client.logout()
-            except Exception:  # noqa: BLE001 — best effort
-                pass
+            # Wait for any in-flight session() block to finish before
+            # logging out — mirrors session()'s invalidation path.
+            with entry.lock:
+                try:
+                    entry.client.logout()
+                except Exception:  # noqa: BLE001 — best effort
+                    pass
 
 _IMAP_MONTHS = (
     "Jan",

--- a/tests/unit/test_imap_pool.py
+++ b/tests/unit/test_imap_pool.py
@@ -412,6 +412,68 @@ class TestClose:
         pool.close()
         pool.close()  # second call must not raise on empty cache
 
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_close_waits_for_in_flight_session_holder(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """#171: close() must acquire entry.lock before logout() so
+        it doesn't race a session()-holder actively using the client.
+        Latent today (FastMCP single-threaded) but a real correctness
+        hazard for the #127 atexit hook + future threading. Pattern
+        mirrors test_same_key_serializes."""
+        client = MagicMock()
+        mock_cls.return_value = client
+
+        inside = threading.Event()
+        release = threading.Event()
+        logout_observed_during_session = threading.Event()
+
+        def thread_a() -> None:
+            """Holds the session for key K until 'release' is set."""
+            with pool.session("h", 993, "u@e.com", "pw", 3.0):
+                inside.set()
+                release.wait(timeout=2.0)
+                # If close() jumped the gun, logout() would have
+                # fired by now — record that as the bug.
+                if client.logout.called:
+                    logout_observed_during_session.set()
+
+        ta = threading.Thread(target=thread_a)
+        ta.start()
+        assert inside.wait(timeout=2.0), "thread_a never entered session"
+
+        # Run close() in its own thread so the test doesn't deadlock
+        # if close() blocks waiting on entry.lock (which is the
+        # expected behavior post-fix).
+        close_done = threading.Event()
+
+        def close_runner() -> None:
+            pool.close()
+            close_done.set()
+
+        tc = threading.Thread(target=close_runner)
+        tc.start()
+
+        # close() should be blocked on entry.lock right now. Give it
+        # a moment to (incorrectly) call logout if the bug is present.
+        time.sleep(0.05)
+        assert not close_done.is_set(), (
+            "close() returned while session-holder was still inside; "
+            "expected it to block on entry.lock"
+        )
+        assert not client.logout.called, (
+            "close() called logout() before session-holder released "
+            "entry.lock — this is the #171 race"
+        )
+
+        # Release thread_a; close() should now proceed.
+        release.set()
+        ta.join(timeout=2.0)
+        tc.join(timeout=2.0)
+        assert close_done.is_set(), "close() never finished"
+        assert client.logout.called, "close() never called logout()"
+        assert not logout_observed_during_session.is_set()
+
 
 # ---------------------------------------------------------------------------
 # ImapConnector wiring


### PR DESCRIPTION
## Summary

`ImapConnectionPool.close()` snapshotted cached entries under `_cache_lock`, cleared the dict, then called `entry.client.logout()` on each — **without** holding `entry.lock`. A thread inside `session()`'s `with entry.lock:` block actively using that client would have its IMAP session logged out mid-operation.

Latent today (FastMCP is single-threaded) but a real correctness hazard for:
- The pool's per-entry lock was designed in for future thread-safety (per the class docstring).
- The atexit hook from #127 fires `close()` at interpreter shutdown alongside any still-running daemon threads.

## Fix

Five lines inside `close()`. Acquire each entry's lock before calling `logout()`, mirroring the pattern at `session()`'s invalidation path. The cache lock is held only long enough to snapshot the entries; per-entry locks are acquired one at a time so a slow logout doesn't block unrelated cache lookups.

## Test plan

- [x] **New regression test `test_close_waits_for_in_flight_session_holder`** using `threading.Event` coordination (same pattern as `test_same_key_serializes`). Two threads: thread A holds a session and signals \"inside\"; thread B (close()) is launched and given 50ms to misbehave. Asserts logout did NOT fire while A was inside, then releases A and verifies close completes and logout fires.
- [x] **Verified red on the original code** — `assert not close_done.is_set()` failed because close returned while A was still inside.
- [x] **Green after the fix.**
- [x] **Existing `TestClose` tests still pass** unchanged.
- [x] `make check-all` passes: lint, mypy strict, all unit tests, complexity gate, version sync, parity.

Closes #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)