### PR TITLE
fix(#201): _resolve_imap_config prefers user_name; CLI keychain key matches runtime

### DIFF
--- a/src/apple_mail_mcp/cli.py
+++ b/src/apple_mail_mcp/cli.py
@@ -36,26 +36,10 @@ def _print_available_accounts(accounts: list[dict[str, object]]) -> None:
         print(f"  - {name}", file=sys.stderr)
 
 
-def _resolve_account(
+def _account_exists(
     accounts: list[dict[str, object]], requested_name: str
-) -> dict[str, object] | None:
-    for acc in accounts:
-        if acc.get("name") == requested_name:
-            return acc
-    return None
-
-
-def _resolve_email(
-    account: dict[str, object], cli_email: str | None
-) -> str | None:
-    if cli_email:
-        return cli_email
-    emails = account.get("email_addresses") or []
-    if isinstance(emails, list) and emails:
-        first = emails[0]
-        if isinstance(first, str) and first:
-            return first
-    return None
+) -> bool:
+    return any(acc.get("name") == requested_name for acc in accounts)
 
 
 def run_setup_imap(
@@ -77,9 +61,8 @@ def run_setup_imap(
     """
     mail = (connector_factory or AppleMailConnector)()
     accounts = mail.list_accounts()
-    matched = _resolve_account(accounts, account_name)
 
-    if matched is None:
+    if not _account_exists(accounts, account_name):
         print(
             f"ERROR: No Mail.app account named {account_name!r}. "
             "Available accounts:",
@@ -88,11 +71,29 @@ def run_setup_imap(
         _print_available_accounts(accounts)
         return 1
 
-    email = _resolve_email(matched, cli_email)
+    # Resolve IMAP config upfront. The connector calls _resolve_imap_config
+    # at every runtime IMAP request to pick the keychain key — so we use
+    # the same email here as the keychain key, otherwise setup writes one
+    # entry and runtime looks for another. (#201)
+    try:
+        host, port, resolved_email = mail._resolve_imap_config(account_name)
+    except MailAccountNotFoundError:
+        print(
+            f"ERROR: Mail.app stopped recognizing {account_name!r} "
+            "between the account list and the IMAP config lookup.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # `--email` is the escape hatch for the rare case where Mail.app's
+    # `user name` is empty or wrong; default to the resolved value so
+    # setup, uninstall, and runtime all share one keychain key.
+    email = cli_email or resolved_email
     if not email:
         print(
-            f"ERROR: Account {account_name!r} has no email addresses in "
-            "Mail.app. Pass --email <email> to set one explicitly.",
+            f"ERROR: Account {account_name!r} has no IMAP login username "
+            "in Mail.app (neither `user name` nor `email addresses`). "
+            "Pass --email <email> to set one explicitly.",
             file=sys.stderr,
         )
         return 1
@@ -136,24 +137,8 @@ def run_setup_imap(
         f"Stored in Keychain as 'apple-mail-mcp.imap.{account_name}'."
     )
 
-    # Verification: derive host/port from Mail.app and try a real LOGIN.
-    try:
-        host, port, resolved_email = mail._resolve_imap_config(account_name)
-    except MailAccountNotFoundError:
-        # Shouldn't happen — we just listed it — but surface clearly.
-        print(
-            f"ERROR: Mail.app stopped recognizing {account_name!r} "
-            "between the account list and the IMAP config lookup.",
-            file=sys.stderr,
-        )
-        return 1
-
-    # Use the email Mail.app actually expects for IMAP LOGIN, which may
-    # differ from `--email` for iCloud (Apple ID alias vs. @icloud.com).
-    verify_email = resolved_email or email
-
     print(f"Testing IMAP connection to {host}:{port}...")
-    imap = (imap_factory or ImapConnector)(host, port, verify_email, password)
+    imap = (imap_factory or ImapConnector)(host, port, email, password)
     try:
         # Use a cheap read-only call; search_messages with limit=1 is enough
         # to exercise login + folder select without paging much data.

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -968,17 +968,21 @@ class AppleMailConnector:
             account: Mail.app account name (e.g. "iCloud", "Gmail").
 
         Returns:
-            Tuple of (host, port, email). `email` is the first entry of
-            Mail.app's `email addresses` list if non-empty, else falls back
-            to the `user name` property.
+            Tuple of (host, port, email). `email` is Mail.app's `user name`
+            property if non-empty, else falls back to the first entry of
+            `email addresses`.
 
-            For iCloud specifically, `user name` is the Apple ID login
-            identifier — which may be any email (e.g. a Gmail address) —
-            while the IMAP server only accepts @icloud.com / @me.com aliases
-            as LOGIN username. `email addresses` reliably contains the
-            alias iCloud's IMAP server expects. For Gmail / Yahoo / generic
-            IMAP accounts, the first email address typically equals
-            `user name`, so the behavior is equivalent there.
+            `user name` is the credential Mail.app itself sends as the IMAP
+            LOGIN — it's the source of truth. `email addresses` is the SMTP
+            From list, which usually overlaps with `user name` for Gmail /
+            Yahoo / @icloud.com-primary accounts but diverges for iCloud
+            accounts whose Apple ID is on a custom domain (Apple's "Custom
+            Email Domain" setup): there `email_addresses[0]` is an SMTP-
+            only From alias that the IMAP server rejects with
+            AUTHENTICATIONFAILED, while `user name` (the Apple ID itself)
+            is what the server actually accepts. Preferring `user name`
+            matches Mail.app's own behavior in every configuration we've
+            seen. (#201)
 
         Raises:
             MailAccountNotFoundError: If the account doesn't exist.
@@ -996,7 +1000,8 @@ class AppleMailConnector:
         raw = self._run_applescript(script)
         parsed = cast(dict[str, Any], parse_applescript_json(raw))
         email_addresses = cast(list[str], parsed.get("email_addresses") or [])
-        email = email_addresses[0] if email_addresses else cast(str, parsed["user_name"])
+        user_name = cast(str, parsed.get("user_name") or "")
+        email = user_name or (email_addresses[0] if email_addresses else "")
         return (
             cast(str, parsed["host"]),
             cast(int, parsed["port"]),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -86,11 +86,12 @@ class TestAccountValidation:
         mock_connector: MagicMock,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        # Strip out email_addresses for one account to simulate a misconfigured
-        # Mail.app entry.
-        accs = _make_accounts()
-        accs[0]["email_addresses"] = []
-        mock_connector.list_accounts.return_value = accs
+        # Simulate a Mail.app account with neither user_name nor
+        # email_addresses populated — _resolve_imap_config returns "" for
+        # the email field after the #201 fallback chain exhausts.
+        mock_connector._resolve_imap_config.return_value = (
+            "imap.mail.me.com", 993, "",
+        )
 
         rc = run_setup_imap(
             account_name="iCloud",
@@ -100,7 +101,7 @@ class TestAccountValidation:
         )
         assert rc == 1
         captured = capsys.readouterr()
-        assert "no email addresses" in captured.err
+        assert "no IMAP login username" in captured.err
         assert "--email" in captured.err
 
     def test_cli_email_override_used_when_provided(
@@ -167,9 +168,9 @@ class TestSetupHappyPath:
             imap_factory=imap_factory,
         )
         assert rc == 0
+        # No --email override → Keychain key + IMAP LOGIN both use the
+        # email returned by _resolve_imap_config (post-#201 = user_name).
         assert set_calls == [("iCloud", "alice@icloud.com", "appspecificpw")]
-        # Verification used the resolved (Mail.app's) email, not necessarily
-        # the same as the Keychain key — important for iCloud.
         assert captured_imap_args == [
             ("imap.mail.me.com", 993, "alice@icloud.com", "appspecificpw"),
         ]
@@ -178,24 +179,30 @@ class TestSetupHappyPath:
         assert "Setup complete." in out
         assert "OK (connected to imap.mail.me.com:993)" in out
 
-    def test_setup_uses_resolved_email_for_imap_login(
+    def test_cli_email_override_wins_for_keychain_and_login(
         self,
         mock_connector: MagicMock,
         mock_imap_client: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """For iCloud, --email may be the Apple ID alias but IMAP needs
-        @icloud.com. The CLI must use _resolve_imap_config's email for LOGIN."""
+        """When --email is supplied, it overrides _resolve_imap_config's
+        result for BOTH the keychain key AND the IMAP LOGIN. Pre-#201 the
+        login silently switched back to the resolver's value, which is
+        what caused the custom-domain Apple ID failures: the user passed
+        the right Apple ID but the resolver swapped in an SMTP-only From
+        alias the IMAP server rejected. (#201)
+        """
         from apple_mail_mcp import cli as cli_mod
 
+        set_calls: list[tuple[str, str, str]] = []
         monkeypatch.setattr(
-            cli_mod, "set_imap_password", lambda a, e, p: None,
+            cli_mod, "set_imap_password",
+            lambda a, e, p: set_calls.append((a, e, p)),
         )
 
-        # User supplied an Apple-ID-style email; Mail.app resolves the IMAP
-        # username to the actual @icloud.com address.
+        # Resolver returns one value; user explicitly passes another.
         mock_connector._resolve_imap_config.return_value = (
-            "imap.mail.me.com", 993, "alice@icloud.com",
+            "imap.mail.me.com", 993, "from-alias@example.com",
         )
 
         captured: list[tuple[str, int, str, str]] = []
@@ -206,16 +213,20 @@ class TestSetupHappyPath:
 
         rc = run_setup_imap(
             account_name="iCloud",
-            cli_email="alice@gmail.com",  # user's Apple ID is a Gmail
+            cli_email="apple-id@example.com",
             uninstall=False,
             connector_factory=lambda: mock_connector,
             getpass_fn=lambda prompt: "pw",
             imap_factory=factory,
         )
         assert rc == 0
-        # IMAP LOGIN uses the Mail.app-resolved email, not the CLI override.
+        # Keychain key uses the CLI override.
+        assert set_calls == [
+            ("iCloud", "apple-id@example.com", "pw"),
+        ]
+        # IMAP LOGIN uses the same CLI override — not the resolver's value.
         assert captured == [
-            ("imap.mail.me.com", 993, "alice@icloud.com", "pw"),
+            ("imap.mail.me.com", 993, "apple-id@example.com", "pw"),
         ]
 
 

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -862,33 +862,34 @@ class TestAppleMailConnector:
     # --- _resolve_imap_config --------------------------------------------
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_resolve_imap_config_prefers_first_email_address(
+    def test_resolve_imap_config_prefers_user_name_for_login(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """Primary path: first email_addresses entry wins over user_name.
-
-        iCloud's IMAP server rejects the Apple-ID user_name as LOGIN
-        but accepts the aliases in email_addresses.
+        """Primary path: user_name (Mail.app's IMAP LOGIN credential) wins
+        over email_addresses[0] (the SMTP From list). They overlap for
+        most accounts but diverge for iCloud accounts on a custom-domain
+        Apple ID — there email_addresses[0] is an SMTP-only From alias
+        the IMAP server rejects with AUTHENTICATIONFAILED. (#201)
         """
         mock_run.return_value = (
             '{"host":"imap.mail.me.com",'
             '"port":993,'
-            '"user_name":"apple.id@gmail.com",'
-            '"email_addresses":["user@icloud.com","user@me.com"]}'
+            '"user_name":"apple-id@example.com",'
+            '"email_addresses":["from-alias@example.com","apple-id@example.com"]}'
         )
         result = connector._resolve_imap_config("iCloud")
-        assert result == ("imap.mail.me.com", 993, "user@icloud.com")
+        assert result == ("imap.mail.me.com", 993, "apple-id@example.com")
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_resolve_imap_config_falls_back_to_user_name_when_emails_empty(
+    def test_resolve_imap_config_falls_back_to_email_addresses_when_user_name_empty(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """Fallback path: empty email_addresses → use user_name."""
+        """Fallback path: empty user_name → use email_addresses[0]. (#201)"""
         mock_run.return_value = (
             '{"host":"imap.gmail.com",'
             '"port":993,'
-            '"user_name":"me@gmail.com",'
-            '"email_addresses":[]}'
+            '"user_name":"",'
+            '"email_addresses":["me@gmail.com"]}'
         )
         result = connector._resolve_imap_config("Gmail")
         assert result == ("imap.gmail.com", 993, "me@gmail.com")


### PR DESCRIPTION
## Summary

- Flip `_resolve_imap_config` to prefer Mail.app's `user name` (the IMAP LOGIN credential) over `email_addresses[0]` (the SMTP From list). Fixes the reported `AUTHENTICATIONFAILED` against iCloud accounts whose Apple ID is on a custom domain.
- Restructure `cli.run_setup_imap` so the keychain key written at setup is always whatever `_resolve_imap_config` returns (defaulting; `--email` still overrides). Without this, the connector flip alone would create a setup-success / runtime-keychain-miss bug for users without `--email`.
- `--email` now wins for BOTH the keychain key and the IMAP LOGIN — pre-fix the login silently switched back to the resolver's value, which is what originally masked the bug for fmasi.

## Background

Reported by @fmasi in #201 with reproduction steps, direct `imapclient` verification against iCloud's IMAP server, and a proposed connector-side patch. The connector change here matches their suggestion; the CLI change closes a secondary keychain-key consistency gap that the flip alone would expose for users who don't pass `--email`. Both are needed to resolve the issue end-to-end.

The original docstring claimed iCloud's IMAP server rejects `user_name` and accepts only @icloud.com aliases. fmasi's empirical testing — and ours — contradicts that: iCloud accepts the Apple ID itself as LOGIN, including custom-domain Apple IDs. If a future user reports the inverse failure, a try-`user_name`-then-fallback pattern at LOGIN time would cover both cases without further design changes.

## Backward compatibility note

Existing users on custom-domain iCloud accounts will need to re-run `setup-imap` once after upgrading. Their old keychain entry (written under the SMTP alias) is unreadable by the new lookup path. IMAP fast paths gracefully fall back to AppleScript on a keychain miss, so the failure mode is "slow operations" rather than "broken operations" until they do. Worth a CHANGELOG entry on release.

## Test plan

- [x] `uv run pytest tests/unit/test_cli.py tests/unit/test_mail_connector.py` — 347 passed
- [x] `make check-all` — all checks green
- [ ] Manual verification on a real custom-domain iCloud account (not in our setup; relying on fmasi's reproduction + their note that 1002/1002 still pass with their version of the connector flip)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)