### PR TITLE
fix(#245): create compose drafts via IMAP APPEND (avoid Mail.app cite-blockquote)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-**Compose drafts (`create_draft seed="new"`) created via IMAP APPEND to avoid Mail.app's cite-blockquote wrapper (#245):** Mail.app wraps any AppleScript-set message `content` in an `Apple-Mail-URLShareWrapper` `<blockquote type="cite">` when it serializes the draft to HTML. On macOS and most receiving clients the neutralizing inline styles hide it, but iOS Mail renders the entire body as a quote (blue text + left bar). This is an unfixed Mail.app regression since Mail 16.0 / macOS Ventura (Apple Feedback FB11734014); it cannot be worked around through AppleScript — Mail's `content` (rich text) is the only writable body, `html content` is a deprecated no-op, and `source` is read-only (verified against `Mail.sdef`).
-
-The fix bypasses Mail's scripting entirely for save-as-draft compose: `create_draft(seed="new", send_now=False, from_account=...)` now builds a clean RFC 822 message (`draft_builder.build_draft_mime`) and APPENDs it to the account's `\Drafts` SPECIAL-USE folder with the `\Draft` flag (`ImapConnector.append_draft`). The stored draft is plain `text/plain` and renders normally on iOS (verified on-device). Header inputs are sanitized against NUL / CR / LF injection. The path reuses the existing Keychain + IMAP-pool plumbing and degrades gracefully: when IMAP isn't configured (no Keychain opt-in) or the account is unknown, it falls back to the AppleScript path via the standard `_IMAP_FALLBACK_EXCS` circuit breaker, so there is no regression for users without IMAP set up.
-
-**Scope / limitations:** This PR covers `seed="new"` save-as-draft only. `reply` / `forward` seeds and `send_now=True` continue to use the AppleScript path for now (the latter cannot be done over IMAP APPEND, which only creates drafts); routing replies through IMAP and a clean SMTP send path are follow-ups. Reported and diagnosed by [@fmasi](https://github.com/fmasi) (#245).
-
 ## [0.8.2] - 2026-05-20
 
 Patch release. Three substantive bug fixes — one security regression in our own gate chain, one regression introduced at v0.8.1, and one long-latent AppleEvent timeout bug surfaced by use on slow Exchange/EWS accounts. Two of the three are contributor-authored: [@fmasi](https://github.com/fmasi) reported and fixed the v0.8.1 regression they noticed within hours of release; [@allenpan05](https://github.com/allenpan05) reported and fixed the AppleEvent timeout bug. Thanks to both.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+**Compose drafts (`create_draft seed="new"`) created via IMAP APPEND to avoid Mail.app's cite-blockquote wrapper (#245):** Mail.app wraps any AppleScript-set message `content` in an `Apple-Mail-URLShareWrapper` `<blockquote type="cite">` when it serializes the draft to HTML. On macOS and most receiving clients the neutralizing inline styles hide it, but iOS Mail renders the entire body as a quote (blue text + left bar). This is an unfixed Mail.app regression since Mail 16.0 / macOS Ventura (Apple Feedback FB11734014); it cannot be worked around through AppleScript — Mail's `content` (rich text) is the only writable body, `html content` is a deprecated no-op, and `source` is read-only (verified against `Mail.sdef`).
+
+The fix bypasses Mail's scripting entirely for save-as-draft compose: `create_draft(seed="new", send_now=False, from_account=...)` now builds a clean RFC 822 message (`draft_builder.build_draft_mime`) and APPENDs it to the account's `\Drafts` SPECIAL-USE folder with the `\Draft` flag (`ImapConnector.append_draft`). The stored draft is plain `text/plain` and renders normally on iOS (verified on-device). Header inputs are sanitized against NUL / CR / LF injection. The path reuses the existing Keychain + IMAP-pool plumbing and degrades gracefully: when IMAP isn't configured (no Keychain opt-in) or the account is unknown, it falls back to the AppleScript path via the standard `_IMAP_FALLBACK_EXCS` circuit breaker, so there is no regression for users without IMAP set up.
+
+**Scope / limitations:** This PR covers `seed="new"` save-as-draft only. `reply` / `forward` seeds and `send_now=True` continue to use the AppleScript path for now (the latter cannot be done over IMAP APPEND, which only creates drafts); routing replies through IMAP and a clean SMTP send path are follow-ups. Reported and diagnosed by [@fmasi](https://github.com/fmasi) (#245).
+
 ## [0.8.2] - 2026-05-20
 
 Patch release. Three substantive bug fixes — one security regression in our own gate chain, one regression introduced at v0.8.1, and one long-latent AppleEvent timeout bug surfaced by use on slow Exchange/EWS accounts. Two of the three are contributor-authored: [@fmasi](https://github.com/fmasi) reported and fixed the v0.8.1 regression they noticed within hours of release; [@allenpan05](https://github.com/allenpan05) reported and fixed the AppleEvent timeout bug. Thanks to both.

--- a/src/apple_mail_mcp/draft_builder.py
+++ b/src/apple_mail_mcp/draft_builder.py
@@ -1,0 +1,71 @@
+"""Build a clean RFC822 draft message for IMAP APPEND (issue #245).
+
+Mail.app's AppleScript ``content`` setter wraps every body in an
+``Apple-Mail-URLShareWrapper`` ``<blockquote type="cite">`` (a Mail.app
+bug, FB11734014) that renders as a quote on iOS. Creating the draft as a
+hand-built RFC822 message and APPENDing it over IMAP bypasses that path
+entirely.
+
+This module is intentionally pure (no Mail.app, no IMAP) so the MIME
+shape is unit-testable in isolation.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+from email.message import EmailMessage
+from email.utils import formatdate, make_msgid
+from pathlib import Path
+
+
+def _sanitize_header(value: str) -> str:
+    """Strip characters that would corrupt or inject email headers.
+
+    Removes NUL (which the email lib passes through silently) and CR/LF
+    (which would otherwise raise or enable header injection). Mirrors the
+    AppleScript path's sanitize_input convention (#173).
+    """
+    return value.replace("\x00", "").replace("\r", "").replace("\n", "")
+
+
+def build_draft_mime(
+    *,
+    sender: str,
+    to: list[str],
+    subject: str,
+    body: str,
+    cc: list[str] | None = None,
+    bcc: list[str] | None = None,
+    attachments: list[Path] | None = None,
+) -> tuple[str, bytes]:
+    """Build a plain-text draft message.
+
+    Returns ``(message_id, raw_bytes)`` where ``message_id`` is the
+    generated RFC 5322 Message-ID (angle-bracketed) and ``raw_bytes`` is
+    the serialized message suitable for ``IMAPClient.append``.
+    """
+    msg = EmailMessage()
+    message_id = make_msgid()
+    msg["Message-ID"] = message_id
+    msg["From"] = _sanitize_header(sender)
+    msg["To"] = ", ".join(_sanitize_header(a) for a in to)
+    if cc:
+        msg["Cc"] = ", ".join(_sanitize_header(a) for a in cc)
+    if bcc:
+        msg["Bcc"] = ", ".join(_sanitize_header(a) for a in bcc)
+    msg["Subject"] = _sanitize_header(subject)
+    msg["Date"] = formatdate(localtime=True)
+    msg.set_content(body)
+
+    for path in attachments or []:
+        path = Path(path)
+        ctype, _encoding = mimetypes.guess_type(path.name)
+        maintype, _, subtype = (ctype or "application/octet-stream").partition("/")
+        msg.add_attachment(
+            path.read_bytes(),
+            maintype=maintype,
+            subtype=subtype or "octet-stream",
+            filename=path.name,
+        )
+
+    return message_id, msg.as_bytes()

--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -34,7 +34,7 @@ from datetime import datetime as _datetime
 from datetime import timedelta as _timedelta
 from typing import Any, cast
 
-from imapclient import IMAPClient
+from imapclient import DRAFT, IMAPClient
 from imapclient.exceptions import IMAPClientError, LoginError
 from imapclient.response_types import Envelope
 
@@ -1047,6 +1047,63 @@ class ImapConnector:
         "Deleted Messages",
         "Deleted Items",
     )
+
+    # Conventional Drafts folder names to fall back on when the server
+    # doesn't advertise \\Drafts via SPECIAL-USE (RFC 6154). Issue #245.
+    _CONVENTIONAL_DRAFTS_NAMES: tuple[str, ...] = (
+        "Drafts",
+        "[Gmail]/Drafts",
+        "INBOX.Drafts",
+    )
+
+    def append_draft(self, raw_message: bytes) -> str:
+        """APPEND a pre-built RFC822 message to the account's Drafts
+        folder with the ``\\Draft`` flag, and return the folder used.
+
+        Bypasses Mail.app's AppleScript ``content`` setter, which wraps
+        every body in an ``Apple-Mail-URLShareWrapper``
+        ``<blockquote type="cite">`` that renders as a quote on iOS
+        (Mail.app bug FB11734014, issue #245). The caller builds
+        ``raw_message`` via :func:`apple_mail_mcp.draft_builder.build_draft_mime`.
+        """
+        with self._session() as client:
+            folder = self._find_drafts_folder(
+                client
+            ) or self._find_drafts_by_convention(client)
+            if folder is None:
+                raise MailMessageNotFoundError(
+                    f"No Drafts folder found on {self._host} "
+                    f"(no \\Drafts SPECIAL-USE flag and none of "
+                    f"{list(self._CONVENTIONAL_DRAFTS_NAMES)} present)."
+                )
+            client.append(folder, raw_message, flags=[DRAFT])
+            return folder
+
+    @staticmethod
+    def _find_drafts_folder(client: IMAPClient) -> str | None:
+        """Return the Drafts folder name via the ``\\Drafts`` SPECIAL-USE
+        flag (RFC 6154), or None if the server doesn't advertise it."""
+        for flags, _delim, name in client.list_folders():
+            if b"\\Drafts" in flags:
+                if isinstance(name, (bytes, bytearray)):
+                    return name.decode("utf-8", errors="replace")
+                return cast(str, name)
+        return None
+
+    def _find_drafts_by_convention(self, client: IMAPClient) -> str | None:
+        """Fall back to conventional Drafts names for servers that don't
+        advertise SPECIAL-USE ``\\Drafts``. First match wins in
+        :attr:`_CONVENTIONAL_DRAFTS_NAMES` order."""
+        present: set[str] = set()
+        for _flags, _delim, name in client.list_folders():
+            if isinstance(name, (bytes, bytearray)):
+                present.add(name.decode("utf-8", errors="replace"))
+            else:
+                present.add(name)
+        for candidate in self._CONVENTIONAL_DRAFTS_NAMES:
+            if candidate in present:
+                return candidate
+        return None
 
     def delete_messages(
         self,

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -4029,7 +4029,7 @@ class AppleMailConnector:
         """
         sender = self._resolve_account_to_sender(from_account)
         host, port, email = self._resolve_imap_config(from_account)
-        password = get_imap_password(from_account, email)
+        password = self._get_imap_password_with_fallback(from_account, email)
         message_id, raw = build_draft_mime(
             sender=sender,
             to=to,

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 
 from imapclient.exceptions import IMAPClientError, LoginError
 
+from .draft_builder import build_draft_mime
 from .drafts import _validate_draft_id
 from .exceptions import (
     MailAccountNotFoundError,
@@ -4005,6 +4006,46 @@ class AppleMailConnector:
             set theMessage to {verb} origMsg opening window false
         """
 
+    def _create_draft_via_imap(
+        self,
+        *,
+        from_account: str,
+        to: list[str],
+        cc: list[str] | None,
+        bcc: list[str] | None,
+        subject: str,
+        body: str,
+        attachment_paths: list[Path] | None,
+    ) -> dict[str, str]:
+        """Create a save-as-draft by APPENDing a clean RFC822 message over
+        IMAP (issue #245), instead of Mail.app's AppleScript ``content``
+        setter. Returns the generated RFC Message-ID as ``draft_id``.
+
+        Raises the standard ``_IMAP_FALLBACK_EXCS`` (e.g. no Keychain
+        opt-in, network failure) which ``create_draft`` catches to fall
+        back to AppleScript. ``MailAccountNotFoundError`` / ``ValueError``
+        from sender resolution are NOT caught — they are caller/config
+        errors and must surface.
+        """
+        sender = self._resolve_account_to_sender(from_account)
+        host, port, email = self._resolve_imap_config(from_account)
+        password = get_imap_password(from_account, email)
+        message_id, raw = build_draft_mime(
+            sender=sender,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            subject=subject,
+            body=body,
+            attachments=(
+                [Path(p) for p in attachment_paths] if attachment_paths else None
+            ),
+        )
+        imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
+        imap.append_draft(raw)
+        self._imap_clear_breaker(from_account)
+        return {"draft_id": message_id, "sent_message_id": ""}
+
     def create_draft(
         self,
         *,
@@ -4021,6 +4062,14 @@ class AppleMailConnector:
         send_now: bool = False,
     ) -> dict[str, str]:
         """Create a draft (fresh, reply, or forward). Optionally send.
+
+        For ``seed="new"`` save-as-draft (``send_now=False``) with a known
+        ``from_account``, the draft is created via IMAP APPEND of a clean
+        RFC 822 message rather than Mail.app's AppleScript ``content``
+        setter, which wraps the body in a cite-blockquote that renders as
+        a quote on iOS (Mail.app bug FB11734014, #245). Falls back to the
+        AppleScript path when IMAP isn't configured. Reply/forward and
+        ``send_now=True`` still use AppleScript.
 
         Args:
             seed: ``"new"``, ``"reply"``, or ``"forward"``.
@@ -4058,6 +4107,33 @@ class AppleMailConnector:
             MailAppleScriptError: AppleScript failure.
         """
         self._validate_create_draft_args(seed, seed_id, to, subject)
+
+        # IMAP-APPEND path for compose drafts (issue #245): bypasses
+        # Mail.app's AppleScript `content` setter, which wraps the body in
+        # an Apple-Mail-URLShareWrapper <blockquote type="cite"> (Mail.app
+        # bug FB11734014) that renders as a quote on iOS. Scoped to
+        # seed="new" save-as-draft with a known account; on the usual
+        # IMAP-degradation signals (e.g. no Keychain opt-in) we fall back
+        # to the AppleScript path below, preserving prior behavior.
+        if (
+            seed == "new"
+            and not send_now
+            and from_account is not None
+            and not self._imap_breaker_open(from_account)
+        ):
+            try:
+                return self._create_draft_via_imap(
+                    from_account=from_account,
+                    to=to or [],
+                    cc=cc,
+                    bcc=bcc,
+                    subject=subject or "",
+                    body=body,
+                    attachment_paths=attachment_paths,
+                )
+            except _IMAP_FALLBACK_EXCS as exc:
+                self._log_imap_fallback(from_account, exc)
+            # fall through to the AppleScript path
 
         # If the caller handed us an RFC 5322 Message-ID (the form read
         # tools emit on the IMAP path per #148), resolve to Mail's

--- a/tests/unit/test_draft_builder.py
+++ b/tests/unit/test_draft_builder.py
@@ -1,0 +1,90 @@
+"""Unit tests for the clean RFC822 draft builder (issue #245).
+
+The builder exists so drafts can be created via IMAP APPEND instead of
+Mail.app's AppleScript ``content`` setter, which wraps every body in an
+``Apple-Mail-URLShareWrapper`` ``<blockquote type="cite">`` (renders as a
+quote on iOS). These tests pin the clean output.
+"""
+
+from __future__ import annotations
+
+import email
+from email import policy
+
+from apple_mail_mcp.draft_builder import build_draft_mime
+
+
+def test_builds_plain_text_draft_without_quote_wrapper():
+    msgid, raw = build_draft_mime(
+        sender="email@fmasi.eu",
+        to=["lazar@hadleigh.co.uk"],
+        subject="Re: Flat 9 Constable House",
+        body="Hi Lazar,\n\nLine two.",
+    )
+    text = raw.decode("utf-8")
+    # The whole point of the fix: no cite-blockquote wrapper.
+    assert "blockquote" not in text.lower()
+    assert "urlshare" not in text.lower()
+
+    msg = email.message_from_bytes(raw, policy=policy.default)
+    assert msg["From"] == "email@fmasi.eu"
+    assert msg["To"] == "lazar@hadleigh.co.uk"
+    assert msg["Subject"] == "Re: Flat 9 Constable House"
+    assert msg["Message-ID"] == msgid
+    assert msg.get_content_type() == "text/plain"
+    assert "Line two." in msg.get_content()
+
+
+def test_multiple_recipients_and_cc_bcc():
+    _msgid, raw = build_draft_mime(
+        sender="email@fmasi.eu",
+        to=["a@example.invalid", "b@example.invalid"],
+        cc=["c@example.invalid"],
+        bcc=["d@example.invalid"],
+        subject="hi",
+        body="body",
+    )
+    msg = email.message_from_bytes(raw, policy=policy.default)
+    assert msg["To"] == "a@example.invalid, b@example.invalid"
+    assert msg["Cc"] == "c@example.invalid"
+    assert msg["Bcc"] == "d@example.invalid"
+
+
+def test_attachment_is_included_with_body(tmp_path):
+    pdf = tmp_path / "invoice.pdf"
+    pdf.write_bytes(b"%PDF-1.7\nfake")
+    _msgid, raw = build_draft_mime(
+        sender="email@fmasi.eu",
+        to=["x@example.invalid"],
+        subject="hi",
+        body="see attached",
+        attachments=[pdf],
+    )
+    msg = email.message_from_bytes(raw, policy=policy.default)
+    assert msg.is_multipart()
+    parts = list(msg.iter_parts())
+    body_part = next(p for p in parts if p.get_content_type() == "text/plain")
+    assert "see attached" in body_part.get_content()
+    att = next(p for p in parts if p.get_filename() == "invoice.pdf")
+    assert att.get_content_type() == "application/pdf"
+    assert att.get_payload(decode=True) == b"%PDF-1.7\nfake"
+    assert "blockquote" not in raw.decode("utf-8", "replace").lower()
+
+
+def test_sanitizes_header_injection_chars():
+    # NUL and CR/LF in header-bound fields must not survive into the
+    # serialized headers (parity with the AppleScript path, #173, and
+    # header-injection safety).
+    _msgid, raw = build_draft_mime(
+        sender="Alice\x00Smith <me@x.com>",
+        to=["a@example.invalid\r\nBcc: evil@example.invalid"],
+        subject="hi\r\nX-Injected: yes",
+        body="body",
+    )
+    assert b"\x00" not in raw
+    msg = email.message_from_bytes(raw, policy=policy.default)
+    # No header injection: the CR/LF collapse into a single (harmless)
+    # value, so the smuggled headers never materialize as real headers.
+    assert msg["From"] == "AliceSmith <me@x.com>"
+    assert msg["Bcc"] is None
+    assert msg["X-Injected"] is None

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -3120,3 +3120,39 @@ class TestFindThreadMembersImapThread:
         # Tier 2 made 2 SEARCHes per folder × 3 folders = 6.
         # BFS adds 3 SEARCHes (1 id × 3 headers) per folder.
         assert client.search.call_count > 6
+
+
+class TestAppendDraft:
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_appends_to_special_use_drafts_with_draft_flag(self, mock_cls):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\Drafts", b"\\HasNoChildren"), b"/", "Drafts"),
+        ]
+
+        conn = ImapConnector("imap.example.com", 993, "u@e.com", "pw")
+        conn.append_draft(b"raw-bytes")
+
+        args, kwargs = mock_client.append.call_args
+        assert args[0] == "Drafts"
+        assert args[1] == b"raw-bytes"
+        flags = kwargs.get("flags", args[2] if len(args) > 2 else None)
+        assert flags is not None and b"\\Draft" in list(flags)
+        mock_client.logout.assert_called_once()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_falls_back_to_conventional_drafts_name(self, mock_cls):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        # No SPECIAL-USE \Drafts flag advertised, but a conventional folder exists.
+        mock_client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\HasNoChildren",), b"/", "Drafts"),
+        ]
+
+        conn = ImapConnector("imap.example.com", 993, "u@e.com", "pw")
+        conn.append_draft(b"raw-bytes")
+
+        assert mock_client.append.call_args[0][0] == "Drafts"

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -5317,6 +5317,9 @@ class TestCreateDraft:
                 subject="hi",
                 body="x",
                 from_account="Gmail",
+                # #245: seed="new" save-as-draft now routes via IMAP APPEND;
+                # send_now=True keeps exercising the AppleScript sender line.
+                send_now=True,
             )
         script = mock_run.call_args[0][0]
         assert (
@@ -5339,6 +5342,9 @@ class TestCreateDraft:
                 subject="hi",
                 body="x",
                 from_account="Gmail",
+                # #245: seed="new" save-as-draft now routes via IMAP APPEND;
+                # send_now=True keeps exercising the AppleScript sender line.
+                send_now=True,
             )
         script = mock_run.call_args[0][0]
         assert 'set sender of theMessage to "me@x.com"' in script
@@ -5362,6 +5368,9 @@ class TestCreateDraft:
                 subject="hi",
                 body="x",
                 from_account="Gmail",
+                # #245: seed="new" save-as-draft now routes via IMAP APPEND;
+                # send_now=True keeps exercising the AppleScript sender line.
+                send_now=True,
             )
         script = mock_run.call_args[0][0]
         assert "\x00" not in script
@@ -6717,3 +6726,84 @@ class TestMailboxResolverShape:
         assert "is not container" in script
         # NOT a localized string comparison.
         assert 'is not "mailbox"' not in script
+
+
+class TestCreateDraftImapAppend:
+    """seed='new' drafts are created via IMAP APPEND to avoid Mail.app's
+    cite-blockquote wrapper (issue #245)."""
+
+    def _conn(self):
+        return AppleMailConnector(timeout=30)
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password", return_value="pw")
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_imap_config",
+        return_value=("imap.host", 993, "appleid@fmasi.eu"),
+    )
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_account_to_sender",
+        return_value="Fred <email@fmasi.eu>",
+    )
+    def test_new_draft_with_account_uses_imap_append(
+        self, _sender, _cfg, _pw, mock_imap_cls, mock_applescript
+    ):
+        conn = self._conn()
+        result = conn.create_draft(
+            seed="new",
+            to=["lazar@hadleigh.co.uk"],
+            subject="Re: Flat 9 Constable House",
+            body="Hi Lazar,\n\nNo wrapper here.",
+            from_account="iCloud",
+            send_now=False,
+        )
+
+        # IMAP path used, AppleScript NOT touched.
+        mock_applescript.assert_not_called()
+        append = mock_imap_cls.return_value.append_draft
+        append.assert_called_once()
+        raw = append.call_args[0][0]
+        assert b"No wrapper here." in raw
+        assert b"blockquote" not in raw.lower()
+        # Display-name From carried into the MIME (IMAP-path equivalent of #158).
+        assert b"Fred <email@fmasi.eu>" in raw
+        # draft_id is the generated RFC Message-ID.
+        assert "@" in result["draft_id"]
+
+    @patch.object(AppleMailConnector, "_run_applescript", return_value="123")
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password", return_value="pw")
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_imap_config",
+        return_value=("imap.host", 993, "appleid@fmasi.eu"),
+    )
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_account_to_sender",
+        return_value="Fred <email@fmasi.eu>",
+    )
+    def test_falls_back_to_applescript_when_imap_not_configured(
+        self, _sender, _cfg, _pw, mock_imap_cls, mock_applescript
+    ):
+        from apple_mail_mcp.exceptions import MailKeychainEntryNotFoundError
+
+        mock_imap_cls.return_value.append_draft.side_effect = (
+            MailKeychainEntryNotFoundError("no creds")
+        )
+        conn = self._conn()
+        result = conn.create_draft(
+            seed="new",
+            to=["x@example.invalid"],
+            subject="hi",
+            body="body",
+            from_account="iCloud",
+            send_now=False,
+        )
+        # Tried IMAP, then fell back to AppleScript.
+        mock_imap_cls.return_value.append_draft.assert_called_once()
+        mock_applescript.assert_called_once()
+        assert result["draft_id"] == "123"


