### PR TITLE
fix(#205): create_draft accepts RFC 5322 Message-IDs from IMAP-path read tools

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -3247,14 +3247,18 @@ class AppleMailConnector:
         """Resolve an RFC 5322 Message-ID header to Mail's internal id.
 
         Used by ``update_draft`` to recover a reply seed from a saved
-        draft's ``In-Reply-To`` header (which carries the original
-        message's RFC 5322 Message-ID, including the angle brackets).
+        draft's ``In-Reply-To`` header, and by ``create_draft`` to accept
+        the bracketless RFC ids that read tools emit on the IMAP path
+        (#148 / #205).
 
         Args:
-            rfc5322_message_id: e.g. ``<calendar-abc123@google.com>``.
-                Angle brackets are accepted; AppleScript's ``message id``
-                property stores the value verbatim as it appears on the
-                wire.
+            rfc5322_message_id: e.g. ``<calendar-abc123@google.com>`` or
+                ``calendar-abc123@google.com``. Angle brackets are added
+                if missing — AppleScript's ``message id`` property stores
+                the value verbatim as it appears on the wire (bracketed
+                per RFC 5322), so the lookup needs the wrapped form. Read
+                tools strip the brackets before emission, so callers
+                forwarding read-tool ids can hand us either form.
 
         Returns:
             Mail's internal numeric id (as a string) of the first
@@ -3263,7 +3267,10 @@ class AppleMailConnector:
         """
         if not rfc5322_message_id:
             return None
-        safe = escape_applescript_string(sanitize_input(rfc5322_message_id))
+        normalized = rfc5322_message_id
+        if not (normalized.startswith("<") and normalized.endswith(">")):
+            normalized = f"<{normalized}>"
+        safe = escape_applescript_string(sanitize_input(normalized))
 
         script = f"""
         tell application "Mail"
@@ -3409,6 +3416,31 @@ class AppleMailConnector:
         data.pop("found", None)
         return cast(dict[str, Any], data)
 
+    def _maybe_resolve_rfc_seed_id(
+        self, seed: str, seed_id: str | None
+    ) -> str | None:
+        """Translate an RFC 5322 Message-ID seed into Mail's internal id.
+
+        Read tools (#148) emit the bracketless RFC id as ``id`` on the
+        IMAP path; passing that value to ``create_draft(reply_to=...)``
+        used to fail because the AppleScript ``whose id is`` clause
+        matches Mail's internal numeric id only. Mail's internal id is a
+        stringified long integer with no ``@``, so ``'@' in seed_id`` is
+        an unambiguous discriminator. (#205)
+
+        Returns ``seed_id`` unchanged for the ``new`` seed, for empty
+        seeds, or for non-RFC ids. Raises ``MailMessageNotFoundError``
+        when an RFC id is passed but doesn't match any message.
+        """
+        if seed not in ("reply", "forward") or not seed_id or "@" not in seed_id:
+            return seed_id
+        resolved = self.find_message_by_message_id(seed_id)
+        if resolved is None:
+            raise MailMessageNotFoundError(
+                f"no message with message-id {seed_id!r}"
+            )
+        return resolved
+
     def create_draft(
         self,
         *,
@@ -3428,8 +3460,12 @@ class AppleMailConnector:
 
         Args:
             seed: ``"new"``, ``"reply"``, or ``"forward"``.
-            seed_id: Mail's internal id of the message to reply/forward.
-                Required when ``seed != "new"``.
+            seed_id: Identifier of the message to reply/forward. Accepts
+                either Mail's internal numeric id OR an RFC 5322
+                Message-ID (with or without angle brackets). The latter
+                is what read tools (``search_messages`` / ``get_messages``)
+                emit as ``id`` on the IMAP path (#148), so callers can
+                forward those ids verbatim. Required when ``seed != "new"``.
             to/cc/bcc: Recipient lists. For reply/forward, ``None`` keeps
                 Mail's auto-derived recipients; an empty list explicitly
                 clears that group; a populated list replaces.
@@ -3467,6 +3503,11 @@ class AppleMailConnector:
                 raise ValueError("'to' is required when seed='new'")
             if not subject:
                 raise ValueError("'subject' is required when seed='new'")
+
+        # If the caller handed us an RFC 5322 Message-ID (the form read
+        # tools emit on the IMAP path per #148), resolve to Mail's
+        # internal id before the `whose id is` lookup below. (#205)
+        seed_id = self._maybe_resolve_rfc_seed_id(seed, seed_id)
 
         # Escape user inputs.
         body_safe = escape_applescript_string(sanitize_input(body))

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -2360,12 +2360,15 @@ async def create_draft(
     it for later or send it now.
 
     Args:
-        reply_to: Mail.app id of a message to reply to. Mutually exclusive
-            with ``forward_of``. When set, ``to``/``cc`` recipients and
-            ``subject`` are auto-derived from the original (override by
-            passing them explicitly).
-        forward_of: Mail.app id of a message to forward. Mutually exclusive
-            with ``reply_to``. ``to`` is required (recipient of the forward).
+        reply_to: Id of a message to reply to. Accepts either Mail.app's
+            internal numeric id or an RFC 5322 Message-ID — pass the ``id``
+            field from any ``search_messages`` / ``get_messages`` row
+            verbatim. Mutually exclusive with ``forward_of``. When set,
+            ``to``/``cc`` recipients and ``subject`` are auto-derived from
+            the original (override by passing them explicitly).
+        forward_of: Id of a message to forward. Accepts the same id forms
+            as ``reply_to``. Mutually exclusive with ``reply_to``. ``to``
+            is required (recipient of the forward).
         to/cc/bcc: Recipient lists. For reply/forward, ``None`` keeps the
             auto-derived recipients; ``[]`` explicitly clears that group;
             a populated list replaces.

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -4728,6 +4728,34 @@ class TestFindMessageByMessageId:
         script = mock_run.call_args[0][0]
         assert "whose message id is" in script
 
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_wraps_brackets_for_bracketless_input(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Read tools (#148) emit RFC ids without angle brackets, but
+        Mail.app stores `message id` with brackets per RFC 5322. The
+        resolver wraps the brackets so callers can pass either form. (#205)
+        """
+        mock_run.return_value = "NOT_FOUND"
+        connector.find_message_by_message_id("abc@example.com")
+        script = mock_run.call_args[0][0]
+        # The AppleScript must search for the bracketed form even though
+        # the caller passed the bracketless form.
+        assert 'whose message id is "<abc@example.com>"' in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_does_not_double_wrap_already_bracketed_input(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Existing callers (e.g. update_draft passing In-Reply-To)
+        already include brackets; the wrapping must be idempotent. (#205)
+        """
+        mock_run.return_value = "NOT_FOUND"
+        connector.find_message_by_message_id("<abc@example.com>")
+        script = mock_run.call_args[0][0]
+        assert 'whose message id is "<abc@example.com>"' in script
+        assert "<<" not in script
+
 
 class TestGetDraftState:
     """Tests for AppleMailConnector.get_draft_state."""
@@ -5179,6 +5207,99 @@ class TestCreateDraft:
             connector.create_draft(
                 seed="reply", seed_id="999999", body="x"
             )
+
+    # ------------------------------------------------------------------
+    # RFC 5322 Message-ID seed_id support (#205)
+    # ------------------------------------------------------------------
+
+    @patch.object(AppleMailConnector, "find_message_by_message_id")
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_reply_resolves_rfc_message_id_seed(
+        self,
+        mock_run: MagicMock,
+        mock_resolve: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """Read tools (#148) emit RFC ids on the IMAP path. create_draft
+        must resolve them to Mail's internal id before building the
+        `whose id is` AppleScript clause. (#205)
+        """
+        mock_resolve.return_value = "160989"
+        mock_run.return_value = "1"
+        connector.create_draft(
+            seed="reply",
+            seed_id="abc-123@example.com",  # RFC form (contains '@')
+            body="thanks",
+        )
+        mock_resolve.assert_called_once_with("abc-123@example.com")
+        script = mock_run.call_args[0][0]
+        # AppleScript looks up by Mail's internal id, not the RFC id.
+        assert 'whose id is "160989"' in script
+        assert "abc-123@example.com" not in script
+
+    @patch.object(AppleMailConnector, "find_message_by_message_id")
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_forward_resolves_rfc_message_id_seed(
+        self,
+        mock_run: MagicMock,
+        mock_resolve: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """Same RFC-id resolution applies to the forward branch. (#205)"""
+        mock_resolve.return_value = "160989"
+        mock_run.return_value = "1"
+        connector.create_draft(
+            seed="forward",
+            seed_id="abc-123@example.com",
+            to=["x@example.com"],
+            body="fyi",
+        )
+        mock_resolve.assert_called_once_with("abc-123@example.com")
+        script = mock_run.call_args[0][0]
+        assert 'whose id is "160989"' in script
+
+    @patch.object(AppleMailConnector, "find_message_by_message_id")
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_internal_numeric_seed_id_skips_resolver(
+        self,
+        mock_run: MagicMock,
+        mock_resolve: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """Existing callers passing Mail's internal numeric id (no '@')
+        must keep working without a resolver round-trip. (#205)
+        """
+        mock_run.return_value = "1"
+        connector.create_draft(
+            seed="reply",
+            seed_id="160989",  # internal id form, no '@'
+            body="thanks",
+        )
+        mock_resolve.assert_not_called()
+        script = mock_run.call_args[0][0]
+        assert 'whose id is "160989"' in script
+
+    @patch.object(AppleMailConnector, "find_message_by_message_id")
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_unresolvable_rfc_seed_raises_message_not_found(
+        self,
+        mock_run: MagicMock,
+        mock_resolve: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """When the RFC id doesn't match any message, surface the same
+        MailMessageNotFoundError the AppleScript SEED_NOT_FOUND path
+        produces — caller can't tell the difference. (#205)
+        """
+        mock_resolve.return_value = None
+        with pytest.raises(MailMessageNotFoundError):
+            connector.create_draft(
+                seed="reply",
+                seed_id="missing@example.com",
+                body="x",
+            )
+        # AppleScript should not run if we can't resolve the seed.
+        mock_run.assert_not_called()
 
 
 class TestExtractDraftAttachments:


### PR DESCRIPTION
## Summary

- `create_draft(reply_to=<id>)` / `create_draft(forward_of=<id>)` now accept the bracketless RFC 5322 Message-ID that read tools emit on the IMAP path (per #148), in addition to Mail's internal numeric id.
- Resolution happens transparently in `mail_connector.create_draft` via a new private `_maybe_resolve_rfc_seed_id` helper that delegates to the existing `find_message_by_message_id` resolver. Discriminator: `'@' in seed_id` (Mail's internal id is a stringified long integer with no `@`).
- `find_message_by_message_id` is now bracket-tolerant — it wraps brackets if missing before the AppleScript `whose message id is` lookup, so callers can pass either form. Pre-existing `update_draft` callers (which pass raw In-Reply-To values with brackets) are unaffected.
- No schema change. Existing callers passing internal numeric ids work unchanged.

## Background

Reported by @fmasi in #205 with a precise call-path trace and the right primitive (`find_message_by_message_id`) identified. The fix matches their analysis. Without this, agents that read with `search_messages` and forwarded the `id` field into `create_draft(reply_to=...)` got silent `message_not_found` failures on IMAP-backed rows (Gmail, iCloud, etc.).

`get_messages` already worked for the same id because it routes through the IMAP fast path with account+mailbox hints — which is why fmasi noticed the asymmetry.

## Out of scope (filed for later)

A similar dormant bug exists in `auto_template_vars` → `get_message` AppleScript fallback when a caller renders a template with an RFC seed_id and no account/mailbox hints (`server.py:2179`). Narrower blast radius (gated on `template_name=`), so deferred to a follow-up issue if a user hits it.

## Test plan

- [x] 5 new unit tests in `TestCreateDraft` and `TestFindMessageByMessageId`
- [x] `uv run pytest tests/unit/test_mail_connector.py::TestCreateDraft tests/unit/test_mail_connector.py::TestFindMessageByMessageId -v` — 35 passed
- [x] `make check-all` — all green (including CC gate: `create_draft` stays at allowlist max 25)
- [ ] Manual verification via fmasi's reproduction: `row = search_messages(account="iCloud", mailbox="INBOX", ...)[0]; create_draft(reply_to=row["id"], body="...")` (no iCloud account in our setup; relying on the unit-test behavioral contract)

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)