### PR TITLE
fix: query both bare and bracketed forms in find_message_by_message_id (#205 follow-up)

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -3253,12 +3253,15 @@ class AppleMailConnector:
 
         Args:
             rfc5322_message_id: e.g. ``<calendar-abc123@google.com>`` or
-                ``calendar-abc123@google.com``. Angle brackets are added
-                if missing — AppleScript's ``message id`` property stores
-                the value verbatim as it appears on the wire (bracketed
-                per RFC 5322), so the lookup needs the wrapped form. Read
-                tools strip the brackets before emission, so callers
-                forwarding read-tool ids can hand us either form.
+                ``calendar-abc123@google.com``. Brackets are stripped
+                from the input; the AppleScript ``whose`` clause then
+                queries for both the bare and bracketed forms in one
+                pass. Mail.app's ``message id`` property storage
+                normalization is not uniform — IMAP-backed accounts
+                (iCloud, Gmail) store the value bare, while other paths
+                may store with angle brackets per RFC 5322. Querying
+                both forms in a single clause is robust to either
+                convention and matches in one round-trip.
 
         Returns:
             Mail's internal numeric id (as a string) of the first
@@ -3267,10 +3270,12 @@ class AppleMailConnector:
         """
         if not rfc5322_message_id:
             return None
-        normalized = rfc5322_message_id
-        if not (normalized.startswith("<") and normalized.endswith(">")):
-            normalized = f"<{normalized}>"
-        safe = escape_applescript_string(sanitize_input(normalized))
+        bare = rfc5322_message_id
+        if bare.startswith("<") and bare.endswith(">"):
+            bare = bare[1:-1]
+        bracketed = f"<{bare}>"
+        safe_bare = escape_applescript_string(sanitize_input(bare))
+        safe_bracketed = escape_applescript_string(sanitize_input(bracketed))
 
         script = f"""
         tell application "Mail"
@@ -3279,7 +3284,7 @@ class AppleMailConnector:
                 try
                     repeat with mb in mailboxes of acc
                         try
-                            set m to first message of mb whose message id is "{safe}"
+                            set m to first message of mb whose (message id is "{safe_bare}" or message id is "{safe_bracketed}")
                             set foundId to (id of m as text)
                             exit repeat
                         end try

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -1414,3 +1414,112 @@ class TestTemplateIntegration:
         assert rendered["subject"] == f"Re: {original_subject}"
         assert recipient_name in rendered["body"]
         assert today in rendered["body"]
+
+
+class TestFindMessageByMessageIdIntegration:
+    """Real-Mail.app round-trip for ``find_message_by_message_id``.
+
+    Unit tests mock ``_run_applescript`` and so cannot catch mismatches
+    between the form the AppleScript ``whose`` clause sends and the form
+    Mail.app's ``message id`` property actually stores. This integration
+    test asserts the round-trip works against real storage, with a
+    message picked from the test account's INBOX at runtime so the test
+    survives any specific Message-ID being deleted.
+    """
+
+    def test_find_by_bare_rfc_id_from_search_messages(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """``search_messages`` on the IMAP path emits the bare RFC
+        Message-ID in the ``id`` field (per #148). Passing that value
+        back through ``find_message_by_message_id`` must resolve to
+        Mail's internal id — the contract ``create_draft(reply_to=...)``
+        and ``create_draft(forward_of=...)`` rely on for #205.
+        """
+        rows = connector.search_messages(
+            account=test_account, mailbox="INBOX", limit=1
+        )
+        if not rows:
+            pytest.skip(f"{test_account} INBOX has no messages to test against")
+
+        rfc_id = rows[0].get("rfc_message_id") or rows[0].get("id")
+        assert rfc_id, "search_messages row missing rfc_message_id/id"
+        # Search results from the IMAP path are bare per #148; this test
+        # is specifically about that form.
+        if rfc_id.startswith("<") and rfc_id.endswith(">"):
+            pytest.skip(
+                "search_messages returned a bracketed id — "
+                "test_account is not on the IMAP path"
+            )
+
+        internal_id = connector.find_message_by_message_id(rfc_id)
+        assert internal_id is not None, (
+            f"find_message_by_message_id returned None for {rfc_id!r} "
+            f"despite the message being present in {test_account}/INBOX"
+        )
+        assert "@" not in internal_id, (
+            "expected Mail's internal numeric id, got something RFC-shaped"
+        )
+
+    def test_find_by_bracketed_rfc_id_matches_bare(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """Both bracketed and bracketless forms of the same RFC id must
+        resolve to the same internal id, so callers (e.g. update_draft
+        passing In-Reply-To with brackets, create_draft passing a bare
+        seed_id from search_messages) can hand us either form.
+        """
+        rows = connector.search_messages(
+            account=test_account, mailbox="INBOX", limit=1
+        )
+        if not rows:
+            pytest.skip(f"{test_account} INBOX has no messages to test against")
+
+        rfc_id = rows[0].get("rfc_message_id") or rows[0].get("id")
+        assert rfc_id, "search_messages row missing rfc_message_id/id"
+        bare = rfc_id[1:-1] if rfc_id.startswith("<") and rfc_id.endswith(">") else rfc_id
+        bracketed = f"<{bare}>"
+
+        by_bare = connector.find_message_by_message_id(bare)
+        by_bracketed = connector.find_message_by_message_id(bracketed)
+
+        assert by_bare is not None, f"bare {bare!r} did not match"
+        assert by_bracketed is not None, f"bracketed {bracketed!r} did not match"
+        assert by_bare == by_bracketed, (
+            f"bare resolved to {by_bare!r}, bracketed to {by_bracketed!r} — "
+            "compound clause should yield the same internal id"
+        )
+
+    def test_create_draft_reply_round_trip_with_bare_rfc_id(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """End-to-end #205 contract: an id from search_messages round-trips
+        through create_draft(seed='reply') without MailMessageNotFoundError.
+        Cleans up the created draft.
+        """
+        rows = connector.search_messages(
+            account=test_account, mailbox="INBOX", limit=1
+        )
+        if not rows:
+            pytest.skip(f"{test_account} INBOX has no messages to test against")
+
+        rfc_id = rows[0].get("rfc_message_id") or rows[0].get("id")
+        assert rfc_id
+        if rfc_id.startswith("<") and rfc_id.endswith(">"):
+            rfc_id = rfc_id[1:-1]
+
+        result = connector.create_draft(
+            seed="reply",
+            seed_id=rfc_id,
+            body="Integration-test draft — safe to discard.",
+        )
+        draft_id = result.get("draft_id") if isinstance(result, dict) else None
+        assert draft_id, f"no draft_id in create_draft result: {result!r}"
+        try:
+            # Lightweight assertion — the draft exists; we don't introspect
+            # its In-Reply-To header here because update_draft / get_draft
+            # paths have their own coverage. We only assert the seed
+            # resolution worked.
+            pass
+        finally:
+            connector.delete_draft(draft_id)

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -4726,35 +4726,57 @@ class TestFindMessageByMessageId:
         mock_run.return_value = "NOT_FOUND"
         connector.find_message_by_message_id("<x@y>")
         script = mock_run.call_args[0][0]
-        assert "whose message id is" in script
+        # Compound clause queries both bare and bracketed forms (#205 follow-up).
+        assert "whose" in script
+        assert "message id is" in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_wraps_brackets_for_bracketless_input(
+    def test_bracketless_input_queries_both_forms(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """Read tools (#148) emit RFC ids without angle brackets, but
-        Mail.app stores `message id` with brackets per RFC 5322. The
-        resolver wraps the brackets so callers can pass either form. (#205)
+        """Mail.app's ``message id`` storage normalization varies by
+        account: IMAP-backed accounts (iCloud, Gmail) store the bare RFC
+        Message-ID; some other paths may store with angle brackets. The
+        resolver therefore queries both forms in a single ``whose``
+        clause so a caller doesn't need to know the storage convention.
         """
         mock_run.return_value = "NOT_FOUND"
         connector.find_message_by_message_id("abc@example.com")
         script = mock_run.call_args[0][0]
-        # The AppleScript must search for the bracketed form even though
-        # the caller passed the bracketless form.
-        assert 'whose message id is "<abc@example.com>"' in script
+        assert 'message id is "abc@example.com"' in script
+        assert 'message id is "<abc@example.com>"' in script
+        assert "whose" in script and " or " in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_does_not_double_wrap_already_bracketed_input(
+    def test_bracketed_input_queries_both_forms(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
         """Existing callers (e.g. update_draft passing In-Reply-To)
-        already include brackets; the wrapping must be idempotent. (#205)
+        already include brackets; strip them and query both forms so
+        we don't depend on Mail.app's storage convention.
         """
         mock_run.return_value = "NOT_FOUND"
         connector.find_message_by_message_id("<abc@example.com>")
         script = mock_run.call_args[0][0]
-        assert 'whose message id is "<abc@example.com>"' in script
-        assert "<<" not in script
+        assert 'message id is "abc@example.com"' in script
+        assert 'message id is "<abc@example.com>"' in script
+        assert "<<" not in script and ">>" not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_returns_internal_id_for_bare_rfc_input(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Read tools (#148) emit bare RFC ids on the IMAP path. Round-trip
+        through ``create_draft(reply_to=...)`` requires this call to return
+        Mail's internal id when the input is bare. Unit test asserts API
+        surface; an integration test asserts the AppleScript actually
+        matches against Mail.app's storage.
+        """
+        mock_run.return_value = "54957"
+        result = connector.find_message_by_message_id(
+            "1779175169746.aa805a12-74b6-4330-93ff-72a175ed8679@example.com"
+        )
+        assert result == "54957"
 
 
 class TestGetDraftState:


### PR DESCRIPTION
# fix(#205 follow-up): query both bare and bracketed forms in find_message_by_message_id

Closes #231.
Follow-up to #208 / #205.

## What

Change `find_message_by_message_id` to strip brackets from input and query Mail.app for both forms in a single compound AppleScript `whose` clause:

```applescript
whose (message id is "abc@example.com" or message id is "<abc@example.com>")
```

That replaces v0.8.1's wrap-and-query-bracketed-only behaviour.

## Why

The v0.8.1 fix in `b56ef66` (PR #208) assumed Mail.app stores `message id` with angle brackets per RFC 5322. On IMAP-backed accounts (iCloud, Gmail), Mail.app stores the value bare. I sampled 81 message ids across 27 mailboxes on two accounts (iCloud + Gmail); zero of them came back bracketed.

So on v0.8.1, every `create_draft(reply_to=<bracketless RFC id>)` and `create_draft(forward_of=…)` call on these accounts raises `MailMessageNotFoundError`. That's the original #205 failure mode, just routed through the helper. End-to-end harness on my setup:

| Branch | Same RFC seed_id, same iCloud account |
|---|---|
| Pre-#208 (`cab806c`) | passed |
| **v0.8.1 (`76ff9d1`)** | failed: `MailMessageNotFoundError` |
| **This PR** | passed |

Why a compound clause and not, say, a wrap-strip-then-retry: it works whichever form Mail.app stored, it adds no extra round-trips, and existing callers passing either form keep working. The dormant `auto_template_vars` → `get_message` path you called out in `b56ef66`'s commit message is covered automatically since the resolver is shared.

## How

```diff
-        normalized = rfc5322_message_id
-        if not (normalized.startswith("<") and normalized.endswith(">")):
-            normalized = f"<{normalized}>"
-        safe = escape_applescript_string(sanitize_input(normalized))
+        bare = rfc5322_message_id
+        if bare.startswith("<") and bare.endswith(">"):
+            bare = bare[1:-1]
+        bracketed = f"<{bare}>"
+        safe_bare = escape_applescript_string(sanitize_input(bare))
+        safe_bracketed = escape_applescript_string(sanitize_input(bracketed))
 
         script = f"""
         tell application "Mail"
             set foundId to ""
             repeat with acc in accounts
                 try
                     repeat with mb in mailboxes of acc
                         try
-                            set m to first message of mb whose message id is "{safe}"
+                            set m to first message of mb whose (message id is "{safe_bare}" or message id is "{safe_bracketed}")
                             set foundId to (id of m as text)
                             exit repeat
```

Docstring rewritten to describe the compound-clause behaviour rather than the v0.8.1 assumption.

## Tests

Unit (`tests/unit/test_mail_connector.py::TestFindMessageByMessageId`):

- `test_wraps_brackets_for_bracketless_input` → `test_bracketless_input_queries_both_forms`. Asserts the script contains both arms joined by `or` inside a `whose` clause.
- `test_does_not_double_wrap_already_bracketed_input` → `test_bracketed_input_queries_both_forms`. Asserts both arms again, plus no double-wrap regardless of input shape.
- New: `test_returns_internal_id_for_bare_rfc_input`. API-surface assertion using the actual #205 seed shape from `search_messages` on the IMAP path.
- `test_script_uses_whose_message_id_clause`. Relaxed slightly to accept the parenthesised compound form.

Integration, new content in `tests/integration/test_mail_integration.py::TestFindMessageByMessageIdIntegration`:

- `test_find_by_bare_rfc_id_from_search_messages`. Pulls a real message from the test account's INBOX, asserts `find_message_by_message_id(bare_rfc_id)` returns Mail's internal id.
- `test_find_by_bracketed_rfc_id_matches_bare`. Same id in both shapes resolves to the same internal id.
- `test_create_draft_reply_round_trip_with_bare_rfc_id`. Full `create_draft(seed="reply", seed_id=<bare RFC id>)` round-trip with cleanup. That's the contract `search_messages` → `create_draft` relies on.

This is the safety net the CLAUDE.md "if you touched AppleScript, write integration tests" rule was asking for. Picks a message at runtime so the suite stays green when specific ids get deleted.

## Verification

```
$ uv run pytest tests/ -m "not integration and not e2e and not benchmark" -q
1010 passed, 47 skipped, 25 deselected in 3.16s

$ uv run pytest tests/unit/test_mail_connector.py::TestFindMessageByMessageId -v
9 passed in 0.02s

$ MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=iCloud uv run pytest \
    tests/integration/test_mail_integration.py::TestFindMessageByMessageIdIntegration \
    --run-integration -v
3 passed in 43.68s   # against real iCloud Mail.app

$ uv run ruff check src/apple_mail_mcp/mail_connector.py tests/
All checks passed!

$ PATH=".venv/bin:$PATH" bash scripts/check_complexity.sh
All functions within threshold (or below their allowlist ceiling).
# find_message_by_message_id stays at CC A
```

## Notes

On the same custom-domain iCloud setup, I also validated `5d7ab07` (#201) end-to-end. Works cleanly, and the CLI keychain-key alignment is better than what I had locally.

PR is narrow on purpose. If you'd rather a different shape (strip-only, query-then-retry, dispatch by account type), say so and I'll rework. Compound clause was my pick because it doesn't assume anything about Mail.app's storage and doesn't cost an extra round-trip. Happy to do a follow-up PR if you want the parallel `auto_template_vars` path tightened explicitly rather than relying on the shared resolver.

— Fred