### PR DESCRIPTION
Fixes the iOS quote-rendering bug for **compose** drafts reported in #245.

## Problem
Mail.app wraps any AppleScript-set message `content` in an `Apple-Mail-URLShareWrapper` `<blockquote type="cite">` when it serializes a draft to HTML (Apple bug **FB11734014**, since Mail 16.0 / Ventura). On macOS the neutralizing inline styles hide it, but **iOS Mail renders the whole body as a quote**. There is no AppleScript-level workaround — verified against `Mail.sdef`: `content` (rich text) is the only writable body, `html content` is a deprecated no-op, and `source` is read-only.

## Fix
For `seed="new"` save-as-draft (`send_now=False`) with a known `from_account`, build a clean RFC 822 message and **IMAP `APPEND`** it to the account's `\Drafts` SPECIAL-USE folder with the `\Draft` flag, bypassing Mail's scripting entirely. Reuses the existing Keychain + IMAP-pool plumbing and **falls back to the AppleScript path** via the standard `_IMAP_FALLBACK_EXCS` circuit breaker when IMAP isn't configured — no regression for non-IMAP users.

- `draft_builder.build_draft_mime` — pure MIME builder (text/plain body, attachments, cc/bcc, NUL/CR/LF header-injection sanitization)
- `ImapConnector.append_draft` + `\Drafts` SPECIAL-USE resolution (with conventional-name fallback)
- `AppleMailConnector.create_draft` routes `seed="new"`/save-as-draft through IMAP with graceful fallback

## Scope / limitations
- `seed="new"` save-as-draft only. **Reply/forward** seeds and **`send_now=True`** still use AppleScript (the latter can't be done over IMAP APPEND, which only creates drafts).
- Routing replies through IMAP and a clean **SMTP send** path are natural follow-ups (noted in #245).

## Testing
- 8 new unit tests: MIME shape / no wrapper, header-injection sanitization, attachments, `\Drafts` resolution (+conventional fallback), routing, and IMAP→AppleScript fallback.
- Full unit suite green (1017); `ruff check` and `mypy` clean.
- Verified **on-device (iOS)** that an APPENDed draft renders without the quote bar.

Refs #245.
