### PR TITLE
refactor(#191): reduce create_draft from CC 36 → 19

### DIFF
--- a/docs/guides/COMPLEXITY.md
+++ b/docs/guides/COMPLEXITY.md
@@ -22,17 +22,16 @@ This mechanism replaced an earlier silent-pass bug (#174): the script ran `radon
 
 The functions below sit above CC 10 intentionally. When touching them, prefer adding one more gate over restructuring. If a change would push any of them above 20, extract a helper first.
 
-> **Allowlisted above-threshold functions:** Five functions currently exceed CC 20. They're pinned in the allowlist at their current ceiling pending dedicated refactor PRs:
+> **Allowlisted above-threshold functions:** Four functions currently exceed CC 20. They're pinned in the allowlist at their current ceiling pending dedicated refactor PRs:
 >
-> - [`server.py::create_draft`](../../src/apple_mail_mcp/server.py) (CC 36) — see follow-up issue.
-> - [`server.py::update_draft`](../../src/apple_mail_mcp/server.py) (CC 34) — see follow-up issue.
-> - [`mail_connector.py::AppleMailConnector.create_draft`](../../src/apple_mail_mcp/mail_connector.py) (CC 25) — see follow-up issue.
-> - [`imap_connector.py::ImapConnector._thread_via_xgm_per_mailbox`](../../src/apple_mail_mcp/imap_connector.py) (CC 21) — see follow-up issue.
-> - [`imap_connector.py::ImapConnector._thread_via_imap_thread`](../../src/apple_mail_mcp/imap_connector.py) (CC 21) — see follow-up issue.
+> - [`server.py::update_draft`](../../src/apple_mail_mcp/server.py) (CC 34) — see #192.
+> - [`mail_connector.py::AppleMailConnector.create_draft`](../../src/apple_mail_mcp/mail_connector.py) (CC 25) — see #193.
+> - [`imap_connector.py::ImapConnector._thread_via_xgm_per_mailbox`](../../src/apple_mail_mcp/imap_connector.py) (CC 21) — see #194.
+> - [`imap_connector.py::ImapConnector._thread_via_imap_thread`](../../src/apple_mail_mcp/imap_connector.py) (CC 21) — see #195.
 
 | File | Function | CC | Why it's complex |
 |---|---|---|---|
-| [`server.py`](../../src/apple_mail_mcp/server.py) | `create_draft` | 36 | Unified compose / reply / reply_all / forward authoring loop with `send_now` opt-in; subsumes the four removed v0.6 send tools. Each `seed_kind` adds branches; `send_now=True` re-enters the safety + rate-limit gate chain previously in `send_email`. **Allowlisted at 36 — refactor candidate.** |
+| [`server.py`](../../src/apple_mail_mcp/server.py) | `create_draft` | 19 | Unified compose / reply / reply_all / forward authoring loop with `send_now` opt-in; subsumes the four removed v0.6 send tools. Dropped from CC 36 → 19 in #191 by extracting `_resolve_create_draft_seed`, `_maybe_apply_template`, `_validate_fresh_seed_fields`, `_run_send_now_gates`, and `_persist_create_draft_seed`. |
 | [`server.py`](../../src/apple_mail_mcp/server.py) | `update_draft` | 34 | Same gate stack as `create_draft` plus the existing-draft lookup and patch-semantic body/recipient updates. **Allowlisted at 34 — refactor candidate.** |
 | [`mail_connector.py`](../../src/apple_mail_mcp/mail_connector.py) | `AppleMailConnector.create_draft` | 25 | Per-`seed_kind` AppleScript dispatch (compose vs reply/reply_all/forward), template rendering branch, recipient list builders for to/cc/bcc, then save-vs-send tail. **Allowlisted at 25 — refactor candidate.** |
 | [`imap_connector.py`](../../src/apple_mail_mcp/imap_connector.py) | `_thread_via_xgm_per_mailbox` | 21 | Tier 1.5 (#125): anchor lookup with INBOX→Sent fallback, THRID FETCH, then per-folder iteration with \\Noselect / select-failure / fetch-failure handling. **Allowlisted at 21 — refactor candidate.** |

--- a/scripts/check_complexity.sh
+++ b/scripts/check_complexity.sh
@@ -50,7 +50,6 @@ THRESHOLD = $THRESHOLD
 # a one-way ratchet. NEVER raise without updating COMPLEXITY.md and
 # justifying the structural reason in the PR.
 ALLOWLIST = {
-    ('server.py', 'create_draft'): 36,
     ('server.py', 'update_draft'): 34,
     ('mail_connector.py', 'AppleMailConnector.create_draft'): 25,
     ('imap_connector.py', 'ImapConnector._thread_via_xgm_per_mailbox'): 21,

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -2146,6 +2146,141 @@ def _build_draft_send_summary(
     return verb + "\n\n" + "\n".join(lines)
 
 
+def _resolve_create_draft_seed(
+    reply_to: str | None,
+    forward_of: str | None,
+) -> tuple[str, str | None]:
+    """Resolve (seed_kind, seed_id) from create_draft's reply_to/forward_of
+    params. Param-shape validation (reply_to AND forward_of both set) is
+    caller's responsibility; this helper assumes valid input. (#191)
+    """
+    if reply_to:
+        return "reply", reply_to
+    if forward_of:
+        return "forward", forward_of
+    return "new", None
+
+
+def _maybe_apply_template(
+    template_name: str | None,
+    template_vars: dict[str, str] | None,
+    seed_id: str | None,
+    subject: str | None,
+    body: str,
+) -> tuple[str | None, str]:
+    """If template_name is set, load it and merge into (subject, body).
+    Caller-supplied values override the rendered output. Pass-through
+    when template_name is None. Raises MailTemplateError on bad
+    templates — caller wraps in try/except + _template_error_response. (#191)
+    """
+    if not template_name:
+        return subject, body
+    template = _get_template_store().get(template_name)
+    auto_vars = mail.auto_template_vars(seed_id)
+    merged_vars: dict[str, str] = {**auto_vars, **(template_vars or {})}
+    rendered = template.render(merged_vars)
+    if subject is None:
+        subject = rendered["subject"]
+    if not body:
+        body = rendered["body"] or ""
+    return subject, body
+
+
+def _validate_fresh_seed_fields(
+    seed_kind: str,
+    to: list[str] | None,
+    subject: str | None,
+) -> dict[str, Any] | None:
+    """For seed_kind=='new', require both `to` and `subject` (post-template
+    rendering). Returns a validation_error dict if missing, None otherwise. (#191)
+    """
+    if seed_kind != "new":
+        return None
+    if not to:
+        return {
+            "success": False,
+            "error": "'to' is required when not replying or forwarding",
+            "error_type": "validation_error",
+        }
+    if not subject:
+        return {
+            "success": False,
+            "error": "'subject' is required when not replying or forwarding",
+            "error_type": "validation_error",
+        }
+    return None
+
+
+async def _run_send_now_gates(
+    operation: str,
+    ctx: Context | None,
+    recipients: list[str],
+    rate_params: dict[str, Any],
+    summary: str,
+    elicit_extra: dict[str, Any],
+    *,
+    validate_recipient_shape: bool = False,
+    validate_args: tuple[Any, ...] = (),
+) -> dict[str, Any] | None:
+    """Run the standard send_now gate chain (#191):
+
+    1. ``check_test_mode_safety(operation, recipients=recipients)``
+    2. ``check_rate_limit(operation, rate_params)``
+    3. If ``validate_recipient_shape``: ``validate_send_operation(*validate_args)``
+    4. ``_elicit_confirmation(ctx, summary, operation, elicit_extra)``
+
+    Returns the first failure response, or ``None`` if all pass.
+
+    The ``validate_recipient_shape`` flag exists so ``update_draft``
+    (#192) can adopt this helper — its send path inherits recipients
+    from existing draft state and doesn't need the shape check.
+    """
+    safety_err = check_test_mode_safety(operation, recipients=recipients)
+    if safety_err:
+        return safety_err
+    rate_err = check_rate_limit(operation, rate_params)
+    if rate_err:
+        return rate_err
+    if validate_recipient_shape:
+        is_valid, error_msg = validate_send_operation(*validate_args)
+        if not is_valid:
+            return {
+                "success": False,
+                "error": error_msg,
+                "error_type": "validation_error",
+            }
+    cancel_err = await _elicit_confirmation(
+        ctx, summary, operation, elicit_extra,
+    )
+    if cancel_err:
+        return cancel_err
+    return None
+
+
+def _persist_create_draft_seed(
+    draft_id: str,
+    seed_kind: str,
+    seed_id: str | None,
+    reply_all: bool,
+    send_now: bool,
+) -> None:
+    """Persist seed metadata for reply/forward drafts so update_draft can
+    rebuild without an O(N) header lookup. No-op for `send_now=True`,
+    failed creates (empty draft_id), or seed kinds without an anchor
+    message. (#191)
+    """
+    if send_now or not draft_id or seed_kind not in ("reply", "forward") or not seed_id:
+        return
+    _get_draft_state_store().set_seed(
+        draft_id,
+        SeedRecord(
+            seed_kind=cast(Any, seed_kind),
+            seed_id=seed_id,
+            reply_all=reply_all,
+        ),
+    )
+
+
 @mcp.tool()
 async def create_draft(
     reply_to: str | None = None,
@@ -2218,90 +2353,51 @@ async def create_draft(
                 "error_type": "validation_error",
             }
 
-        # Resolve seed.
-        if reply_to:
-            seed_kind = "reply"
-            seed_id: str | None = reply_to
-        elif forward_of:
-            seed_kind = "forward"
-            seed_id = forward_of
-        else:
-            seed_kind = "new"
-            seed_id = None
+        seed_kind, seed_id = _resolve_create_draft_seed(reply_to, forward_of)
 
         # ----------------------------------------------------------------
-        # Template resolution
+        # Template resolution (#191: pulled out to _maybe_apply_template).
         # ----------------------------------------------------------------
-        if template_name:
-            try:
-                template = _get_template_store().get(template_name)
-                auto_vars = mail.auto_template_vars(seed_id)
-                merged_vars: dict[str, str] = {**auto_vars, **(template_vars or {})}
-                rendered = template.render(merged_vars)
-                # User-supplied subject/body override the rendered output.
-                if subject is None:
-                    subject = rendered["subject"]
-                if not body:
-                    body = rendered["body"] or ""
-            except MailTemplateError as e:
-                return _template_error_response(e)
+        try:
+            subject, body = _maybe_apply_template(
+                template_name, template_vars, seed_id, subject, body,
+            )
+        except MailTemplateError as e:
+            return _template_error_response(e)
 
         # Fresh-seed required-field validation (after template rendering
         # so a template can supply subject/body).
-        if seed_kind == "new":
-            if not to:
-                return {
-                    "success": False,
-                    "error": "'to' is required when not replying or forwarding",
-                    "error_type": "validation_error",
-                }
-            if not subject:
-                return {
-                    "success": False,
-                    "error": "'subject' is required when not replying or forwarding",
-                    "error_type": "validation_error",
-                }
+        fresh_err = _validate_fresh_seed_fields(seed_kind, to, subject)
+        if fresh_err:
+            return fresh_err
 
         # ----------------------------------------------------------------
-        # Send-only checks (drafts are local — no rate limit / safety)
+        # Send-only checks (drafts are local — no rate limit / safety).
+        # #191: gate chain pulled out to _run_send_now_gates.
         # ----------------------------------------------------------------
         if send_now:
             all_recipients = (to or []) + (cc or []) + (bcc or [])
-            # #175: always call the gate when send_now=True — even with an
-            # empty recipients list — so the implicit-reply path doesn't
-            # silently bypass the reserved-domain check. The gate itself
-            # rejects empty recipients in test mode.
-            safety_err = check_test_mode_safety(
-                "create_draft", recipients=all_recipients
+            summary = _build_draft_send_summary(
+                seed_kind, to, cc, bcc, subject, body,
             )
-            if safety_err:
-                return safety_err
-            rate_err = check_rate_limit(
-                "create_draft", {"subject": subject, "to": to}
-            )
-            if rate_err:
-                return rate_err
-            if to is not None or cc is not None or bcc is not None:
+            gate_err = await _run_send_now_gates(
+                operation="create_draft",
+                ctx=ctx,
+                recipients=all_recipients,
+                rate_params={"subject": subject, "to": to},
+                summary=summary,
+                elicit_extra={
+                    "subject": subject, "to": to, "seed_kind": seed_kind,
+                },
                 # Only validate recipient shape when caller supplied any —
                 # for reply with no overrides, recipients come from Mail.
-                is_valid, error_msg = validate_send_operation(
-                    to or [], cc, bcc
-                )
-                if not is_valid:
-                    return {
-                        "success": False,
-                        "error": error_msg,
-                        "error_type": "validation_error",
-                    }
-            summary = _build_draft_send_summary(
-                seed_kind, to, cc, bcc, subject, body
+                validate_recipient_shape=(
+                    to is not None or cc is not None or bcc is not None
+                ),
+                validate_args=(to or [], cc, bcc),
             )
-            cancel_err = await _elicit_confirmation(
-                ctx, summary, "create_draft",
-                {"subject": subject, "to": to, "seed_kind": seed_kind},
-            )
-            if cancel_err:
-                return cancel_err
+            if gate_err:
+                return gate_err
 
         # ----------------------------------------------------------------
         # Connector call
@@ -2326,17 +2422,9 @@ async def create_draft(
         )
         draft_id = result.get("draft_id", "")
 
-        # Persist seed metadata for reply/forward drafts so update_draft
-        # can rebuild without an O(N) header lookup.
-        if not send_now and draft_id and seed_kind in ("reply", "forward") and seed_id:
-            _get_draft_state_store().set_seed(
-                draft_id,
-                SeedRecord(
-                    seed_kind=cast(Any, seed_kind),
-                    seed_id=seed_id,
-                    reply_all=reply_all,
-                ),
-            )
+        _persist_create_draft_seed(
+            draft_id, seed_kind, seed_id, reply_all, send_now,
+        )
 
         operation_logger.log_operation(
             "create_draft",


### PR DESCRIPTION
## Summary

Pure CC reduction. Extracted 5 single-responsibility helpers from `server.py::create_draft`, dropping its cyclomatic complexity from 36 to **19** (below the CC ≤ 20 threshold). No behavior change.

## Helpers added

| Helper | CC | Pulls out |
|---|---|---|
| `_resolve_create_draft_seed(reply_to, forward_of) → (kind, id)` | 3 | Seed kind/id resolution |
| `_maybe_apply_template(...) → (subject, body)` | 6 | Template load + render + merge. Raises `MailTemplateError`. |
| `_validate_fresh_seed_fields(seed_kind, to, subject) → dict \| None` | 4 | "Fresh seed requires to + subject" validation |
| `_run_send_now_gates(...) → dict \| None` | 6 | safety → rate → optional recipient-shape → elicit confirmation chain |
| `_persist_create_draft_seed(...) → None` | 5 | The 4-condition guard for reply/forward seed persistence |

All helpers are 3-6 CC each, well under threshold.

## `_run_send_now_gates` is reusable for #192

The new helper takes a `validate_recipient_shape` flag specifically so `update_draft`'s refactor (#192) can adopt it as-is — update_draft inherits recipients from existing draft state and doesn't need the shape check.

## Test plan

- [x] All 20 existing tests pass unchanged (10 in `TestCreateDraftTool` + 10 in `TestDraftToolErrorPaths`). Externally observable behavior identical.
- [x] `uv run radon cc src/apple_mail_mcp/server.py -s | grep create_draft` → CC 19 (was 36).
- [x] Removed `create_draft` entry from `scripts/check_complexity.sh` allowlist (function is now under threshold).
- [x] COMPLEXITY.md updated: dropped from "allowlisted above-threshold" callout (4 entries left, was 5), added issue numbers for remaining four.
- [x] `make check-all` passes.

Closes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)