### PR TITLE
fix(#243): IMAP Keychain lookup tries both name and UUID forms

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -1074,6 +1074,51 @@ class AppleMailConnector:
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
+    def _get_imap_password_with_fallback(
+        self, account: str, email: str
+    ) -> str:
+        """Look up the IMAP Keychain password, retrying with the alternative
+        account-identifier form (name ↔ UUID) on a NotFound miss. (#243)
+
+        Keychain entries are written by ``setup-imap`` keyed on whatever
+        string the user typed — typically the Mail.app account NAME.
+        Callers (including the MCP layer) may legitimately pass either the
+        name or the UUID per the documented stability story on
+        ``search_messages.account``. This wrapper bridges the gap: try the
+        caller-supplied form first; on NotFound, resolve UUID↔name via
+        ``list_accounts()`` and retry. Other Keychain errors (AccessDenied,
+        generic Keychain errors) are NOT retried — they're explicit signals
+        from macOS and falling back would mask them.
+        """
+        try:
+            return get_imap_password(account, email)
+        except MailKeychainEntryNotFoundError:
+            alt = self._alternative_account_identifier(account)
+            if alt is None:
+                raise
+            return get_imap_password(alt, email)
+
+    def _alternative_account_identifier(self, account: str) -> str | None:
+        """Given a Mail.app account name OR UUID, return the other form.
+
+        Returns ``None`` if the input doesn't match any account or if the
+        account list can't be retrieved. Used by
+        ``_get_imap_password_with_fallback`` to bridge the
+        name-vs-UUID Keychain key mismatch.
+        """
+        try:
+            accounts = self.list_accounts()
+        except Exception:
+            return None
+        for acc in accounts:
+            name = acc.get("name")
+            uid = acc.get("id")
+            if name == account and uid:
+                return cast(str, uid)
+            if uid == account and name:
+                return cast(str, name)
+        return None
+
     def _resolve_imap_config(self, account: str) -> tuple[str, int, str]:
         """Query Mail.app for the IMAP connection details of an account.
 
@@ -1153,7 +1198,7 @@ class AppleMailConnector:
             MailAccountNotFoundError: Mail.app doesn't know this account.
         """
         host, port, email = self._resolve_imap_config(account)
-        password = get_imap_password(account, email)
+        password = self._get_imap_password_with_fallback(account, email)
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.search_messages(
             mailbox=mailbox,
@@ -1566,7 +1611,7 @@ class AppleMailConnector:
         caller (get_message) catches and falls back.
         """
         host, port, email = self._resolve_imap_config(account)
-        password = get_imap_password(account, email)
+        password = self._get_imap_password_with_fallback(account, email)
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.get_message(
             message_id,
@@ -1796,7 +1841,7 @@ class AppleMailConnector:
         caller (get_attachments) catches and falls back.
         """
         host, port, email = self._resolve_imap_config(account)
-        password = get_imap_password(account, email)
+        password = self._get_imap_password_with_fallback(account, email)
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.get_attachments(message_id, mailbox=mailbox)
 
@@ -1898,7 +1943,7 @@ class AppleMailConnector:
         """
         account = cast(str, anchor["account"])
         host, port, email = self._resolve_imap_config(account)
-        password = get_imap_password(account, email)
+        password = self._get_imap_password_with_fallback(account, email)
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.find_thread_members(
             anchor_rfc_message_id=cast(str, anchor["rfc_message_id"]),
@@ -1921,7 +1966,7 @@ class AppleMailConnector:
         and falls back via _IMAP_FALLBACK_EXCS.
         """
         host, port, email = self._resolve_imap_config(account)
-        password = get_imap_password(account, email)
+        password = self._get_imap_password_with_fallback(account, email)
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.move_messages(
             message_ids=message_ids,
@@ -1977,7 +2022,7 @@ class AppleMailConnector:
         (_try_imap_delete) catches and falls back via _IMAP_FALLBACK_EXCS.
         """
         host, port, email = self._resolve_imap_config(account)
-        password = get_imap_password(account, email)
+        password = self._get_imap_password_with_fallback(account, email)
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.delete_messages(
             message_ids=message_ids,
@@ -2029,7 +2074,7 @@ class AppleMailConnector:
         unchanged.
         """
         host, port, email = self._resolve_imap_config(account)
-        password = get_imap_password(account, email)
+        password = self._get_imap_password_with_fallback(account, email)
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.set_read_status(
             message_ids=message_ids,
@@ -2153,7 +2198,7 @@ class AppleMailConnector:
         exceptions unchanged.
         """
         host, port, email = self._resolve_imap_config(account)
-        password = get_imap_password(account, email)
+        password = self._get_imap_password_with_fallback(account, email)
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         return imap.set_flagged_status(
             message_ids=message_ids,
@@ -2997,7 +3042,7 @@ class AppleMailConnector:
 
         try:
             host, port, email = self._resolve_imap_config(account)
-            password = get_imap_password(account, email)
+            password = self._get_imap_password_with_fallback(account, email)
         except (
             MailKeychainEntryNotFoundError, MailKeychainAccessDeniedError
         ) as e:
@@ -3067,7 +3112,7 @@ class AppleMailConnector:
 
         try:
             host, port, email = self._resolve_imap_config(account)
-            password = get_imap_password(account, email)
+            password = self._get_imap_password_with_fallback(account, email)
         except (
             MailKeychainEntryNotFoundError, MailKeychainAccessDeniedError
         ) as e:

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -6202,3 +6202,158 @@ class TestReceivedWithinHours:
         fixed = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         monkeypatch.setattr(mail_connector, "_now", lambda: fixed)
         assert mail_connector._now() == fixed
+
+
+# =============================================================================
+# IMAP Keychain dual-form lookup (#243)
+# =============================================================================
+
+
+class TestKeychainDualFormLookup:
+    """Keychain entries are written under whatever string the user typed at
+    setup-imap time (typically the account NAME). Callers may legitimately
+    pass either the name or the UUID (per the docstring's stability claim).
+    The wrapper retries with the alternative form on initial NotFound.
+    """
+
+    def test_primary_lookup_succeeds_no_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the caller-supplied form matches the Keychain entry, the
+        wrapper returns the password without touching list_accounts."""
+        from apple_mail_mcp import mail_connector
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        list_accounts_called = []
+        monkeypatch.setattr(
+            mail_connector, "get_imap_password",
+            lambda acct, email: "PRIMARY-PW" if acct == "Gmail" else (_ for _ in ()).throw(AssertionError(f"unexpected {acct}")),
+        )
+        c = AppleMailConnector()
+        monkeypatch.setattr(
+            c, "list_accounts",
+            lambda: list_accounts_called.append(1) or [],
+        )
+        result = c._get_imap_password_with_fallback("Gmail", "alice@gmail.com")
+        assert result == "PRIMARY-PW"
+        assert list_accounts_called == [], (
+            "list_accounts must not be called on the happy path"
+        )
+
+    def test_uuid_lookup_falls_back_to_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Caller passed the UUID; Keychain entry was written under the
+        name. Wrapper resolves UUID → name and retries."""
+        from apple_mail_mcp import mail_connector
+        from apple_mail_mcp.exceptions import MailKeychainEntryNotFoundError
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        attempts: list[str] = []
+
+        def fake_get(acct: str, email: str) -> str:
+            attempts.append(acct)
+            if acct == "Gmail":
+                return "FALLBACK-PW"
+            raise MailKeychainEntryNotFoundError(f"no entry for {acct}")
+
+        monkeypatch.setattr(mail_connector, "get_imap_password", fake_get)
+        c = AppleMailConnector()
+        monkeypatch.setattr(
+            c, "list_accounts",
+            lambda: [{"name": "Gmail", "id": "04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16"}],
+        )
+        result = c._get_imap_password_with_fallback(
+            "04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16", "alice@gmail.com"
+        )
+        assert result == "FALLBACK-PW"
+        # Order: UUID first, then name
+        assert attempts == ["04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16", "Gmail"]
+
+    def test_name_lookup_falls_back_to_uuid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Inverse case: setup wrote the entry under UUID; caller used the name."""
+        from apple_mail_mcp import mail_connector
+        from apple_mail_mcp.exceptions import MailKeychainEntryNotFoundError
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        def fake_get(acct: str, email: str) -> str:
+            if acct == "04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16":
+                return "UUID-PW"
+            raise MailKeychainEntryNotFoundError(f"no entry for {acct}")
+
+        monkeypatch.setattr(mail_connector, "get_imap_password", fake_get)
+        c = AppleMailConnector()
+        monkeypatch.setattr(
+            c, "list_accounts",
+            lambda: [{"name": "Gmail", "id": "04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16"}],
+        )
+        assert c._get_imap_password_with_fallback(
+            "Gmail", "alice@gmail.com"
+        ) == "UUID-PW"
+
+    def test_both_forms_missing_raises_original(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from apple_mail_mcp import mail_connector
+        from apple_mail_mcp.exceptions import MailKeychainEntryNotFoundError
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        def always_missing(acct: str, email: str) -> str:
+            raise MailKeychainEntryNotFoundError(f"no entry for {acct}")
+
+        monkeypatch.setattr(mail_connector, "get_imap_password", always_missing)
+        c = AppleMailConnector()
+        monkeypatch.setattr(
+            c, "list_accounts",
+            lambda: [{"name": "Gmail", "id": "04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16"}],
+        )
+        with pytest.raises(MailKeychainEntryNotFoundError):
+            c._get_imap_password_with_fallback(
+                "04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16", "alice@gmail.com"
+            )
+
+    def test_access_denied_does_not_fall_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AccessDenied is a deliberate user/system signal — falling back
+        would mask it. Only NotFound triggers the alternative-form retry."""
+        from apple_mail_mcp import mail_connector
+        from apple_mail_mcp.exceptions import MailKeychainAccessDeniedError
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        attempts: list[str] = []
+
+        def fake_get(acct: str, email: str) -> str:
+            attempts.append(acct)
+            raise MailKeychainAccessDeniedError(f"denied for {acct}")
+
+        monkeypatch.setattr(mail_connector, "get_imap_password", fake_get)
+        c = AppleMailConnector()
+        # list_accounts must not be consulted; assert via failure if called
+        monkeypatch.setattr(
+            c, "list_accounts",
+            lambda: (_ for _ in ()).throw(AssertionError("should not be called")),
+        )
+        with pytest.raises(MailKeychainAccessDeniedError):
+            c._get_imap_password_with_fallback("Gmail", "alice@gmail.com")
+        assert attempts == ["Gmail"]
+
+    def test_no_alternative_in_account_list_raises_original(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If list_accounts can't find the input form (e.g. wrong account),
+        re-raise the original NotFound — don't try a guess."""
+        from apple_mail_mcp import mail_connector
+        from apple_mail_mcp.exceptions import MailKeychainEntryNotFoundError
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        def always_missing(acct: str, email: str) -> str:
+            raise MailKeychainEntryNotFoundError(f"no entry for {acct}")
+
+        monkeypatch.setattr(mail_connector, "get_imap_password", always_missing)
+        c = AppleMailConnector()
+        monkeypatch.setattr(c, "list_accounts", lambda: [])
+        with pytest.raises(MailKeychainEntryNotFoundError):
+            c._get_imap_password_with_fallback("Unknown", "alice@example.com")


### PR DESCRIPTION
## Summary
- IMAP fast path now finds the Keychain entry regardless of whether the caller passes the Mail.app account name (e.g. `Gmail`) or its UUID (e.g. `04E9E040-...`).
- New `_get_imap_password_with_fallback` wrapper retries with the alternative form (resolved via `list_accounts()`) on NotFound. `AccessDenied` and other Keychain errors are not retried — they're explicit signals that falling back would mask.
- All 10 IMAP fast-path call sites updated.
- 6 unit tests cover the happy path, UUID→name fallback, name→UUID fallback, both-forms-missing, AccessDenied non-retry, and the no-alternative-found case.

## Closes
Closes #243

## Test plan
- [x] `make check-all` passes (1072 unit tests, lint, mypy, complexity, version-sync, parity)
- [x] Live verification against a real Gmail account: a UUID-keyed `search_messages(received_within_hours=24, limit=50)` that was timing out at 60s on the AppleScript fallback now returns in 2.9s via the IMAP fast path.

## Notes
- Out of scope: the `setup-imap` CLI doesn't accept UUIDs as `--account` values (related bug surfaced during the user's workaround attempt). Worth a follow-up issue if needed, but doesn't block this fix — once IMAP is set up under either form, the runtime now bridges the other.
- Trade-off: on a Keychain miss we now make one extra AppleScript call (`list_accounts`). That's <1s and only happens on the "wrong form was used" path; the common case (form matches) has zero overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)