### PR TITLE
refactor(#193): reduce AppleMailConnector.create_draft from CC 25 → 13

### DIFF
--- a/docs/guides/COMPLEXITY.md
+++ b/docs/guides/COMPLEXITY.md
@@ -22,15 +22,11 @@ This mechanism replaced an earlier silent-pass bug (#174): the script ran `radon
 
 The functions below sit above CC 10 intentionally. When touching them, prefer adding one more gate over restructuring. If a change would push any of them above 20, extract a helper first.
 
-> **Allowlisted above-threshold functions:** One function currently exceeds CC 20. It's pinned in the allowlist at its current ceiling pending a dedicated refactor PR:
->
-> - [`mail_connector.py::AppleMailConnector.create_draft`](../../src/apple_mail_mcp/mail_connector.py) (CC 25) — see #193.
-
 | File | Function | CC | Why it's complex |
 |---|---|---|---|
 | [`server.py`](../../src/apple_mail_mcp/server.py) | `create_draft` | 19 | Unified compose / reply / reply_all / forward authoring loop with `send_now` opt-in; subsumes the four removed v0.6 send tools. Dropped from CC 36 → 19 in #191 by extracting `_resolve_create_draft_seed`, `_maybe_apply_template`, `_validate_fresh_seed_fields`, `_run_send_now_gates`, and `_persist_create_draft_seed`. |
 | [`server.py`](../../src/apple_mail_mcp/server.py) | `update_draft` | 18 | Same gate stack as `create_draft` plus the existing-draft lookup, three-tier subject/body resolution (caller > template > state), and delete-and-recreate semantics. Dropped from CC 34 → 18 in #192 by reusing `_run_send_now_gates` and `_persist_draft_seed` (both extracted in #191) plus adding `_resolve_update_subject_body` and `_merge_draft_recipients`. |
-| [`mail_connector.py`](../../src/apple_mail_mcp/mail_connector.py) | `AppleMailConnector.create_draft` | 25 | Per-`seed_kind` AppleScript dispatch (compose vs reply/reply_all/forward), template rendering branch, recipient list builders for to/cc/bcc, then save-vs-send tail. **Allowlisted at 25 — refactor candidate.** |
+| [`mail_connector.py`](../../src/apple_mail_mcp/mail_connector.py) | `AppleMailConnector.create_draft` | 13 | Per-`seed_kind` AppleScript dispatch (compose vs reply/reply_all/forward), recipient list builders for to/cc/bcc, then save-vs-send tail. Dropped from 25 → 13 in #193 by extracting `_validate_create_draft_args`, `_build_attachment_block`, and `_build_creation_block`. |
 | [`imap_connector.py`](../../src/apple_mail_mcp/imap_connector.py) | `_thread_via_xgm_per_mailbox` | 16 | Tier 1.5 (#125): anchor lookup with INBOX→Sent fallback, THRID FETCH, then per-folder iteration with \\Noselect / select-failure / fetch-failure handling. Dropped from 21 → 16 in #194/#195 by extracting the shared `_merge_envelope_fetch_into` helper that Tier 1.5 and Tier 2 both used inline. |
 | [`imap_connector.py`](../../src/apple_mail_mcp/imap_connector.py) | `_thread_via_imap_thread` | 16 | Tier 2 (#123): per-mailbox SELECT + narrow-search + THREAD + cluster-walk + FETCH, with rejection branches at each step. Dropped from 21 → 16 in #194/#195 by extracting the shared `_merge_envelope_fetch_into` helper. |
 | [`mail_connector.py`](../../src/apple_mail_mcp/mail_connector.py) | `AppleMailConnector.update_message` | 17 | Patch semantics: each optional field (`read_status`, `flag_color`, `destination_mailbox`, `flagged`, `source_mailbox`) adds a branch; mutation-order rules add a few more. Dropped from 21 → 17 in #174 by extracting `_try_imap_fast_paths` and `_build_flag_actions`. |
@@ -53,7 +49,7 @@ The functions below sit above CC 10 intentionally. When touching them, prefer ad
 | [`mail_connector.py`](../../src/apple_mail_mcp/mail_connector.py) | `_collect_thread_applescript` | 11 | AppleScript-side BFS fallback when IMAP thread tiers don't apply. |
 | [`imap_connector.py`](../../src/apple_mail_mcp/imap_connector.py) | `ImapConnector.get_message` | 11 | `headers_only` vs full-body fetch, search-by-bracketed-msgid path, error mapping. |
 
-Accepted because: each is a sequence of orthogonal gates or optional-parameter branches, not tangled logic. They read top-to-bottom and each branch has a clear exit. The one remaining allowlisted entry is a documented exception pending refactor — see #193.
+Accepted because: each is a sequence of orthogonal gates or optional-parameter branches, not tangled logic. They read top-to-bottom and each branch has a clear exit. The complexity allowlist is currently empty — no function exceeds CC 20.
 
 ## Adding a new documented exception
 

--- a/scripts/check_complexity.sh
+++ b/scripts/check_complexity.sh
@@ -49,9 +49,7 @@ THRESHOLD = $THRESHOLD
 # Lowering an entry (after a successful refactor) is encouraged — it's
 # a one-way ratchet. NEVER raise without updating COMPLEXITY.md and
 # justifying the structural reason in the PR.
-ALLOWLIST = {
-    ('mail_connector.py', 'AppleMailConnector.create_draft'): 25,
-}
+ALLOWLIST: dict[tuple[str, str], int] = {}
 
 data = json.load(sys.stdin)
 new_violations = []

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -3441,6 +3441,96 @@ class AppleMailConnector:
             )
         return resolved
 
+    @staticmethod
+    def _validate_create_draft_args(
+        seed: str,
+        seed_id: str | None,
+        to: list[str] | None,
+        subject: str | None,
+    ) -> None:
+        """Validate the per-seed argument requirements of create_draft.
+        Raises ValueError with a specific message on the first violation.
+        (#193)
+        """
+        if seed not in ("new", "reply", "forward"):
+            raise ValueError(
+                f"seed must be 'new', 'reply', or 'forward'; got {seed!r}"
+            )
+        if seed in ("reply", "forward"):
+            if not seed_id:
+                raise ValueError(f"seed_id is required for seed={seed!r}")
+        else:  # seed == "new"
+            if not to:
+                raise ValueError("'to' is required when seed='new'")
+            if not subject:
+                raise ValueError("'subject' is required when seed='new'")
+
+    @staticmethod
+    def _build_attachment_block(
+        attachment_paths: list[Path] | None,
+    ) -> str:
+        """AppleScript fragment that attaches files to ``theMessage``.
+        Returns ``""`` when ``attachment_paths`` is None or empty.
+        Raises ``FileNotFoundError`` on the first non-existent path. (#193)
+        """
+        if not attachment_paths:
+            return ""
+        for p in attachment_paths:
+            if not Path(p).is_file():
+                raise FileNotFoundError(f"attachment not found: {p}")
+        paths_safe = ", ".join(
+            f'"{escape_applescript_string(str(Path(p).resolve()))}"'
+            for p in attachment_paths
+        )
+        return f"""
+            repeat with apath in {{{paths_safe}}}
+                tell theMessage to make new attachment with properties {{file name:(POSIX file apath)}} at after last paragraph
+            end repeat
+        """
+
+    @staticmethod
+    def _build_creation_block(
+        seed: str,
+        seed_id_safe: str | None,
+        reply_all: bool,
+        subject_safe: str | None,
+        body_safe: str,
+    ) -> str:
+        """Per-seed AppleScript fragment that produces ``theMessage``.
+
+        The reply/forward branches share the cross-account ``whose id
+        is "{seed_id_safe}"`` lookup pattern, differing only in the
+        Mail.app verb (``reply`` / ``reply to all`` / ``forward``).
+        ``seed_id_safe`` is expected to be Mail's internal id —
+        callers route RFC 5322 ids through
+        ``_maybe_resolve_rfc_seed_id`` first (#205). (#193)
+        """
+        if seed == "new":
+            return (
+                f'set theMessage to make new outgoing message with properties '
+                f'{{subject:"{subject_safe}", content:"{body_safe}", visible:false}}'
+            )
+        if seed == "reply":
+            verb = "reply to all" if reply_all else "reply"
+        else:  # forward
+            verb = "forward"
+        return f"""
+            set origMsg to missing value
+            repeat with acc in accounts
+                try
+                    repeat with mb in mailboxes of acc
+                        try
+                            set origMsg to first message of mb whose id is "{seed_id_safe}"
+                            exit repeat
+                        end try
+                    end repeat
+                end try
+                if origMsg is not missing value then exit repeat
+            end repeat
+            if origMsg is missing value then error "SEED_NOT_FOUND"
+            set theMessage to {verb} origMsg opening window false
+        """
+
     def create_draft(
         self,
         *,
@@ -3493,16 +3583,7 @@ class AppleMailConnector:
             MailMessageNotFoundError: ``seed_id`` not found in any mailbox.
             MailAppleScriptError: AppleScript failure.
         """
-        if seed not in ("new", "reply", "forward"):
-            raise ValueError(f"seed must be 'new', 'reply', or 'forward'; got {seed!r}")
-        if seed in ("reply", "forward"):
-            if not seed_id:
-                raise ValueError(f"seed_id is required for seed={seed!r}")
-        else:  # seed == "new"
-            if not to:
-                raise ValueError("'to' is required when seed='new'")
-            if not subject:
-                raise ValueError("'subject' is required when seed='new'")
+        self._validate_create_draft_args(seed, seed_id, to, subject)
 
         # If the caller handed us an RFC 5322 Message-ID (the form read
         # tools emit on the IMAP path per #148), resolve to Mail's
@@ -3553,22 +3634,7 @@ class AppleMailConnector:
         cc_block = _recipient_block("cc", cc)
         bcc_block = _recipient_block("bcc", bcc)
 
-        # Attachment block.
-        attachment_block = ""
-        if attachment_paths:
-            for p in attachment_paths:
-                pp = Path(p)
-                if not pp.is_file():
-                    raise FileNotFoundError(f"attachment not found: {pp}")
-            paths_safe = ", ".join(
-                f'"{escape_applescript_string(str(Path(p).resolve()))}"'
-                for p in attachment_paths
-            )
-            attachment_block = f"""
-                repeat with apath in {{{paths_safe}}}
-                    tell theMessage to make new attachment with properties {{file name:(POSIX file apath)}} at after last paragraph
-                end repeat
-            """
+        attachment_block = self._build_attachment_block(attachment_paths)
 
         # Subject override (reply/forward only — for new, subject is set
         # via `make new outgoing message ... properties`).
@@ -3593,49 +3659,9 @@ class AppleMailConnector:
         else:
             body_block = ""
 
-        # Seed-specific creation block.
-        if seed == "new":
-            creation_block = (
-                f'set theMessage to make new outgoing message with properties '
-                f'{{subject:"{subject_safe}", content:"{body_safe}", visible:false}}'
-            )
-        elif seed == "reply":
-            verb = "reply to all" if reply_all else "reply"
-            # Look up seed across all accounts/mailboxes; reuse the existing
-            # message-id lookup pattern.
-            creation_block = f"""
-                set origMsg to missing value
-                repeat with acc in accounts
-                    try
-                        repeat with mb in mailboxes of acc
-                            try
-                                set origMsg to first message of mb whose id is "{seed_id_safe}"
-                                exit repeat
-                            end try
-                        end repeat
-                    end try
-                    if origMsg is not missing value then exit repeat
-                end repeat
-                if origMsg is missing value then error "SEED_NOT_FOUND"
-                set theMessage to {verb} origMsg opening window false
-            """
-        else:  # forward
-            creation_block = f"""
-                set origMsg to missing value
-                repeat with acc in accounts
-                    try
-                        repeat with mb in mailboxes of acc
-                            try
-                                set origMsg to first message of mb whose id is "{seed_id_safe}"
-                                exit repeat
-                            end try
-                        end repeat
-                    end try
-                    if origMsg is not missing value then exit repeat
-                end repeat
-                if origMsg is missing value then error "SEED_NOT_FOUND"
-                set theMessage to forward origMsg opening window false
-            """
+        creation_block = self._build_creation_block(
+            seed, seed_id_safe, reply_all, subject_safe, body_safe,
+        )
 
         # Terminal block: save (with id-bridging diff) or send.
         if send_now:


### PR DESCRIPTION
## Summary

- Three focused extractions from `AppleMailConnector.create_draft`:
  - `_validate_create_draft_args` — encapsulates the 5 ValueError raises (invalid seed, missing seed_id for reply/forward, missing to/subject for new).
  - `_build_attachment_block` — file-existence check + AppleScript fragment assembly (raises FileNotFoundError on missing paths).
  - `_build_creation_block` — per-seed AppleScript fragment; folds the previously-duplicated reply and forward templates into one shared template with a `verb` selector.
- `create_draft` CC: 25 → 13.
- **Complexity allowlist is now empty** — was 4 entries at the start of v0.8.1 (`create_draft` server + connector, `_thread_via_xgm_per_mailbox`, `_thread_via_imap_thread`). The gate is fully back to "no exceptions" with no function above CC 20.
- COMPLEXITY.md's "Allowlisted above-threshold functions" callout removed.

## CC after

| Function | Before | After |
|---|---|---|
| `AppleMailConnector.create_draft` | 25 (allowlist) | 13 |
| `_validate_create_draft_args` | n/a | 6 (new) |
| `_build_attachment_block` | n/a | 5 (new) |
| `_build_creation_block` | n/a | 4 (new) |

## Test plan

- [x] `uv run pytest tests/unit/test_mail_connector.py::TestCreateDraft -v` — 27 passed (unchanged)
- [x] `uv run radon cc src/apple_mail_mcp/mail_connector.py -s` — confirms targets above
- [x] `make check-all` — all green; complexity gate now reports empty allowlist

Pure mechanical refactor — same AppleScript emitted, same raises, same return shape, same SEED_NOT_FOUND mapping (still routed through `_maybe_resolve_rfc_seed_id` from #205). No new tests needed; existing TestCreateDraft tests exercise each extraction surface.

After landing: v0.8.1 milestone has zero open issues — ready to cut the release.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)