### PR TITLE
feat(#230): received_within_hours filter on search_messages

### DIFF
--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -44,6 +44,7 @@ Search for messages matching specified criteria.
 | `is_flagged` | boolean | No | None | Filter by flagged status (true=flagged, false=not flagged) |
 | `date_from` | string | No | None | Inclusive lower bound on `date_received`. ISO 8601 YYYY-MM-DD. |
 | `date_to` | string | No | None | Inclusive upper bound on `date_received` (full day included). ISO 8601 YYYY-MM-DD. |
+| `received_within_hours` | integer | No | None | Relative-time filter — only return messages received within the last N hours. Hour precision (Mail.app evaluates the cutoff server-side on the AppleScript path; IMAP path day-floors via SINCE and Python post-filters). Composes with `date_from` / `date_to` — most restrictive filter wins. Must be `> 0`. Days = 24, weeks = 168. |
 | `has_attachment` | boolean | No | None | Filter messages with (true) or without (false) attachments |
 | `limit` | integer | No | 50 | Maximum number of results to return |
 | `source` | list[string] \| null | No | null | Optional list of message ids (with optional `"SELECTED"` sentinel) to scope the search to. `null` (default) searches the account/mailbox normally. |

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -9,6 +9,7 @@ import time
 import warnings
 from collections.abc import Callable
 from datetime import date as _date
+from datetime import datetime as _datetime
 from datetime import timedelta as _timedelta
 from pathlib import Path
 from typing import Any, cast
@@ -63,6 +64,104 @@ logger = logging.getLogger(__name__)
 # Strict ISO 8601 YYYY-MM-DD — search_messages's date_from/date_to filters
 # reject anything else to prevent AppleScript injection via the date clause.
 _ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _now() -> _datetime:
+    """Indirection for monkeypatching in tests (#230). Returns tz-aware
+    local time so comparison with IMAP envelope dates (also tz-aware) is
+    well-defined."""
+    return _datetime.now().astimezone()
+
+
+def _build_date_filter_clauses(
+    date_from: str | None,
+    date_to: str | None,
+    received_within_hours: int | None,
+) -> list[str]:
+    """Build the date-related AppleScript IF clauses for the search loop.
+
+    Extracted from `_search_messages_applescript` to keep that function
+    under the cyclomatic-complexity ceiling. All three date filters
+    compose by intersection (any matching clause skips the message).
+    """
+    clauses: list[str] = []
+
+    if date_from is not None:
+        if not _ISO_DATE_RE.match(date_from):
+            raise ValueError(
+                f"date_from must be ISO 8601 YYYY-MM-DD, got: {date_from!r}"
+            )
+        clauses.append(
+            f'if (date received of msg) < (date "{date_from}") '
+            f'then set includeThis to false'
+        )
+
+    if date_to is not None:
+        if not _ISO_DATE_RE.match(date_to):
+            raise ValueError(
+                f"date_to must be ISO 8601 YYYY-MM-DD, got: {date_to!r}"
+            )
+        # Upper bound is exclusive of the day AFTER date_to, so the full
+        # day of date_to is included.
+        next_day = (
+            _date.fromisoformat(date_to) + _timedelta(days=1)
+        ).isoformat()
+        clauses.append(
+            f'if (date received of msg) >= (date "{next_day}") '
+            f'then set includeThis to false'
+        )
+
+    if received_within_hours is not None:
+        if not isinstance(received_within_hours, int) or received_within_hours <= 0:
+            raise ValueError(
+                f"received_within_hours must be > 0, got: {received_within_hours!r}"
+            )
+        # Hour-precise filter: Mail.app computes the cutoff against its
+        # own wall clock at script-eval time. No Python timezone math
+        # needed on this path. (#230)
+        clauses.append(
+            f'if (date received of msg) < ((current date) - '
+            f'({received_within_hours} * hours)) '
+            f'then set includeThis to false'
+        )
+
+    return clauses
+
+
+def _filter_imap_results_to_cutoff(
+    messages: list[dict[str, Any]], cutoff_dt: _datetime
+) -> list[dict[str, Any]]:
+    """Trim IMAP search results to messages received at-or-after `cutoff_dt`.
+
+    The IMAP path's day-granular SINCE under-filters when the caller wants
+    hour precision (e.g., received_within_hours=6 just before midnight
+    includes everything since midnight on the previous day). This pass
+    enforces hour precision in Python using the ISO 8601 ``date_received``
+    that the IMAP connector emits.
+
+    Messages whose ``date_received`` is missing or unparseable are kept
+    defensively — better to over-return than to silently drop rows. The
+    AS path doesn't need this helper because its embedded
+    ``(current date) - (N * hours)`` clause is already hour-precise.
+    """
+    if cutoff_dt.tzinfo is None:
+        cutoff_dt = cutoff_dt.astimezone()
+    kept: list[dict[str, Any]] = []
+    for m in messages:
+        raw = m.get("date_received")
+        if not raw:
+            kept.append(m)
+            continue
+        try:
+            parsed = _datetime.fromisoformat(str(raw))
+        except (TypeError, ValueError):
+            kept.append(m)
+            continue
+        if parsed.tzinfo is None:
+            parsed = parsed.astimezone()
+        if parsed >= cutoff_dt:
+            kept.append(m)
+    return kept
 
 # Threshold (seconds) above which the AppleScript search path emits an
 # INFO-level recommendation to enable IMAP delegation. Calibrated against
@@ -1081,6 +1180,7 @@ class AppleMailConnector:
         is_flagged: bool | None = None,
         date_from: str | None = None,
         date_to: str | None = None,
+        received_within_hours: int | None = None,
         has_attachment: bool | None = None,
         limit: int | None = None,
         include_attachments: bool = False,
@@ -1114,6 +1214,24 @@ class AppleMailConnector:
         """
         body_search = bool(body_contains or text_contains)
 
+        # #230: received_within_hours is a hour-granular relative cutoff that
+        # composes with date_from. Validate up front (so both IMAP and AS
+        # paths see a consistent error), then desugar to date_from for the
+        # IMAP path's day-granular SINCE pre-filter and post-filter results
+        # to enforce hour precision. The AS path receives the raw param and
+        # embeds an (current date) - (N * hours) clause that Mail.app
+        # evaluates server-side — no post-filter needed there.
+        cutoff_dt: _datetime | None = None
+        if received_within_hours is not None:
+            if not isinstance(received_within_hours, int) or received_within_hours <= 0:
+                raise ValueError(
+                    f"received_within_hours must be > 0, got: {received_within_hours!r}"
+                )
+            cutoff_dt = _now() - _timedelta(hours=received_within_hours)
+            cutoff_date_iso = cutoff_dt.date().isoformat()
+            if date_from is None or cutoff_date_iso > date_from:
+                date_from = cutoff_date_iso
+
         if not self._imap_breaker_open(account):
             try:
                 result = self._imap_search(
@@ -1131,6 +1249,8 @@ class AppleMailConnector:
                     body_contains,
                     text_contains,
                 )
+                if cutoff_dt is not None:
+                    result = _filter_imap_results_to_cutoff(result, cutoff_dt)
                 self._imap_clear_breaker(account)
                 return result
             except _IMAP_FALLBACK_EXCS as exc:
@@ -1165,6 +1285,7 @@ class AppleMailConnector:
                 include_attachments,
                 body_contains,
                 text_contains,
+                received_within_hours=received_within_hours,
             )
         finally:
             elapsed = time.perf_counter() - start
@@ -1192,6 +1313,7 @@ class AppleMailConnector:
         include_attachments: bool = False,
         body_contains: str | None = None,
         text_contains: str | None = None,
+        received_within_hours: int | None = None,
     ) -> list[dict[str, Any]]:
         """AppleScript path for search_messages (the universal baseline).
 
@@ -1270,30 +1392,9 @@ class AppleMailConnector:
                 f'then set includeThis to false'
             )
 
