### PR TITLE
feat(#217): MCP tool annotations + --read-only split-server flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 }
 ```
 
+### Optional: split read / write servers
+
+Claude Desktop prompts per-tool for permission. If you want to **batch-approve the 9 read tools** (list / search / get) and still gate the 14 mutating tools per call, run the connector twice — once with `--read-only`, once without — under two separate `mcpServers` entries:
+
+```json
+{
+  "mcpServers": {
+    "apple-mail-read": {
+      "command": "uv",
+      "args": ["--directory", "/path/to/apple-mail-mcp", "run", "python", "-m", "apple_mail_mcp.server", "--read-only"]
+    },
+    "apple-mail-write": {
+      "command": "uv",
+      "args": ["--directory", "/path/to/apple-mail-mcp", "run", "python", "-m", "apple_mail_mcp.server"]
+    }
+  }
+}
+```
+
+The `--read-only` server exposes only the 9 read tools, so Claude Desktop's per-server permission UI naturally groups them. The full server still gates writes individually. Trade-off: 2× connector processes. See [`docs/reference/TOOLS.md`](docs/reference/TOOLS.md) for the per-tool classification and a note on MCP annotation hints (`readOnlyHint` / `destructiveHint` / `idempotentHint`) which forward-compatible hosts may use to provide the same UX without the split.
+
 ## Permissions
 
 On first run, macOS will prompt for Automation access. Grant permission in:

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -7,6 +7,25 @@ Complete reference for all MCP tools provided by the Apple Mail MCP server.
 **Current Version:** v0.6.0
 **Total Tools:** 27
 
+## Tool annotations (`readOnlyHint` / `destructiveHint` / `idempotentHint`)
+
+Every tool ships with the per-tool annotations the MCP 2025-03 spec defines so hosts that honor them can group / batch-approve permissions. Hosts that ignore the hints get the same behavior they always did — annotations are forward-compatible.
+
+| Hint | What it means | Defaults |
+|---|---|---|
+| `readOnlyHint` | `true` if the tool only reads state; `false` if it can mutate Mail.app, the filesystem, or remote IMAP state. | always set explicitly |
+| `destructiveHint` | `true` if the tool can remove or overwrite existing state (delete, move, rename, replace). `false` for purely additive tools (create / save-new). | always set explicitly |
+| `idempotentHint` | `true` if calling the tool a second time with the same arguments leaves end state unchanged. | always set explicitly |
+| `openWorldHint` | Out of scope for v0.9.0 — unset; defaults to `true` per the spec. | n/a |
+
+**Classification:**
+
+- **Read-only (9):** `list_accounts`, `list_mailboxes`, `list_rules`, `list_templates`, `search_messages`, `get_messages`, `get_thread`, `get_template`, `render_template`. All have `readOnlyHint=true`, `destructiveHint=false`, `idempotentHint=true`.
+- **Mutating destructive (9):** `update_message`, `update_mailbox`, `update_rule`, `update_draft`, `delete_draft`, `delete_mailbox`, `delete_messages`, `delete_rule`, `delete_template`. All have `destructiveHint=true`, `idempotentHint=true`.
+- **Mutating additive (5):** `create_mailbox`, `create_draft`, `create_rule`, `save_template`, `save_attachments`. All have `destructiveHint=false`. Idempotent except `create_draft` and `create_rule` (each call may create a new entity).
+
+**Host doesn't honor annotations?** Use the split-server config in the [README](../../README.md#optional-split-read--write-servers). Pass `--read-only` to one connector entry to expose only the 9 read tools; pair with a second non-read-only entry. Claude Desktop's per-server permission UI then naturally groups them. The two approaches compose: annotations describe the model, the split-server flag enforces it client-side.
+
 ## Phase 1 Tools (v0.1.0) - Core Foundation
 
 ### search_messages

--- a/scripts/check_client_server_parity.sh
+++ b/scripts/check_client_server_parity.sh
@@ -10,8 +10,17 @@ echo "Checking client-server parity..."
 # Extract public methods from connector (exclude __init__, _private)
 CONNECTOR_METHODS=$(grep -E '^\s+def [a-z]' "$CONNECTOR" | grep -v '^\s+def _' | sed 's/.*def \([a-z_]*\)(.*/\1/' | sort)
 
-# Extract @mcp.tool() decorated functions from server
-SERVER_TOOLS=$(grep -A1 '@mcp.tool' "$SERVER" | grep 'def ' | sed 's/.*def \([a-z_]*\)(.*/\1/' | sort)
+# Extract decorated tool functions from server. Matches both the bare
+# @mcp.tool() decorator (legacy) and the @_tool(...) helper that wraps it
+# (#217 — annotation-aware decorator that gates registration on
+# --read-only). Once a decorator line is seen, the next `def`/`async def`
+# line is the tool's function name. BSD-awk friendly.
+SERVER_TOOLS=$(awk '
+    /^@_tool\(/ || /^@mcp\.tool\(/ { in_dec=1; next }
+    in_dec && /^(async )?def / {
+        sub(/^(async )?def /, ""); sub(/\(.*$/, ""); print; in_dec=0
+    }
+' "$SERVER" | sort)
 
 echo ""
 echo "Connector public methods:"

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -5,9 +5,11 @@ FastMCP server for Apple Mail integration.
 import argparse
 import atexit
 import logging
+import sys
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 from fastmcp import Context, FastMCP
 from fastmcp.server.elicitation import AcceptedElicitation
@@ -50,8 +52,45 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# Read-only mode (#217). The connector can be launched with `--read-only`
+# to skip registration of the 14 mutating tools so Claude Desktop users can
+# run two server entries side-by-side and batch-approve the read-only one.
+# `_pre_parse_read_only` parses argv at module load (tolerant of unknown
+# args, which `main()` parses again with the full schema) so the
+# `@_tool(..., mutating=True)` decorator below can decide registration at
+# decoration time without restructuring the per-tool decoration sites.
+def _pre_parse_read_only(argv: list[str] | None = None) -> bool:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--read-only", action="store_true")
+    args, _ = parser.parse_known_args(argv if argv is not None else sys.argv[1:])
+    return bool(args.read_only)
+
+
+_READ_ONLY = _pre_parse_read_only()
+
 # Create FastMCP server
 mcp = FastMCP("apple-mail")
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _tool(
+    annotations: dict[str, Any], *, mutating: bool = False
+) -> Callable[[F], F]:
+    """Annotation-aware tool decorator that gates registration on `_READ_ONLY`.
+
+    `mutating=True` tools are skipped when the server was launched with
+    `--read-only`; the function stays callable (handy for tests) but is not
+    registered with MCP. Non-mutating tools always register.
+    """
+
+    def wrap(fn: F) -> F:
+        if mutating and _READ_ONLY:
+            return fn
+        return mcp.tool(annotations=annotations)(fn)
+
+    return wrap
 
 # Initialize mail connector. Pool is opt-in via APPLE_MAIL_MCP_IMAP_POOL=1
 # (default off, per #75 acceptance criteria — keep per-call lifecycle the
@@ -139,7 +178,9 @@ async def _elicit_confirmation(
     return None
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
+)
 def list_accounts() -> dict[str, Any]:
     """
     List all configured email accounts in Apple Mail.
@@ -184,7 +225,9 @@ def list_accounts() -> dict[str, Any]:
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
+)
 def list_rules() -> dict[str, Any]:
     """
     List all Mail.app rules (read-only).
@@ -243,7 +286,10 @@ def _resolve_rule_name(rule_index: int) -> str | None:
     return None
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
+    mutating=True,
+)
 async def delete_rule(
     rule_index: int,
     ctx: Context | None = None,
@@ -322,7 +368,10 @@ async def delete_rule(
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False},
+    mutating=True,
+)
 def create_rule(
     name: str,
     conditions: list[dict[str, Any]],
@@ -405,7 +454,10 @@ def create_rule(
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
+    mutating=True,
+)
 async def update_rule(
     rule_index: int,
     name: str | None = None,
@@ -527,7 +579,9 @@ async def update_rule(
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
+)
 def list_mailboxes(account: str) -> dict[str, Any]:
     """
     List all mailboxes for an account.
@@ -706,7 +760,9 @@ def _apply_search_filters(
     return [m for m in messages if matches(m)][:limit]
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
+)
 def search_messages(
     account: str | None = None,
     mailbox: str = "INBOX",
@@ -946,7 +1002,9 @@ def search_messages(
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
+)
 def get_messages(
     message_ids: list[str],
     include_content: bool = True,
@@ -1034,7 +1092,10 @@ def get_messages(
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
+    mutating=True,
+)
 def update_message(
     message_ids: list[str],
     read_status: bool | None = None,
@@ -1198,7 +1259,9 @@ def update_message(
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
+)
 def get_thread(message_id: str) -> dict[str, Any]:
     """
     Return all messages in the thread containing the given message.
@@ -1263,7 +1326,10 @@ def get_thread(message_id: str) -> dict[str, Any]:
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True},
+    mutating=True,
+)
 def save_attachments(
     message_id: str,
     save_directory: str,
@@ -1360,7 +1426,10 @@ def save_attachments(
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True},
+    mutating=True,
+)
 def create_mailbox(
     account: str,
     name: str,
@@ -1448,7 +1517,10 @@ def create_mailbox(
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
+    mutating=True,
+)
 def update_mailbox(
     account: str,
     name: str,
@@ -1592,7 +1664,10 @@ def update_mailbox(
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
+    mutating=True,
+)
 async def delete_mailbox(
     account: str,
     name: str,
@@ -1722,7 +1797,10 @@ async def delete_mailbox(
         }
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
+    mutating=True,
+)
 def delete_messages(
     message_ids: list[str],
     permanent: bool = False,
@@ -1840,7 +1918,9 @@ def _template_error_response(e: MailTemplateError) -> dict[str, Any]:
     return {"success": False, "error": str(e), "error_type": et}
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
+)
 def list_templates() -> dict[str, Any]:
     """List all stored email templates.
 
@@ -1870,7 +1950,9 @@ def list_templates() -> dict[str, Any]:
         return {"success": False, "error": str(e), "error_type": "unknown"}
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
+)
 def get_template(name: str) -> dict[str, Any]:
     """Read a single template by name.
 
@@ -1901,7 +1983,10 @@ def get_template(name: str) -> dict[str, Any]:
         return {"success": False, "error": str(e), "error_type": "unknown"}
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True},
+    mutating=True,
+)
 def save_template(
     name: str, body: str, subject: str | None = None
 ) -> dict[str, Any]:
@@ -1946,7 +2031,10 @@ def save_template(
         return {"success": False, "error": str(e), "error_type": "unknown"}
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
+    mutating=True,
+)
 async def delete_template(
     name: str, ctx: Context | None = None
 ) -> dict[str, Any]:
@@ -1991,7 +2079,9 @@ async def delete_template(
         return {"success": False, "error": str(e), "error_type": "unknown"}
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
+)
 def render_template(
     name: str,
     message_id: str | None = None,
@@ -2369,7 +2459,10 @@ def _merge_draft_recipients(
     )
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False},
+    mutating=True,
+)
 async def create_draft(
     reply_to: str | None = None,
     forward_of: str | None = None,
@@ -2542,7 +2635,10 @@ async def create_draft(
         return {"success": False, "error": str(e), "error_type": "unknown"}
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
+    mutating=True,
+)
 async def update_draft(
     draft_id: str,
     to: list[str] | None = None,
@@ -2709,7 +2805,10 @@ async def update_draft(
                 pass
 
 
-@mcp.tool()
+@_tool(
+    {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
+    mutating=True,
+)
 def delete_draft(draft_id: str) -> dict[str, Any]:
     """Delete (move to Trash) an existing draft.
 
@@ -2753,6 +2852,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         description=(
             "Apple Mail MCP server. With no subcommand, starts the MCP "
             "server (this is what Claude Desktop / mcp clients invoke)."
+        ),
+    )
+    parser.add_argument(
+        "--read-only",
+        action="store_true",
+        help=(
+            "Start the server with only the 9 read-only tools registered "
+            "(skips the 14 mutating tools). Pair with a second non-read-only "
+            "server entry in your MCP client to batch-approve reads while "
+            "still gating writes per call. See docs/reference/TOOLS.md."
         ),
     )
     sub = parser.add_subparsers(dest="command")
@@ -2807,6 +2916,11 @@ def main(argv: list[str] | None = None) -> int:
             uninstall=args.uninstall,
         )
 
+    if _READ_ONLY:
+        logger.info(
+            "Read-only mode: 14 mutating tools skipped (--read-only). "
+            "Only the 9 read tools are registered."
+        )
     logger.info("Starting Apple Mail MCP server")
     mcp.run()
     return 0

--- a/tests/unit/test_server_annotations.py
+++ b/tests/unit/test_server_annotations.py
@@ -1,0 +1,232 @@
+"""Tests for MCP tool annotations (#217).
+
+Covers:
+
+- The `_tool` decorator helper behavior (skip mutating tools in read-only mode,
+  register otherwise, pass annotations through).
+- Every tool registered on the production `mcp` instance has the expected
+  `readOnlyHint` / `destructiveHint` / `idempotentHint` values per the
+  classification table in the issue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from apple_mail_mcp import server
+
+# ---------------------------------------------------------------------------
+# Classification — the source of truth that the tests below assert against.
+# Keep aligned with the table in the #217 implementation plan.
+# ---------------------------------------------------------------------------
+
+READ_ONLY_TOOLS: set[str] = {
+    "list_accounts",
+    "list_mailboxes",
+    "list_rules",
+    "list_templates",
+    "search_messages",
+    "get_messages",
+    "get_thread",
+    "get_template",
+    "render_template",
+}
+
+# Mutating tools, partitioned by destructiveHint.
+DESTRUCTIVE_TOOLS: set[str] = {
+    "update_message",
+    "update_mailbox",
+    "update_rule",
+    "update_draft",
+    "delete_draft",
+    "delete_mailbox",
+    "delete_messages",
+    "delete_rule",
+    "delete_template",
+}
+
+ADDITIVE_TOOLS: set[str] = {
+    "create_mailbox",
+    "create_draft",
+    "create_rule",
+    "save_template",
+    "save_attachments",
+}
+
+MUTATING_TOOLS = DESTRUCTIVE_TOOLS | ADDITIVE_TOOLS
+
+# Idempotent: same args → same end state.
+NON_IDEMPOTENT_TOOLS: set[str] = {
+    "create_draft",   # each call may create a new draft
+    "create_rule",    # rules may be appended on each call
+}
+
+
+# ---------------------------------------------------------------------------
+# _tool helper behavior
+# ---------------------------------------------------------------------------
+
+
+class TestToolHelper:
+    """The `_tool` decorator's read-only gating behavior."""
+
+    def test_mutating_tool_skipped_when_read_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_mcp = Mock()
+        monkeypatch.setattr(server, "mcp", fake_mcp)
+        monkeypatch.setattr(server, "_READ_ONLY", True)
+
+        def my_mutator() -> int:
+            return 42
+
+        result = server._tool(
+            {"destructiveHint": True}, mutating=True
+        )(my_mutator)
+
+        assert result is my_mutator
+        fake_mcp.tool.assert_not_called()
+
+    def test_mutating_tool_registered_when_not_read_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: list[tuple[dict[str, Any], Any]] = []
+
+        def fake_tool(*, annotations: dict[str, Any]) -> Any:
+            def inner(fn: Any) -> Any:
+                captured.append((annotations, fn))
+                return fn
+
+            return inner
+
+        fake_mcp = Mock()
+        fake_mcp.tool.side_effect = fake_tool
+        monkeypatch.setattr(server, "mcp", fake_mcp)
+        monkeypatch.setattr(server, "_READ_ONLY", False)
+
+        def my_mutator() -> None:
+            return None
+
+        server._tool({"destructiveHint": True}, mutating=True)(my_mutator)
+
+        assert len(captured) == 1
+        ann, fn = captured[0]
+        assert ann == {"destructiveHint": True}
+        assert fn is my_mutator
+
+    def test_read_only_tool_always_registered(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """mutating=False (default) registers even in read-only mode."""
+        fake_mcp = Mock()
+        fake_mcp.tool.return_value = lambda fn: fn
+        monkeypatch.setattr(server, "mcp", fake_mcp)
+        monkeypatch.setattr(server, "_READ_ONLY", True)
+
+        @server._tool({"readOnlyHint": True})
+        def my_reader() -> None:
+            return None
+
+        fake_mcp.tool.assert_called_once_with(annotations={"readOnlyHint": True})
+
+
+# ---------------------------------------------------------------------------
+# Per-tool annotations on the production `mcp` instance
+# ---------------------------------------------------------------------------
+
+
+def _registered_tools() -> dict[str, Any]:
+    """Return the production mcp's tools keyed by name."""
+    tools = asyncio.run(server.mcp.list_tools())
+    return {t.name: t for t in tools}
+
+
+def _hint(tool: Any, key: str) -> Any:
+    """Pull a hint from a Tool object's annotations, supporting either an
+    object-with-attribute or dict-shaped representation."""
+    ann = tool.annotations
+    if ann is None:
+        return None
+    # FastMCP exposes annotations as a ToolAnnotations dataclass-ish object,
+    # but allows dict at construction. Support both via getattr fallback.
+    if hasattr(ann, key):
+        return getattr(ann, key)
+    if isinstance(ann, dict):
+        return ann.get(key)
+    return None
+
+
+class TestProductionAnnotations:
+    """Default-mode registration must match the classification table."""
+
+    def test_tool_count_unchanged_in_default_mode(self) -> None:
+        names = set(_registered_tools().keys())
+        assert names == READ_ONLY_TOOLS | MUTATING_TOOLS
+
+    def test_classifications_partition_correctly(self) -> None:
+        """No overlap between read-only and mutating sets; counts are 9 + 14."""
+        assert READ_ONLY_TOOLS.isdisjoint(MUTATING_TOOLS)
+        assert len(READ_ONLY_TOOLS) == 9
+        assert len(MUTATING_TOOLS) == 14
+        assert DESTRUCTIVE_TOOLS.isdisjoint(ADDITIVE_TOOLS)
+
+    @pytest.mark.parametrize("name", sorted(READ_ONLY_TOOLS))
+    def test_read_only_tool_annotations(self, name: str) -> None:
+        tool = _registered_tools()[name]
+        assert _hint(tool, "readOnlyHint") is True, name
+        assert _hint(tool, "destructiveHint") is False, name
+        assert _hint(tool, "idempotentHint") is True, name
+
+    @pytest.mark.parametrize("name", sorted(DESTRUCTIVE_TOOLS))
+    def test_destructive_tool_annotations(self, name: str) -> None:
+        tool = _registered_tools()[name]
+        assert _hint(tool, "readOnlyHint") is False, name
+        assert _hint(tool, "destructiveHint") is True, name
+        expected_idempotent = name not in NON_IDEMPOTENT_TOOLS
+        assert _hint(tool, "idempotentHint") is expected_idempotent, name
+
+    @pytest.mark.parametrize("name", sorted(ADDITIVE_TOOLS))
+    def test_additive_tool_annotations(self, name: str) -> None:
+        tool = _registered_tools()[name]
+        assert _hint(tool, "readOnlyHint") is False, name
+        assert _hint(tool, "destructiveHint") is False, name
+        expected_idempotent = name not in NON_IDEMPOTENT_TOOLS
+        assert _hint(tool, "idempotentHint") is expected_idempotent, name
+
+
+# ---------------------------------------------------------------------------
+# Argparse — --read-only is visible and parses
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnlyFlag:
+    def test_pre_parse_returns_false_with_no_args(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("sys.argv", ["apple-mail-mcp"])
+        assert server._pre_parse_read_only() is False
+
+    def test_pre_parse_returns_true_with_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("sys.argv", ["apple-mail-mcp", "--read-only"])
+        assert server._pre_parse_read_only() is True
+
+    def test_pre_parse_ignores_unknown_args(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The pre-parse uses parse_known_args; downstream args don't crash it."""
+        monkeypatch.setattr(
+            "sys.argv", ["apple-mail-mcp", "setup-imap", "--account", "Gmail"]
+        )
+        assert server._pre_parse_read_only() is False
+
+    def test_root_parser_advertises_flag(self) -> None:
+        """--help should mention --read-only so users can discover it."""
+        parser = server._build_arg_parser()
+        help_text = parser.format_help()
+        assert "--read-only" in help_text


### PR DESCRIPTION
## Summary
- Adds `readOnlyHint` / `destructiveHint` / `idempotentHint` annotations to all 23 tools per the MCP 2025-03 spec.
- Adds `--read-only` CLI flag that registers only the 9 read tools; intended for the split-server config (one read-only entry + one full entry in `claude_desktop_config.json`).
- Belt-and-suspenders: annotations forward-compatible for hosts that honor them; split-server fallback works on hosts that don't.
- Classification: 9 read-only, 9 destructive (delete/update*), 5 additive (create/save). `create_draft` and `create_rule` are non-idempotent; rest are idempotent.
- New `@_tool(annotations, mutating=...)` helper at top of `server.py` co-locates classification with each tool definition; gated on a module-level `_READ_ONLY` flag set by argv pre-parse.
- 32 new unit tests in `tests/unit/test_server_annotations.py` covering helper behavior, per-tool annotations, and pre-parse argv handling.
- `scripts/check_client_server_parity.sh` updated to recognize the new `@_tool` decorator pattern.

## Closes
Closes #217

## Test plan
- [x] `make check-all` passes (ruff, mypy, 1059 unit tests, complexity, version-sync, parity)
- [ ] Manual smoke: install in Claude Desktop with both the standard and split-server config blocks from the updated README; confirm both servers boot and the read-only one exposes 9 tools
- [ ] Empirical honor test (post-merge): run `list_accounts` in Claude Desktop with annotations present, observe whether the permission UI batches/changes copy; comment result on #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)