### PR TITLE
fix(#227): wrap AppleScript with `with timeout of N` so connector timeout actually works

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -99,7 +99,7 @@ _RULE_OPERATOR_MAP = {
 }
 
 
-def _wrap_as_json_script(body: str) -> str:
+def _wrap_as_json_script(body: str, *, timeout: int) -> str:
     """Wrap a tell-block body with ASObjC imports and an NSJSONSerialization return.
 
     The `body` must:
@@ -115,11 +115,23 @@ def _wrap_as_json_script(body: str) -> str:
 
     The wrapper:
       - Prepends `use framework "Foundation"` and `use scripting additions`.
+      - Wraps the body in `with timeout of {timeout} seconds ... end timeout`
+        so Mail's default 60 s AppleEvent timeout does not fire before the
+        connector's subprocess timeout — see issue #227. Without this,
+        per-message property fetches on Exchange/EWS mailboxes (server-
+        bound, not local) trip `AppleEvent timed out (-1712)` and leave the
+        scripting bridge in `Connection is invalid (-609)` for ~30 s.
       - After the tell block, serializes `resultData` via NSJSONSerialization
-        and returns the resulting NSString as text.
+        and returns the resulting NSString as text. The serializer runs in
+        the ASObjC bridge (no AppleEvent) so it is intentionally OUTSIDE the
+        timeout block — but `resultData` is still visible because AppleScript
+        `with timeout` is a control construct, not a scope.
 
     Args:
         body: AppleScript tell-block source setting `resultData`.
+        timeout: AppleEvent timeout in seconds for the wrapped tell block.
+            Callers should pass ``self.timeout`` so the in-script timeout
+            matches the subprocess-level kill timer.
 
     Returns:
         Full AppleScript source ready for osascript.
@@ -128,7 +140,9 @@ def _wrap_as_json_script(body: str) -> str:
         'use framework "Foundation"\n'
         "use scripting additions\n"
         "\n"
+        f"with timeout of {timeout} seconds\n"
         f"{body}\n"
+        "end timeout\n"
         "\n"
         "set jsonData to (current application's NSJSONSerialization's "
         "dataWithJSONObject:resultData options:0 |error|:(missing value))\n"
@@ -428,7 +442,7 @@ class AppleMailConnector:
         end tell
         """
 
-        script = _wrap_as_json_script(tell_body)
+        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
         result = self._run_applescript(script)
         accounts = cast(list[dict[str, Any]], parse_applescript_json(result))
         # Normalize empty-string full_name to None so callers don't have
@@ -503,7 +517,7 @@ class AppleMailConnector:
         end tell
         """
 
-        script = _wrap_as_json_script(tell_body)
+        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
@@ -871,7 +885,7 @@ class AppleMailConnector:
             set resultData to {{|run_script_set|:(run script of r is not missing value), |play_sound_set|:(play sound of r is not missing value), |redirect_set|:((redirect message of r) is not ""), |forward_text_set|:((forward text of r) is not ""), |reply_text_set|:((reply text of r) is not ""), |highlight_text|:(highlight text using color of r), |color_message|:((color message of r) as text)}}
         end tell
         '''
-        script = _wrap_as_json_script(tell_body)
+        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
         raw = self._run_applescript(script)
         parsed = cast(dict[str, Any], parse_applescript_json(raw))
 
@@ -957,7 +971,7 @@ class AppleMailConnector:
         end tell
         '''
 
-        script = _wrap_as_json_script(tell_body)
+        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
@@ -996,7 +1010,7 @@ class AppleMailConnector:
             set resultData to {{|host|:(server name of acctRef), |port|:(port of acctRef), |user_name|:(user name of acctRef), |email_addresses|:acctEmails}}
         end tell
         '''
-        script = _wrap_as_json_script(tell_body)
+        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
         raw = self._run_applescript(script)
         parsed = cast(dict[str, Any], parse_applescript_json(raw))
         email_addresses = cast(list[str], parsed.get("email_addresses") or [])
@@ -1361,7 +1375,7 @@ class AppleMailConnector:
         end tell
         '''
 
-        script = _wrap_as_json_script(tell_body)
+        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
@@ -1516,7 +1530,7 @@ class AppleMailConnector:
         end tell
         '''
 
-        script = _wrap_as_json_script(tell_body)
+        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
         result = self._run_applescript(script)
         return cast(dict[str, Any], parse_applescript_json(result))
 
@@ -1723,7 +1737,7 @@ class AppleMailConnector:
         end tell
         '''
 
-        script = _wrap_as_json_script(tell_body)
+        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
@@ -2258,7 +2272,7 @@ class AppleMailConnector:
         end tell
         '''
 
-        anchor_script = _wrap_as_json_script(anchor_body)
+        anchor_script = _wrap_as_json_script(anchor_body, timeout=self.timeout)
         anchor_raw = self._run_applescript(anchor_script)
         raw = cast(dict[str, Any], parse_applescript_json(anchor_raw))
 
@@ -2317,7 +2331,7 @@ class AppleMailConnector:
         end tell
         '''
 
-        candidates_script = _wrap_as_json_script(candidates_body)
+        candidates_script = _wrap_as_json_script(candidates_body, timeout=self.timeout)
         candidates_raw = self._run_applescript(candidates_script)
         candidates = cast(
             list[dict[str, Any]],
@@ -3186,7 +3200,7 @@ class AppleMailConnector:
         end tell
         """
 
-        script = _wrap_as_json_script(tell_body)
+        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
@@ -3407,7 +3421,7 @@ class AppleMailConnector:
         end tell
         """
 
-        script = _wrap_as_json_script(tell_body)
+        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
         raw = self._run_applescript(script)
         data = parse_applescript_json(raw)
         if not isinstance(data, dict) or not data.get("found"):

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -4527,27 +4527,90 @@ class TestWhoseIdQuoting:
 
 class TestWrapAsJsonScript:
     def test_wrapper_contains_framework_directive(self) -> None:
-        script = _wrap_as_json_script('tell application "Mail"\n    set resultData to {}\nend tell')
+        script = _wrap_as_json_script(
+            'tell application "Mail"\n    set resultData to {}\nend tell',
+            timeout=60,
+        )
         assert 'use framework "Foundation"' in script
         assert "use scripting additions" in script
 
     def test_wrapper_appends_json_serialization(self) -> None:
-        script = _wrap_as_json_script('tell application "Mail"\n    set resultData to {}\nend tell')
+        script = _wrap_as_json_script(
+            'tell application "Mail"\n    set resultData to {}\nend tell',
+            timeout=60,
+        )
         assert "NSJSONSerialization" in script
         assert "dataWithJSONObject:resultData" in script
 
     def test_wrapper_preserves_body(self) -> None:
         body = 'tell application "Mail"\n    set resultData to {name:"INBOX"}\nend tell'
-        script = _wrap_as_json_script(body)
+        script = _wrap_as_json_script(body, timeout=60)
         assert body in script
 
     def test_wrapper_orders_framework_before_body_before_epilogue(self) -> None:
         body = 'tell application "Mail"\n    set resultData to {name:"INBOX"}\nend tell'
-        script = _wrap_as_json_script(body)
+        script = _wrap_as_json_script(body, timeout=60)
         framework_idx = script.index('use framework "Foundation"')
         body_idx = script.index(body)
         epilogue_idx = script.index("NSJSONSerialization")
         assert framework_idx < body_idx < epilogue_idx
+
+    # Regression coverage for issue #227 — Mail's default AppleEvent timeout
+    # is 60 s, so without an explicit `with timeout` clause an Exchange/EWS
+    # iteration that takes 70 s raises `AppleEvent timed out (-1712)` no
+    # matter what subprocess timeout the connector was constructed with.
+
+    def test_wrapper_includes_with_timeout_clause(self) -> None:
+        body = 'tell application "Mail"\n    set resultData to {}\nend tell'
+        script = _wrap_as_json_script(body, timeout=180)
+        assert "with timeout of 180 seconds" in script
+        assert "end timeout" in script
+
+    def test_wrapper_timeout_brackets_the_tell_body(self) -> None:
+        """The tell block must be inside the with-timeout block — putting it
+        outside leaves the AppleEvent default of 60 s in force."""
+        body = 'tell application "Mail"\n    set resultData to {}\nend tell'
+        script = _wrap_as_json_script(body, timeout=180)
+        with_idx = script.index("with timeout of 180 seconds")
+        body_idx = script.index(body)
+        end_timeout_idx = script.index("end timeout")
+        assert with_idx < body_idx < end_timeout_idx
+
+    @pytest.mark.parametrize("timeout", [30, 60, 120, 300, 600])
+    def test_wrapper_emits_caller_supplied_timeout(self, timeout: int) -> None:
+        body = 'tell application "Mail"\n    set resultData to {}\nend tell'
+        script = _wrap_as_json_script(body, timeout=timeout)
+        assert f"with timeout of {timeout} seconds" in script
+
+
+class TestConnectorThreadsTimeoutIntoScripts:
+    """Issue #227 — AppleMailConnector(timeout=N) must propagate N into the
+    AppleScript `with timeout` clause, not just into subprocess.run."""
+
+    @patch("subprocess.run")
+    def test_list_accounts_emits_connector_timeout(
+        self, mock_run: MagicMock
+    ) -> None:
+        connector = AppleMailConnector(timeout=240)
+        mock_run.return_value = MagicMock(returncode=0, stdout="[]", stderr="")
+        connector.list_accounts()
+        script = mock_run.call_args.kwargs.get("input") or mock_run.call_args.args[0]
+        assert "with timeout of 240 seconds" in script
+
+    @patch("subprocess.run")
+    def test_search_messages_applescript_emits_connector_timeout(
+        self, mock_run: MagicMock
+    ) -> None:
+        connector = AppleMailConnector(timeout=300)
+        mock_run.return_value = MagicMock(returncode=0, stdout="[]", stderr="")
+        connector._search_messages_applescript(
+            account="Exchange",
+            mailbox="Inbox",
+            sender_contains="ofca",
+            limit=10,
+        )
+        script = mock_run.call_args.kwargs.get("input") or mock_run.call_args.args[0]
+        assert "with timeout of 300 seconds" in script
 
 
 class TestAutoTemplateVars:


### PR DESCRIPTION
Closes #227.

## What changed

`_wrap_as_json_script()` now takes a required `timeout: int` keyword-only
argument and wraps the body in `with timeout of {timeout} seconds ...
end timeout`. All 12 call sites inside `AppleMailConnector` pass
`timeout=self.timeout`, so the in-script AppleEvent timeout matches
the subprocess-level kill timer.

Without this clause Mail's default 60 s AppleEvent timeout fires
*before* whatever subprocess timeout the connector was configured
with, causing `AppleEvent timed out (-1712)` on Exchange/EWS accounts
even when the caller asked for `timeout=300`. The follow-on
`Connection is invalid (-609)` then makes the next ~30 s of calls
unusable until Mail recovers.

## How tested

TDD: 9 new unit tests in `TestWrapAsJsonScript` and a new
`TestConnectorThreadsTimeoutIntoScripts` class. All 13 cases were
RED before the fix, GREEN after.

```
$ make check-all
ruff: All checks passed!
mypy: Success: no issues found in 11 source files
pytest: 1018 passed, 44 skipped, 25 deselected in 2.43s
complexity: All functions ≤ CC 20
coverage: 92.09% (≥90% required)
All checks passed.
```

The 4 pre-existing wrap tests were updated to pass the new required
kwarg.

## Why not also add `APPLE_MAIL_MCP_TIMEOUT` env var

The bug is that the existing `timeout` parameter doesn't work at all
for AppleEvent-bound work. That's a complete fix on its own and
worth keeping isolated for review. A follow-up issue for the env-var
configuration can land separately if desired — happy to file it.

## Scope

- `src/apple_mail_mcp/mail_connector.py`: `_wrap_as_json_script` sig +
  body change; 12 call sites updated to pass `timeout=self.timeout`.
- `tests/unit/test_mail_connector.py`: 4 existing tests adjusted to
  the new sig; 9 new tests covering the timeout-emission contract.
- No public API change. `AppleMailConnector(timeout=N)` already
  existed; this PR makes it actually take effect.

## Real-world repro that motivated this

Filed in the issue. Briefly: extracting OFCA email templates from an
Exchange mailbox (`Allen Pan(Eastech)`), 102 messages in the DNC
folder, sender_contains/subject_contains filters. Every search hit
the 60 s wall and eventually killed the MCP server with
`Connection closed`. Post-fix, the same workflow completes.