-        if date_from is not None:
-            if not _ISO_DATE_RE.match(date_from):
-                raise ValueError(
-                    f"date_from must be ISO 8601 YYYY-MM-DD, got: {date_from!r}"
-                )
-            filter_checks.append(
-                f'if (date received of msg) < (date "{date_from}") '
-                f'then set includeThis to false'
-            )
-
-        if date_to is not None:
-            if not _ISO_DATE_RE.match(date_to):
-                raise ValueError(
-                    f"date_to must be ISO 8601 YYYY-MM-DD, got: {date_to!r}"
-                )
-            # Upper bound is exclusive of the day AFTER date_to, so the full
-            # day of date_to is included.
-            next_day = (
-                _date.fromisoformat(date_to) + _timedelta(days=1)
-            ).isoformat()
-            filter_checks.append(
-                f'if (date received of msg) >= (date "{next_day}") '
-                f'then set includeThis to false'
-            )
+        filter_checks.extend(
+            _build_date_filter_clauses(date_from, date_to, received_within_hours)
+        )
 
         if has_attachment is True:
             filter_checks.append(

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -772,6 +772,7 @@ def search_messages(
     is_flagged: bool | None = None,
     date_from: str | None = None,
     date_to: str | None = None,
+    received_within_hours: int | None = None,
     has_attachment: bool | None = None,
     limit: int = 50,
     source: list[str] | None = None,
@@ -815,6 +816,10 @@ def search_messages(
         is_flagged: Filter by flagged status (true=flagged, false=not flagged).
         date_from: Inclusive lower bound on date received. ISO 8601 YYYY-MM-DD.
         date_to: Inclusive upper bound on date received (full day included). ISO 8601 YYYY-MM-DD.
+        received_within_hours: Relative-time filter. When set, only return
+            messages received within the last N hours (hour precision).
+            Composes with ``date_from`` / ``date_to`` — the most restrictive
+            filter wins. Must be a positive int. Days = 24, weeks = 168, etc.
         has_attachment: Filter messages with (true) or without (false) attachments.
         limit: Maximum results to return (default: 50).
         source: Optional list of message ids (with optional ``"SELECTED"``
@@ -940,6 +945,7 @@ def search_messages(
             is_flagged=is_flagged,
             date_from=date_from,
             date_to=date_to,
+            received_within_hours=received_within_hours,
             has_attachment=has_attachment,
             limit=limit,
             include_attachments=include_attachments,

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -5952,3 +5952,253 @@ class TestDeleteMailbox:
         mock_cfg.assert_not_called()
         mock_pw.assert_not_called()
         mock_imap_cls.assert_not_called()
+
+
+# =============================================================================
+# received_within_hours (#230)
+# =============================================================================
+
+
+class TestReceivedWithinHours:
+    """Tests for the new `received_within_hours` parameter on search_messages.
+
+    Connector-tier coverage: AppleScript clause emission, IMAP-path
+    post-filter, validation, composition with date_from, and the _now()
+    monkeypatch hook used for deterministic time math.
+    """
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_applescript_emits_relative_hours_clause(
+        self, mock_run: MagicMock
+    ) -> None:
+        """AS path should embed `(current date) - (N * hours)` directly so
+        Mail.app does the hour-precise comparison server-side."""
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+        connector = AppleMailConnector()
+        mock_run.return_value = "[]"
+        connector._search_messages_applescript(
+            "Gmail", "INBOX", received_within_hours=6
+        )
+        script = mock_run.call_args[0][0]
+        assert (
+            "if (date received of msg) < ((current date) - (6 * hours)) "
+            "then set includeThis to false"
+        ) in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_applescript_rejects_zero_hours(
+        self, mock_run: MagicMock
+    ) -> None:
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+        connector = AppleMailConnector()
+        with pytest.raises(ValueError, match="received_within_hours"):
+            connector._search_messages_applescript(
+                "Gmail", "INBOX", received_within_hours=0
+            )
+        mock_run.assert_not_called()
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_applescript_rejects_negative_hours(
+        self, mock_run: MagicMock
+    ) -> None:
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+        connector = AppleMailConnector()
+        with pytest.raises(ValueError, match="received_within_hours"):
+            connector._search_messages_applescript(
+                "Gmail", "INBOX", received_within_hours=-5
+            )
+        mock_run.assert_not_called()
+
+    def test_search_messages_combines_received_within_hours_with_date_from(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """received_within_hours takes the more-restrictive cutoff vs date_from.
+
+        Cutoff is now - 48h = 2026-05-23. date_from is 2026-05-01 (less
+        restrictive). The AS path should see date_from=2026-05-23.
+        """
+        from datetime import datetime
+
+        from apple_mail_mcp import mail_connector
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        monkeypatch.setattr(
+            mail_connector, "_now",
+            lambda: datetime(2026, 5, 25, 14, 30, 0).astimezone(),
+        )
+        connector = AppleMailConnector()
+        # Force AS path
+        monkeypatch.setattr(
+            connector, "_imap_breaker_open", lambda account: True
+        )
+        captured: dict[str, Any] = {}
+
+        def fake_as(
+            account: str,
+            mailbox: str = "INBOX",
+            sender_contains: str | None = None,
+            subject_contains: str | None = None,
+            read_status: bool | None = None,
+            is_flagged: bool | None = None,
+            date_from: str | None = None,
+            *args: Any,
+            **kwargs: Any,
+        ) -> list[dict[str, Any]]:
+            captured["date_from"] = date_from
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr(
+            connector, "_search_messages_applescript", fake_as
+        )
+        connector.search_messages(
+            "Gmail",
+            mailbox="INBOX",
+            date_from="2026-05-01",
+            received_within_hours=48,
+        )
+        assert captured["date_from"] == "2026-05-23"
+        # received_within_hours plumbed through (so AS embeds hour clause)
+        assert captured.get("received_within_hours") == 48
+
+    def test_search_messages_keeps_more_restrictive_date_from(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When date_from is more restrictive than the relative cutoff, it wins."""
+        from datetime import datetime
+
+        from apple_mail_mcp import mail_connector
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        monkeypatch.setattr(
+            mail_connector, "_now",
+            lambda: datetime(2026, 5, 25, 14, 30, 0).astimezone(),
+        )
+        connector = AppleMailConnector()
+        monkeypatch.setattr(
+            connector, "_imap_breaker_open", lambda account: True
+        )
+        captured: dict[str, Any] = {}
+
+        def fake_as(
+            account: str,
+            mailbox: str = "INBOX",
+            sender_contains: str | None = None,
+            subject_contains: str | None = None,
+            read_status: bool | None = None,
+            is_flagged: bool | None = None,
+            date_from: str | None = None,
+            *args: Any,
+            **kwargs: Any,
+        ) -> list[dict[str, Any]]:
+            captured["date_from"] = date_from
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr(
+            connector, "_search_messages_applescript", fake_as
+        )
+        # received_within_hours=720 = 30 days, cutoff = 2026-04-25.
+        # date_from = 2026-05-25 is more restrictive.
+        connector.search_messages(
+            "Gmail",
+            mailbox="INBOX",
+            date_from="2026-05-25",
+            received_within_hours=720,
+        )
+        assert captured["date_from"] == "2026-05-25"
+
+    def test_search_messages_imap_path_post_filters_by_cutoff(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """IMAP path returns day-granular SINCE results; the cutoff_dt
+        post-filter trims to hour precision."""
+        from datetime import datetime, timedelta, timezone
+
+        from apple_mail_mcp import mail_connector
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        # Use a fixed UTC "now" for determinism. Cutoff = now - 6h.
+        now_utc = datetime(2026, 5, 25, 14, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(mail_connector, "_now", lambda: now_utc)
+
+        connector = AppleMailConnector()
+        # IMAP path: breaker closed and _imap_search returns 3 messages.
+        monkeypatch.setattr(
+            connector, "_imap_breaker_open", lambda account: False
+        )
+        msg_within = {
+            "id": "a",
+            "date_received": (now_utc - timedelta(hours=3)).isoformat(),
+        }
+        msg_outside = {
+            "id": "b",
+            "date_received": (now_utc - timedelta(hours=10)).isoformat(),
+        }
+        msg_unparseable = {"id": "c", "date_received": ""}
+
+        def fake_imap(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+            return [msg_within, msg_outside, msg_unparseable]
+
+        monkeypatch.setattr(connector, "_imap_search", fake_imap)
+        monkeypatch.setattr(
+            connector, "_imap_clear_breaker", lambda account: None
+        )
+
+        result = connector.search_messages(
+            "Gmail",
+            mailbox="INBOX",
+            received_within_hours=6,
+        )
+
+        ids = [m["id"] for m in result]
+        # Within cutoff: kept. Outside: dropped. Unparseable: kept (defensive).
+        assert "a" in ids
+        assert "b" not in ids
+        assert "c" in ids
+
+    def test_search_messages_no_effect_when_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """received_within_hours=None preserves existing behavior."""
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        connector = AppleMailConnector()
+        monkeypatch.setattr(
+            connector, "_imap_breaker_open", lambda account: True
+        )
+        captured: dict[str, Any] = {}
+
+        def fake_as(
+            account: str,
+            mailbox: str = "INBOX",
+            sender_contains: str | None = None,
+            subject_contains: str | None = None,
+            read_status: bool | None = None,
+            is_flagged: bool | None = None,
+            date_from: str | None = None,
+            *args: Any,
+            **kwargs: Any,
+        ) -> list[dict[str, Any]]:
+            captured["date_from"] = date_from
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr(
+            connector, "_search_messages_applescript", fake_as
+        )
+        connector.search_messages("Gmail", mailbox="INBOX", date_from="2026-05-01")
+        assert captured.get("received_within_hours") is None
+        assert captured["date_from"] == "2026-05-01"
+
+    def test_now_helper_is_monkeypatchable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The _now() module helper exists and can be monkeypatched in tests."""
+        from datetime import datetime, timezone
+
+        from apple_mail_mcp import mail_connector
+
+        fixed = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(mail_connector, "_now", lambda: fixed)
+        assert mail_connector._now() == fixed

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -645,6 +645,7 @@ class TestSearchMessages:
             is_flagged=None,
             date_from=None,
             date_to=None,
+            received_within_hours=None,
             has_attachment=None,
             limit=10,
             include_attachments=False,
@@ -706,6 +707,7 @@ class TestSearchMessages:
             is_flagged=True,
             date_from="2026-04-01",
             date_to="2026-04-15",
+            received_within_hours=None,
             has_attachment=True,
             limit=25,
             include_attachments=False,
@@ -751,6 +753,39 @@ class TestSearchMessages:
 
         assert result["success"] is False
         assert result["error_type"] == "unknown"
+
+    # ---- received_within_hours (#230) ----------------------------------
+
+    def test_received_within_hours_passed_to_connector(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.search_messages.return_value = []
+        result = search_messages("Gmail", received_within_hours=24)
+        assert result["success"] is True
+        kwargs = mock_mail.search_messages.call_args.kwargs
+        assert kwargs["received_within_hours"] == 24
+
+    def test_received_within_hours_zero_rejected(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """Validation raised in connector; server surfaces validation_error."""
+        mock_mail.search_messages.side_effect = ValueError(
+            "received_within_hours must be > 0, got: 0"
+        )
+        result = search_messages("Gmail", received_within_hours=0)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        assert "received_within_hours" in result["error"]
+
+    def test_received_within_hours_negative_rejected(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        mock_mail.search_messages.side_effect = ValueError(
+            "received_within_hours must be > 0, got: -5"
+        )
+        result = search_messages("Gmail", received_within_hours=-5)
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
 
     # ---- source="selected" (folded-in get_selected_messages, #131) -------
 


### PR DESCRIPTION
## Summary
- Adds `received_within_hours: int | None = None` to `search_messages` for hour-granular "last N hours" queries.
- Composes with `date_from`/`date_to` — most restrictive filter wins.
- AppleScript path embeds `(date received of msg) < ((current date) - (N * hours))` so Mail.app does the hour-precise comparison server-side.
- IMAP path uses day-floored SINCE (per RFC 3501) and Python post-filters to enforce hour precision on the returned set.
- New `_now()` helper at module level lets tests monkeypatch wall-clock time (no freezegun dependency).
- Extracted `_build_date_filter_clauses` to keep `_search_messages_applescript` under the complexity ceiling.

## Closes
Closes #230

## Test plan
- [x] `make check-all` passes (1066 unit tests, lint, mypy, complexity, version-sync, parity)
- [ ] Manual smoke (post-merge, optional): `search_messages(account="Gmail", received_within_hours=24, limit=20)` returns only messages from the last 24 hours on a real account

## Notes
- Param ordering: inserted after `date_to`, before `has_attachment` — keeps date-related params adjacent.
- `received_within_hours <= 0` is rejected at the connector tier with `ValueError`; server surfaces as `error_type: "validation_error"` via the existing catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)