### PR TITLE
release: v0.8.2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Mail via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.8.1 | **Tests:** 1009 unit / 19 e2e / 37 integration | **Coverage:** 92%
+**Version:** v0.8.2 | **Tests:** 1027 unit / 19 e2e / 37 integration | **Coverage:** 92%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-05-20
+
+Patch release. Three substantive bug fixes — one security regression in our own gate chain, one regression introduced at v0.8.1, and one long-latent AppleEvent timeout bug surfaced by use on slow Exchange/EWS accounts. Two of the three are contributor-authored: [@fmasi](https://github.com/fmasi) reported and fixed the v0.8.1 regression they noticed within hours of release; [@allenpan05](https://github.com/allenpan05) reported and fixed the AppleEvent timeout bug. Thanks to both.
+
+### Fixed
+
+**`_elicit_confirmation` fails closed on missing context / unsupported elicitation (#226):** The confirmation step in our destructive-operation gate chain had two silent-pass paths that bypassed enforcement: when `ctx` was `None` (any MCP client that didn't pass a context) and when `ctx.elicit(...)` raised (clients that don't implement the elicitation capability). Both paths returned `None`, which downstream callers interpret as "approved." Result: every gated tool that wires through the helper — `delete_rule`, `update_rule`, `delete_mailbox`, `delete_template`, plus `create_draft` / `update_draft` with `send_now=True` (via `_run_send_now_gates`) — could be invoked without confirmation from any MCP client that doesn't implement elicitation. The safety and rate-limit gates still fired, but the explicit "user confirmed this action" gate was gone.
+
+Both bypass paths now return a typed `confirmation_required` error distinct from the existing `cancelled` (user-declined) error — MCP clients can give different UX for "user said no" vs "couldn't ask user." Both paths now also log to the audit trail with distinct statuses (`confirmation_required` for missing ctx, `confirmation_unavailable` for elicit-raise) so operators can spot bypass attempts. The `cancelled` error message changes from "User declined to send" to "User declined to continue" — the helper is used for deletes and rule mutations too, not just sends.
+
+Surfaced via a contributor's fork patch surveyed during the v0.8.1 post-mortem.
+
+**`find_message_by_message_id` regression introduced at v0.8.1 (#231, fix #232 by @fmasi):** v0.8.1's PR #208 added bracket-wrapping to `find_message_by_message_id` based on the (unverified) assumption that Mail.app stores `message id` with brackets per RFC 5322. fmasi sampled 81 message ids across 27 mailboxes on two accounts (iCloud + Gmail) and found **zero** stored bracketed — IMAP servers strip outer brackets per RFC 3501 when returning Message-ID via FETCH ENVELOPE, and Mail.app stores whatever IMAP gave it. The v0.8.1 wrap meant `create_draft(reply_to=<bare RFC id>)` and `create_draft(forward_of=...)` were silently failing with `MailMessageNotFoundError` on IMAP-backed accounts — the original #205 failure mode, just routed through the helper.
+
+Fix uses a compound AppleScript clause that queries both forms in one round-trip: `whose (message id is "X" or message id is "<X>")`. Strips brackets from input first so the canonical bare form drives both arms. Robust to whatever Mail.app actually stored on any account type. PR #232 also adds three integration tests against real Mail.app — the safety net that CLAUDE.md's "if you touched AppleScript, write integration tests" rule was asking for. PR #208's unit tests passed because they asserted the generated AppleScript string but never verified Mail.app would actually match against it; the integration tests added here close that gap.
+
+**AppleEvent timeout bypass on AppleScript paths (#227, fix #228 by @allenpan05):** AppleScript scripts emitted by `_wrap_as_json_script` lacked a `with timeout of N seconds` clause. As a result, Mail's default 60-second AppleEvent timeout fired before whatever subprocess timeout the connector was constructed with — `AppleMailConnector(timeout=N)` was effectively a no-op for any operation Mail couldn't complete in 60s. Once the AppleEvent timed out, the scripting bridge entered an unresponsive `Connection is invalid (-609)` state for ~30s. Hit reliably on Exchange/EWS accounts where per-message property fetches are server-bound rather than local.
+
+`_wrap_as_json_script` now takes a required `timeout` keyword arg and wraps the body in `with timeout of {timeout} seconds ... end timeout`. All 12 call sites pass `self.timeout` so the in-script timeout matches the subprocess kill timer. Default-configured users (`AppleMailConnector(timeout=60)`) see no behavior change since that matches Mail's old default; users who passed higher timeouts now actually get them.
+
+**Known gap:** ~10 other `_run_applescript` call sites (mutation paths like `mark_as_read`, `move_messages`, `update_message`) build their AppleScript directly without going through `_wrap_as_json_script` and therefore don't yet get the `with timeout` protection. These are typically small-batch operations that don't approach the 60s wall in practice, but the gap is tracked as #233 for v0.9.0.
+
 ## [0.8.1] - 2026-05-17
 
 Patch release. Three user-facing bug fixes — two reported by external contributor [@fmasi](https://github.com/fmasi) with full reproductions — plus a refactor sweep that drops every remaining function below the CC 20 threshold (complexity allowlist now empty).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server that provides programmatic access to Apple Mail, enabling AI assistants like Claude to read, send, search, and manage emails on macOS.
 
-> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.8.1`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
+> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.8.2`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
 
 ## Tools (23)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-mail-mcp"
-version = "0.8.1"
+version = "0.8.2"
 description = "MCP server for Apple Mail integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_mail_mcp/__init__.py
+++ b/src/apple_mail_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Mail MCP Server
 A Model Context Protocol server for Apple Mail integration.
 """
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-mcp"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Patch release with three substantive bug fixes — two of them contributor-authored:

### Fixed
- **#226** — `_elicit_confirmation` fails closed when ctx is None or elicitation unavailable. **Security regression fix**: confirmation gate was bypassable by any MCP client that didn't implement elicitation.
- **#231** (PR #232 by [@fmasi](https://github.com/fmasi)) — v0.8.1's bracket-wrap in `find_message_by_message_id` reintroduced #205 on IMAP-backed accounts. Replaced with a compound `whose (X or Y)` clause that queries both bare and bracketed forms in one round-trip; fmasi added the integration tests v0.8.1 was missing.
- **#227** (PR #228 by [@allenpan05](https://github.com/allenpan05)) — AppleScript paths emitted by `_wrap_as_json_script` lacked `with timeout of N seconds` wrapping. Mail's default 60s AppleEvent timeout fired before the connector's configurable subprocess timeout, making `AppleMailConnector(timeout=N)` a no-op. allenpan05's fix threads `self.timeout` into all 12 wrapper call sites.

### Known gap (tracked for v0.9.0)
- **#233** — ~10 other `_run_applescript` call sites build their AppleScript directly (mutation paths) and don't yet get `with timeout` protection.

## Validation

- [x] Milestone v0.8.2: 0 open / 6 closed
- [x] Version sync across `pyproject.toml`, `__init__.py`, `CLAUDE.md`, `CHANGELOG.md`
- [x] `make test` — 1027 unit tests pass (up from 1009 at v0.8.1)
- [x] `make coverage` — 92.20% (fail_under 90)
- [x] `./scripts/check_complexity.sh` — empty allowlist, no violators
- [x] `./scripts/check_client_server_parity.sh`
- [x] `./scripts/check_applescript_safety.sh`
- [x] `./scripts/check_dependencies.sh` — same urllib3 dev-only chain as prior releases; new pyjwt CVE (PYSEC-2025-183) is in unfixed-upstream JWT verification code that local-stdio servers don't exercise. Will file follow-up to revisit when fastmcp/mcp ships a fixed pyjwt range.
- [x] `feature-dev:code-reviewer` review — one CHANGELOG factual error caught and fixed (I had `delete_messages` in the gated-tools list; it has no `ctx` parameter and was never gated. Corrected list: `delete_rule` / `update_rule` / `delete_mailbox` / `delete_template` + `create_draft` / `update_draft` via `_run_send_now_gates`)

## Test plan

- [ ] Wait for CI to pass
- [ ] Rebase merge into main (linear history)
- [ ] Tag v0.8.2 on main, push to trigger release workflow
- [ ] Close milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)