### PR TITLE
fix(#199): delete_messages — resolve Trash before SELECT to avoid LIST-deselect

### DIFF
--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -1053,8 +1053,12 @@ class ImapConnector:
         ]
 
         with self._session() as client:
-            client.select_folder(source_mailbox, readonly=False)
-
+            # #199 / #198: do all LIST traffic in AUTHENTICATED state.
+            # Some servers (Exchange Online, older Dovecot) issue an
+            # implicit CLOSE when LIST runs while a mailbox is SELECTED,
+            # causing the subsequent SEARCH to fail with "No mailbox
+            # selected". Resolve capabilities + Trash before SELECT so
+            # all SELECT-state work happens in one uninterrupted window.
             has_move = self._has_capability(client, b"MOVE")
             has_uidplus = self._has_capability(client, b"UIDPLUS")
             if not has_move and not has_uidplus:
@@ -1074,6 +1078,8 @@ class ImapConnector:
                     f"{list(self._CONVENTIONAL_TRASH_NAMES)} were "
                     f"present in the folder listing"
                 )
+
+            client.select_folder(source_mailbox, readonly=False)
 
             uids: list[int] = []
             for bracketed in bracketed_ids:

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -1672,6 +1672,34 @@ class TestImapDeleteMessages:
         client.move.assert_not_called()
 
     @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_delete_resolves_trash_before_selecting_source(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """All LIST traffic must run before SELECT. Some servers
+        (Exchange Online, older Dovecot) implicitly CLOSE the selected
+        mailbox when LIST runs while SELECTED, which would make the
+        subsequent SEARCH fail with "No mailbox selected" and silently
+        kick the operation onto the slower AppleScript fallback. (#199)
+        """
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.capabilities.return_value = {b"MOVE"}
+        client.list_folders.return_value = self._trash_listing()
+        client.search.return_value = [1]
+
+        ImapConnector("h", 993, "u@e.com", "pw").delete_messages(
+            ["a@x"], source_mailbox="INBOX",
+        )
+
+        call_names = [c[0] for c in client.method_calls]
+        list_idx = call_names.index("list_folders")
+        select_idx = call_names.index("select_folder")
+        assert list_idx < select_idx, (
+            f"list_folders (call #{list_idx}) must run before "
+            f"select_folder (call #{select_idx}) — see #199"
+        )
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
     def test_delete_strips_and_re_adds_brackets_for_search(
         self, mock_cls: MagicMock
     ) -> None:


### PR DESCRIPTION
## Summary

- Reorder `ImapConnector.delete_messages`: capability check → trash resolve → SELECT → SEARCH → MOVE / COPY+STORE+EXPUNGE. All LIST traffic now finishes in AUTHENTICATED state before SELECT begins.
- Add one regression test (`test_delete_resolves_trash_before_selecting_source`) that asserts the relative ordering via `client.method_calls` so a future refactor can't reintroduce the same window.

## Background

RFC 3501 §6.3.8 lets LIST run in either Authenticated or Selected state without mutating Selected state. Most servers honor that; Exchange Online and some older Dovecot deployments issue an implicit CLOSE on certain LIST transitions, deselecting the mailbox and breaking the subsequent SEARCH with `IMAPClientError: "No mailbox selected"`.

The failure was safe — `IMAPClientError ∈ _IMAP_FALLBACK_EXCS` → AppleScript fallback — so users on affected servers saw degraded perf on delete operations, not data loss. Surfaced by the feature-dev:code-reviewer agent during the v0.8.0 release review (#198).

Capability check also moves to the top of the function (it's a cached local lookup, free, and an early raise avoids wasted LIST round trips on the rare servers advertising neither MOVE nor UIDPLUS).

No behavior change for spec-compliant servers.

## Test plan

- [x] `uv run pytest tests/unit/test_imap_connector.py::TestImapDeleteMessages -v` — 13 passed (12 existing + 1 new ordering test)
- [x] `make check-all` — all green
- [ ] Manual: no Exchange Online / pre-Dovecot-2.3 available in test infra. Real-world fix is observable as "delete operations stop falling back to AppleScript" on affected servers.

Worth a CHANGELOG entry on v0.8.1 release (Fixed section): "Reordered `delete_messages` IMAP operations to keep LIST in AUTHENTICATED state — fixes silent AppleScript fallback on Exchange Online and older Dovecot servers."

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)