### PR TITLE
fix(security): IMAP CRLF command injection + attachment path traversals

### DIFF
--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -237,6 +237,41 @@ def _iso_to_imap_before(iso: str, field: str) -> str:
     return f"{d.day:02d}-{_IMAP_MONTHS[d.month - 1]}-{d.year}"
 
 
+def _reject_control_chars(value: str, field: str) -> None:
+    """Raise ValueError if ``value`` contains a C0 control character or DEL.
+
+    IMAP command arguments and RFC 3501 quoted strings must not contain
+    CR/LF. imapclient quotes string args but does NOT promote CR/LF-bearing
+    values to literals (its 8-bit detector only fires on bytes > 127), so a
+    raw CRLF embedded in a value is sent inline on the authenticated control
+    channel and splits the command — letting following bytes be parsed as a
+    new tagged command (IMAP command injection, CWE-93). Applied to every
+    free-text value that becomes an IMAP command argument (SEARCH terms,
+    Message-IDs, mailbox names) before it can reach the wire.
+    """
+    for ch in value:
+        if ord(ch) < 0x20 or ord(ch) == 0x7F:
+            raise ValueError(
+                f"{field} contains a disallowed control character "
+                f"(U+{ord(ch):04X}); control characters are not permitted "
+                f"in IMAP command arguments"
+            )
+
+
+def _bracket_message_id(message_id: str) -> str:
+    """Validate a Message-ID and return it in RFC 5322 bracketed form.
+
+    Rejects control characters (see :func:`_reject_control_chars`), then
+    wraps the id in angle brackets unless it already is. Single chokepoint
+    for every ``SEARCH HEADER "Message-ID" "<id>"`` construction so no call
+    site can build a bracketed id without the CRLF-injection guard.
+    """
+    _reject_control_chars(message_id, "message_id")
+    if message_id.startswith("<") and message_id.endswith(">"):
+        return message_id
+    return f"<{message_id}>"
+
+
 def _build_search_criteria(
     sender_contains: str | None,
     subject_contains: str | None,
@@ -254,8 +289,10 @@ def _build_search_criteria(
     """
     criteria: list[Any] = []
     if sender_contains:
+        _reject_control_chars(sender_contains, "sender_contains")
         criteria.extend(["FROM", sender_contains])
     if subject_contains:
+        _reject_control_chars(subject_contains, "subject_contains")
         criteria.extend(["SUBJECT", subject_contains])
     if read_status is True:
         criteria.append("SEEN")
@@ -270,8 +307,10 @@ def _build_search_criteria(
     if date_to is not None:
         criteria.extend(["BEFORE", _iso_to_imap_before(date_to, "date_to")])
     if body_contains:
+        _reject_control_chars(body_contains, "body_contains")
         criteria.extend(["BODY", body_contains])
     if text_contains:
+        _reject_control_chars(text_contains, "text_contains")
         criteria.extend(["TEXT", text_contains])
     return criteria or ["ALL"]
 
@@ -577,6 +616,7 @@ class ImapConnector:
             body_contains,
             text_contains,
         )
+        _reject_control_chars(mailbox, "mailbox")
 
         with self._session() as client:
             client.select_folder(mailbox, readonly=True)
@@ -666,11 +706,8 @@ class ImapConnector:
                 back to AppleScript.)
             IMAPClientError: Login / SELECT / SEARCH / FETCH failed.
         """
-        bracketed = (
-            message_id
-            if message_id.startswith("<") and message_id.endswith(">")
-            else f"<{message_id}>"
-        )
+        bracketed = _bracket_message_id(message_id)
+        _reject_control_chars(mailbox, "mailbox")
 
         fetch_keys: list[bytes] = [b"ENVELOPE", b"FLAGS"]
         want_body = include_content and not headers_only
@@ -751,11 +788,8 @@ class ImapConnector:
                 the Message-ID.
             IMAPClientError: Login / SELECT / SEARCH / FETCH failed.
         """
-        bracketed = (
-            message_id
-            if message_id.startswith("<") and message_id.endswith(">")
-            else f"<{message_id}>"
-        )
+        bracketed = _bracket_message_id(message_id)
+        _reject_control_chars(mailbox, "mailbox")
 
         with self._session() as client:
             client.select_folder(mailbox, readonly=True)
@@ -828,6 +862,7 @@ class ImapConnector:
             ``read_status``, ``flagged``), deduped by Message-ID, sorted
             chronologically ascending.
         """
+        _reject_control_chars(anchor_rfc_message_id, "anchor_rfc_message_id")
         with self._session() as client:
             # Tier 1: Gmail X-GM-THRID via [Gmail]/All Mail
             if self._has_capability(client, b"X-GM-EXT-1"):
@@ -881,6 +916,7 @@ class ImapConnector:
             imapclient.exceptions.IMAPClientError: Server-side error
                 (mailbox doesn't exist, permission denied, etc.).
         """
+        _reject_control_chars(name, "name")
         with self._session() as client:
             try:
                 info = client.select_folder(name, readonly=True)
@@ -926,6 +962,8 @@ class ImapConnector:
                 (source missing, destination exists, parent missing,
                 permission denied, etc.).
         """
+        _reject_control_chars(old_name, "old_name")
+        _reject_control_chars(new_name, "new_name")
         with self._session() as client:
             client.rename_folder(old_name, new_name)
 
@@ -969,10 +1007,9 @@ class ImapConnector:
             IMAPClientError: SELECT / SEARCH / MOVE / COPY / STORE /
                 EXPUNGE failed at the protocol level.
         """
-        bracketed_ids = [
-            mid if mid.startswith("<") and mid.endswith(">") else f"<{mid}>"
-            for mid in message_ids
-        ]
+        bracketed_ids = [_bracket_message_id(mid) for mid in message_ids]
+        _reject_control_chars(source_mailbox, "source_mailbox")
+        _reject_control_chars(destination_mailbox, "destination_mailbox")
 
         with self._session() as client:
             client.select_folder(source_mailbox, readonly=False)
@@ -1047,10 +1084,8 @@ class ImapConnector:
                 SPECIAL-USE or conventional names.
             IMAPClientError: Protocol-level failure.
         """
-        bracketed_ids = [
-            mid if mid.startswith("<") and mid.endswith(">") else f"<{mid}>"
-            for mid in message_ids
-        ]
+        bracketed_ids = [_bracket_message_id(mid) for mid in message_ids]
+        _reject_control_chars(source_mailbox, "source_mailbox")
 
         with self._session() as client:
             # #199 / #198: do all LIST traffic in AUTHENTICATED state.
@@ -1126,10 +1161,8 @@ class ImapConnector:
             IMAPClientError: SELECT / SEARCH / STORE failed at the
                 protocol level.
         """
-        bracketed_ids = [
-            mid if mid.startswith("<") and mid.endswith(">") else f"<{mid}>"
-            for mid in message_ids
-        ]
+        bracketed_ids = [_bracket_message_id(mid) for mid in message_ids]
+        _reject_control_chars(source_mailbox, "source_mailbox")
 
         with self._session() as client:
             client.select_folder(source_mailbox, readonly=False)
@@ -1185,10 +1218,8 @@ class ImapConnector:
             IMAPClientError: SELECT / SEARCH / STORE failed at the
                 protocol level.
         """
-        bracketed_ids = [
-            mid if mid.startswith("<") and mid.endswith(">") else f"<{mid}>"
-            for mid in message_ids
-        ]
+        bracketed_ids = [_bracket_message_id(mid) for mid in message_ids]
+        _reject_control_chars(source_mailbox, "source_mailbox")
 
         with self._session() as client:
             client.select_folder(source_mailbox, readonly=False)
@@ -1321,7 +1352,7 @@ class ImapConnector:
 
         client.select_folder(all_mail, readonly=True)
 
-        bracketed = f"<{anchor_rfc_message_id}>"
+        bracketed = _bracket_message_id(anchor_rfc_message_id)
         try:
             anchor_uids = client.search(["HEADER", "Message-ID", bracketed])
         except IMAPClientError:
@@ -1384,7 +1415,7 @@ class ImapConnector:
         falls through to Tier 2 / Tier 3.
         """
         # Step 1: locate the anchor's UID. Try INBOX first, then \\Sent.
-        bracketed = f"<{anchor_rfc_message_id}>"
+        bracketed = _bracket_message_id(anchor_rfc_message_id)
         anchor_uid: int | None = None
         for folder_name in self._anchor_lookup_folders(client):
             try:
@@ -1483,7 +1514,7 @@ class ImapConnector:
         Returns ``None`` (not raise) when THREAD gets rejected
         mid-flight — dispatcher then falls through to Tier 3.
         """
-        bracketed = f"<{anchor_rfc_message_id}>"
+        bracketed = _bracket_message_id(anchor_rfc_message_id)
         # Pick the algorithm name the server actually advertises.
         if self._has_capability(client, b"THREAD=REFERENCES"):
             algo = "REFERENCES"
@@ -1630,7 +1661,7 @@ class ImapConnector:
             # substring; each search is server-side and indexed.
             uids_found: set[int] = set()
             for id_ in known_ids:
-                id_quoted = f"<{id_}>"
+                id_quoted = _bracket_message_id(id_)
                 for header in ("Message-ID", "In-Reply-To", "References"):
                     try:
                         uids = client.search(["HEADER", header, id_quoted])

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -40,6 +40,7 @@ from .utils import (
     escape_applescript_string,
     get_flag_index,
     parse_applescript_json,
+    sanitize_filename,
     sanitize_input,
     validate_email,
 )
@@ -126,6 +127,51 @@ def _build_date_filter_clauses(
         )
 
     return clauses
+
+
+def _compute_attachment_save_targets(
+    attachment_names: list[str],
+    save_directory: Path,
+    attachment_indices: list[int] | None,
+) -> list[tuple[int, Path]]:
+    """Map selected attachments to sanitized, contained target paths.
+
+    Returns ``(one_based_attachment_index, target_path)`` pairs in selection
+    order. The attachment name originates from the email and is fully
+    attacker-controlled (``name of att``), so it must never be concatenated
+    into a filesystem path unsanitized — a ``../`` or absolute name would let
+    the write escape ``save_directory`` (path traversal → arbitrary file
+    write). Each name is reduced to a safe basename via
+    :func:`sanitize_filename`; colliding basenames are de-duplicated with the
+    attachment index so two attachments can't silently overwrite each other.
+    Any target that would still escape ``save_directory`` after resolution is
+    dropped defensively.
+
+    ``save_directory`` must already be resolved by the caller.
+    """
+    if attachment_indices is not None:
+        wanted = [
+            (i, attachment_names[i])
+            for i in attachment_indices
+            if 0 <= i < len(attachment_names)
+        ]
+    else:
+        wanted = list(enumerate(attachment_names))
+
+    targets: list[tuple[int, Path]] = []
+    used: set[str] = set()
+    for idx, name in wanted:
+        safe = sanitize_filename(name)
+        if safe in used:
+            safe = f"{idx}_{safe}"
+        used.add(safe)
+        target = (save_directory / safe).resolve()
+        # sanitize_filename already strips separators and "..", so this can
+        # only fail if that contract is ever broken — keep it as a hard gate.
+        if target == save_directory or not target.is_relative_to(save_directory):
+            continue
+        targets.append((idx + 1, target))  # AppleScript indexing is 1-based
+    return targets
 
 
 def _filter_imap_results_to_cutoff(
@@ -2591,16 +2637,27 @@ class AppleMailConnector:
         except (RuntimeError, OSError) as e:
             raise ValueError(f"Invalid save directory: {e}") from e
 
-        message_id_safe = escape_applescript_string(sanitize_input(message_id))
-        dir_safe = escape_applescript_string(str(save_directory))
+        # Enumerate attachment names first so the (attacker-controlled)
+        # filename never reaches a filesystem path unsanitized. The leaf
+        # names are reduced to safe basenames and joined under the resolved
+        # save_directory on the Python side; the AppleScript then saves each
+        # selected attachment by index to a precomputed, contained POSIX
+        # path. (Concatenating `name of att` into the path inside AppleScript
+        # was a path-traversal → arbitrary-file-write vector.)
+        attachments = self._get_attachments_applescript(message_id)
+        targets = _compute_attachment_save_targets(
+            [str(a.get("name", "")) for a in attachments],
+            save_directory,
+            attachment_indices,
+        )
+        if not targets:
+            return 0
 
-        # Build index filter if specified
-        if attachment_indices is not None:
-            # Convert to 1-based indexing for AppleScript
-            indices_str = ", ".join(str(i + 1) for i in attachment_indices)
-            index_filter = f"items {{{indices_str}}} of"
-        else:
-            index_filter = ""
+        message_id_safe = escape_applescript_string(sanitize_input(message_id))
+        idx_list = ", ".join(str(idx) for idx, _ in targets)
+        path_list = ", ".join(
+            f'"{escape_applescript_string(str(path))}"' for _, path in targets
+        )
 
         script = f"""
         tell application "Mail"
@@ -2609,13 +2666,16 @@ class AppleMailConnector:
                 repeat with mb in mailboxes of acc
                     try
                         set msg to first message of mb whose id is "{message_id_safe}"
-                        set attList to {index_filter} mail attachments of msg
+                        set theAtts to mail attachments of msg
+                        set idxList to {{{idx_list}}}
+                        set pathList to {{{path_list}}}
                         set saveCount to 0
 
-                        repeat with att in attList
+                        repeat with k from 1 to count of idxList
+                            set ai to item k of idxList
+                            set tp to item k of pathList
                             try
-                                set attName to name of att
-                                save att in ("{dir_safe}/" & attName)
+                                save (item ai of theAtts) in (POSIX file tp)
                                 set saveCount to saveCount + 1
                             end try
                         end repeat

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -174,6 +174,31 @@ def _compute_attachment_save_targets(
     return targets
 
 
+def _compute_draft_extract_targets(
+    attachment_names: list[str], dest_dir: Path
+) -> list[Path]:
+    """Sanitized, contained per-attachment target paths under ``dest_dir/<i>/``.
+
+    Each attachment name is attacker-influenced (it can originate from a
+    forwarded message's MIME filename), so it is reduced to a safe basename
+    via :func:`sanitize_filename` before being joined under its index
+    subdirectory. The subdir-per-index scheme isolates basename collisions;
+    sanitization stops a ``..``/absolute name from escaping ``dest_dir`` once
+    the path is resolved (``Path.resolve`` collapses ``..``). Returns one
+    resolved path per name, in order.
+    """
+    dest_resolved = dest_dir.resolve()
+    targets: list[Path] = []
+    for i, name in enumerate(attachment_names):
+        target = (dest_dir / str(i) / sanitize_filename(name)).resolve()
+        if not target.is_relative_to(dest_resolved):
+            # Unreachable while sanitize_filename strips separators and "..";
+            # kept as a hard gate against a future regression in that contract.
+            raise ValueError(f"draft attachment {name!r} escapes dest_dir")
+        targets.append(target)
+    return targets
+
+
 def _filter_imap_results_to_cutoff(
     messages: list[dict[str, Any]], cutoff_dt: _datetime
 ) -> list[dict[str, Any]]:
@@ -4012,17 +4037,17 @@ class AppleMailConnector:
         if not attachment_names:
             return []
 
-        # Pre-create per-attachment subdirectories on the Python side so
-        # the AppleScript only has to do `save att in (POSIX file <path>)`.
-        target_paths: list[Path] = []
-        for i, name in enumerate(attachment_names):
-            subdir = dest_dir / str(i)
-            subdir.mkdir(parents=True, exist_ok=True)
-            target_paths.append(subdir / name)
+        # Compute sanitized, containment-checked target paths on the Python
+        # side (the attachment name is attacker-influenced — it can carry a
+        # forwarded message's MIME filename), then pre-create each per-index
+        # subdirectory so the AppleScript only does `save att in (POSIX file
+        # <path>)`.
+        target_paths = _compute_draft_extract_targets(attachment_names, dest_dir)
+        for p in target_paths:
+            p.parent.mkdir(parents=True, exist_ok=True)
 
         targets_safe = ", ".join(
-            f'"{escape_applescript_string(str(p.resolve()))}"'
-            for p in target_paths
+            f'"{escape_applescript_string(str(p))}"' for p in target_paths
         )
 
         script = f"""

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -340,6 +340,45 @@ class TestMailIntegration:
             assert isinstance(att["size"], int)
             assert isinstance(att["downloaded"], bool)
 
+    def test_save_attachments_stays_contained(
+        self, connector: AppleMailConnector, test_account: str, tmp_path: Path
+    ) -> None:
+        """Real save_attachments writes only inside the chosen directory.
+
+        Exercises the two-pass AppleScript path (enumerate names → save by
+        index to Python-sanitized POSIX paths) on a real message. The
+        security property — an attacker-controlled attachment filename can
+        never escape ``save_directory`` — is proven deterministically by the
+        ``_compute_attachment_save_targets`` unit tests; this integration
+        test confirms the AppleScript `save (item i of theAtts) in (POSIX
+        file tp)` round-trip actually writes files in real Mail.app and that
+        nothing lands outside the directory. Scans a few INBOX messages for
+        one with attachments; skips if none is found.
+        """
+        matches = connector.search_messages(
+            account=test_account, mailbox="INBOX", limit=10
+        )
+        target_id = next(
+            (m["id"] for m in matches if connector.get_attachments(m["id"])),
+            None,
+        )
+        if target_id is None:
+            pytest.skip("no INBOX message with attachments to save")
+
+        before = {p.resolve() for p in tmp_path.rglob("*")}
+        count = connector.save_attachments(
+            message_id=target_id, save_directory=tmp_path
+        )
+        assert isinstance(count, int)
+
+        written = {p.resolve() for p in tmp_path.rglob("*") if p.is_file()}
+        # Every file that appeared is strictly inside the save directory.
+        for p in written:
+            assert p.is_relative_to(tmp_path.resolve())
+        # Nothing was written outside (the parent dir gained no new files).
+        new_files = written - before
+        assert all(p.is_relative_to(tmp_path.resolve()) for p in new_files)
+
     def test_get_attachments_via_imap(
         self, connector: AppleMailConnector, test_account: str
     ) -> None:

--- a/tests/unit/test_attachments.py
+++ b/tests/unit/test_attachments.py
@@ -107,7 +107,12 @@ class TestSaveAttachments:
         self, mock_run: MagicMock, connector: AppleMailConnector, tmp_path: Path
     ) -> None:
         """Test saving a single attachment."""
-        mock_run.return_value = "1"
+        # First call enumerates names; second call performs the save.
+        mock_run.side_effect = [
+            '[{"name":"document.pdf","mime_type":"application/pdf",'
+            '"size":1,"downloaded":true}]',
+            "1",
+        ]
 
         result = connector.save_attachments(
             message_id="12345",
@@ -116,7 +121,7 @@ class TestSaveAttachments:
         )
 
         assert result == 1
-        call_args = mock_run.call_args[0][0]
+        call_args = mock_run.call_args_list[-1][0][0]
         assert str(tmp_path) in call_args
 
     @patch.object(AppleMailConnector, "_run_applescript")
@@ -124,7 +129,12 @@ class TestSaveAttachments:
         self, mock_run: MagicMock, connector: AppleMailConnector, tmp_path: Path
     ) -> None:
         """Test saving all attachments from a message."""
-        mock_run.return_value = "3"
+        mock_run.side_effect = [
+            '[{"name":"a.pdf","mime_type":"application/pdf","size":1,"downloaded":true},'
+            '{"name":"b.pdf","mime_type":"application/pdf","size":2,"downloaded":true},'
+            '{"name":"c.pdf","mime_type":"application/pdf","size":3,"downloaded":true}]',
+            "3",
+        ]
 
         result = connector.save_attachments(
             message_id="12345",
@@ -196,3 +206,83 @@ class TestAttachmentSecurity:
         # Preserve safe names
         assert sanitize_filename("document.pdf") == "document.pdf"
         assert sanitize_filename("my-file_v2.txt") == "my-file_v2.txt"
+
+
+class TestSaveAttachmentsPathTraversal:
+    """save_attachments must not let an attacker-controlled attachment
+    filename (``name of att`` — set by whoever sent the email) escape the
+    chosen save directory. Path traversal here is an arbitrary file write."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    def test_compute_targets_sanitizes_traversal_name(self, tmp_path: Path) -> None:
+        from apple_mail_mcp.mail_connector import _compute_attachment_save_targets
+
+        names = ["../../../../tmp/evil.sh", "report.pdf"]
+        targets = _compute_attachment_save_targets(names, tmp_path.resolve(), None)
+
+        # Every target stays strictly within the save directory.
+        for _, p in targets:
+            assert p.resolve().is_relative_to(tmp_path.resolve())
+            assert p.resolve() != tmp_path.resolve()
+        # The traversal name is reduced to a safe basename.
+        assert targets[0][1].name == "evil.sh"
+        # AppleScript indices are 1-based and preserve order.
+        assert [i for i, _ in targets] == [1, 2]
+
+    def test_compute_targets_absolute_name_contained(self, tmp_path: Path) -> None:
+        from apple_mail_mcp.mail_connector import _compute_attachment_save_targets
+
+        targets = _compute_attachment_save_targets(
+            ["/etc/cron.d/evil"], tmp_path.resolve(), None
+        )
+        assert len(targets) == 1
+        assert targets[0][1].resolve().is_relative_to(tmp_path.resolve())
+        assert targets[0][1].name == "evil"
+
+    def test_compute_targets_dedupes_collisions(self, tmp_path: Path) -> None:
+        from apple_mail_mcp.mail_connector import _compute_attachment_save_targets
+
+        # Two names that sanitize to the same basename must not collapse to
+        # one path (which would silently overwrite/lose an attachment).
+        targets = _compute_attachment_save_targets(
+            ["a/report.pdf", "b/report.pdf"], tmp_path.resolve(), None
+        )
+        paths = {str(p) for _, p in targets}
+        assert len(paths) == 2
+
+    def test_compute_targets_respects_indices(self, tmp_path: Path) -> None:
+        from apple_mail_mcp.mail_connector import _compute_attachment_save_targets
+
+        targets = _compute_attachment_save_targets(
+            ["a.pdf", "b.pdf", "c.pdf"], tmp_path.resolve(), [0, 2]
+        )
+        assert [i for i, _ in targets] == [1, 3]
+        assert [p.name for _, p in targets] == ["a.pdf", "c.pdf"]
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_save_does_not_concatenate_raw_name(
+        self, mock_run: MagicMock, connector: AppleMailConnector, tmp_path: Path
+    ) -> None:
+        # First call enumerates attachments (returns a malicious name);
+        # the second call saves to the precomputed, sanitized paths.
+        mock_run.side_effect = [
+            '[{"name":"../../../../tmp/evil.sh","mime_type":"x",'
+            '"size":1,"downloaded":true}]',
+            "1",
+        ]
+        result = connector.save_attachments(message_id="123", save_directory=tmp_path)
+
+        assert result == 1
+        save_script = mock_run.call_args_list[-1][0][0]
+        # The vulnerable runtime path concatenation must be gone.
+        assert "& attName" not in save_script
+        assert "name of att" not in save_script
+        # Saves target a Python-sanitized POSIX path under the chosen dir.
+        assert "POSIX file" in save_script
+        assert str(tmp_path) in save_script
+        # No traversal sequence survives into the script.
+        assert "/tmp/evil.sh" not in save_script
+        assert ".." not in save_script

--- a/tests/unit/test_drafts.py
+++ b/tests/unit/test_drafts.py
@@ -224,3 +224,47 @@ class TestDraftStateStore:
         # The on-disk JSON shouldn't have reply_all for forward seeds.
         data = json.loads((tmp_path / "160991.json").read_text())
         assert "reply_all" not in data
+
+
+class TestExtractDraftAttachmentsPathTraversal:
+    """extract_draft_attachments must not let an attachment filename (which
+    can originate from a forwarded message's attacker-set MIME filename)
+    escape dest_dir. ``.resolve()`` collapses ``..`` deterministically, so an
+    unsanitized name would write attacker bytes to an arbitrary path."""
+
+    def test_traversal_name_contained(self, tmp_path: Path) -> None:
+        from apple_mail_mcp.mail_connector import _compute_draft_extract_targets
+
+        targets = _compute_draft_extract_targets(
+            ["../../../../tmp/evil.sh", "report.pdf"], tmp_path
+        )
+        for p in targets:
+            assert p.resolve().is_relative_to(tmp_path.resolve())
+        # Reduced to a safe basename, kept under its index subdir.
+        assert targets[0].name == "evil.sh"
+        assert len(targets) == 2
+
+    def test_absolute_name_contained(self, tmp_path: Path) -> None:
+        from apple_mail_mcp.mail_connector import _compute_draft_extract_targets
+
+        targets = _compute_draft_extract_targets(["/etc/passwd"], tmp_path)
+        assert targets[0].resolve().is_relative_to(tmp_path.resolve())
+        assert targets[0].name == "passwd"
+
+    def test_extract_script_targets_sanitized_path(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        conn = AppleMailConnector(timeout=30)
+        with patch.object(AppleMailConnector, "_run_applescript") as mock_run:
+            mock_run.return_value = "0"
+            conn.extract_draft_attachments(
+                "160991", ["../../../../tmp/evil.sh"], tmp_path
+            )
+            script = mock_run.call_args[0][0]
+
+        # The AppleScript saves to the sanitized path under dest_dir/0/,
+        # never the resolved-out-of-tree path the raw name would produce.
+        expected = str((tmp_path / "0" / "evil.sh").resolve())
+        assert expected in script

--- a/tests/unit/test_imap_injection.py
+++ b/tests/unit/test_imap_injection.py
@@ -1,0 +1,127 @@
+"""Security regression tests: IMAP CRLF command injection (CWE-93).
+
+imapclient quotes string arguments but does NOT promote CR/LF-bearing
+values to IMAP literals (its 8-bit detector only fires on bytes > 127),
+so a raw CRLF embedded in a SEARCH term, a Message-ID, or a mailbox name
+is sent inline on the authenticated control channel and splits the
+command — letting subsequent bytes be parsed as a new tagged command.
+
+The connector must reject control characters in every value that becomes
+an IMAP command argument, before it reaches the wire.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apple_mail_mcp.imap_connector import ImapConnector, _build_search_criteria
+
+# A representative injection payload and a grab-bag of control characters.
+_INJECTION = 'x\r\nA1 DELETE "INBOX"'
+_CONTROL_CHARS = ["\r", "\n", "\x00", "\x07", "\x1f"]
+
+
+def _conn() -> ImapConnector:
+    return ImapConnector("imap.example.com", 993, "u@example.com", "pw")
+
+
+class TestSearchCriteriaRejectControlChars:
+    """Free-text SEARCH criteria must reject control characters."""
+
+    @pytest.mark.parametrize(
+        "field",
+        ["sender_contains", "subject_contains", "body_contains", "text_contains"],
+    )
+    @pytest.mark.parametrize("ctrl", _CONTROL_CHARS)
+    def test_build_search_criteria_rejects_control_chars(self, field: str, ctrl: str) -> None:
+        kwargs: dict[str, object] = {
+            "sender_contains": None,
+            "subject_contains": None,
+            "read_status": None,
+            "is_flagged": None,
+            field: f"a{ctrl}b",
+        }
+        with pytest.raises(ValueError):
+            _build_search_criteria(**kwargs)  # type: ignore[arg-type]
+
+    def test_build_search_criteria_allows_clean_text(self) -> None:
+        criteria = _build_search_criteria(None, "hello world", None, None)
+        assert "SUBJECT" in criteria
+        assert "hello world" in criteria
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_search_messages_never_reaches_wire_with_crlf(self, mock_cls: MagicMock) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        with pytest.raises(ValueError):
+            _conn().search_messages(subject_contains=_INJECTION)
+        client.search.assert_not_called()
+        client.select_folder.assert_not_called()
+
+
+class TestMessageIdRejectControlChars:
+    """Message-ID HEADER searches must reject control characters."""
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_get_message_rejects_crlf(self, mock_cls: MagicMock) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        with pytest.raises(ValueError):
+            _conn().get_message(_INJECTION, mailbox="INBOX")
+        client.search.assert_not_called()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_delete_messages_rejects_crlf(self, mock_cls: MagicMock) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        with pytest.raises(ValueError):
+            _conn().delete_messages([_INJECTION], source_mailbox="INBOX")
+        client.search.assert_not_called()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_move_messages_rejects_crlf(self, mock_cls: MagicMock) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        with pytest.raises(ValueError):
+            _conn().move_messages(
+                [_INJECTION], source_mailbox="INBOX", destination_mailbox="Archive"
+            )
+        client.search.assert_not_called()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_find_thread_members_rejects_crlf_anchor(self, mock_cls: MagicMock) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        with pytest.raises(ValueError):
+            _conn().find_thread_members(_INJECTION, anchor_references=[])
+        client.search.assert_not_called()
+
+
+class TestMailboxNameRejectControlChars:
+    """Mailbox/folder names become IMAP command args too (SELECT/DELETE/RENAME)."""
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_search_rejects_crlf_mailbox(self, mock_cls: MagicMock) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        with pytest.raises(ValueError):
+            _conn().search_messages(mailbox="INBOX\r\nA1 DELETE x")
+        client.select_folder.assert_not_called()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_delete_mailbox_rejects_crlf(self, mock_cls: MagicMock) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        with pytest.raises(ValueError):
+            _conn().delete_mailbox("Junk\r\nA1 DELETE INBOX")
+        # Must fail fast — before the SELECT pre-flight reaches the wire.
+        client.select_folder.assert_not_called()
+        client.delete_folder.assert_not_called()
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_rename_mailbox_rejects_crlf(self, mock_cls: MagicMock) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        with pytest.raises(ValueError):
+            _conn().rename_mailbox("Old", "New\r\nA1 DELETE INBOX")
+        client.rename_folder.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes three high-severity vulnerabilities found in a full-codebase security audit. All share one root pattern — **untrusted, attacker-controlled strings reach a protocol/filesystem sink without control-character or path sanitization** — and are fixed one commit each, TDD throughout (failing test first, then minimal fix).

The realistic attacker here is **email content** a remote sender controls (Message-ID header, attachment filename) plus **tool arguments steerable by prompt injection** in mail the user asks Claude to triage.

## Findings & fixes

### 1. IMAP CRLF command injection — `imap_connector.py` (CWE-93) · `8b0b997`
`imapclient` quotes SEARCH terms / Message-IDs / mailbox names but does **not** promote CR/LF-bearing values to IMAP literals (its 8-bit detector only fires on bytes > 127). A raw CRLF was therefore sent **inline on the authenticated control channel**, splitting the command so following bytes parse as a new tagged command (e.g. `STORE +FLAGS (\Deleted)`, `DELETE`, `EXPUNGE`). Reachable on the IMAP fast path (Keychain entry configured) via prompt-injected `search_messages`/message-id tool args, or an attacker-set `Message-ID` header on `get_thread`. *Verified the wire-encoding gap against `imapclient==3.1.0`.*

**Fix:** new `_reject_control_chars` / `_bracket_message_id` chokepoints reject any C0/DEL char (fail fast, before any bytes hit the wire) on every value that becomes an IMAP command argument: the 4 free-text SEARCH criteria, all Message-ID HEADER searches (`get_message`, `get_attachments`, `move_messages`, `delete_messages`, `set_read_status`, `set_flagged_status`, thread-anchor + thread-walk lookups), and mailbox/folder names (`search`, `get_message`, `get_attachments`, `delete_mailbox`, `rename_mailbox`, move/delete source + destination).

### 2. `save_attachments` path traversal — `mail_connector.py` (CWE-22) · `3007b3e`
The save path was built **inside AppleScript** by concatenating the chosen directory with `name of att` — the attachment's filename, fully controlled by whoever sent the email. A name like `../../../../Library/LaunchAgents/x.plist` (or an absolute path) escaped `save_directory` → **attacker-controlled arbitrary file write** (LaunchAgent persistence, `~/.zshenv`/`~/.ssh` overwrite), triggered merely by saving a received attachment. `sanitize_filename()` existed and was unit-tested but was **never wired into any sink**.

**Fix:** two-pass flow mirroring the safe `extract_draft_attachments` — enumerate names, reduce each to a safe basename + containment-check under the resolved directory in Python (new pure `_compute_attachment_save_targets`, de-duping colliding basenames), then save each attachment **by index** to a precomputed `POSIX file` path. No email-derived name reaches a path unsanitized.

### 3. `extract_draft_attachments` path traversal — `mail_connector.py` (CWE-22) · `56ec305`
Same class: `(dest_dir / str(i) / name).resolve()` — `.resolve()` collapses `..`, so an unsanitized name escaped `dest_dir` before the path was handed to `save … in (POSIX file tp)`. Reachable via `update_draft` preserving the attachments of a draft seeded by forwarding an attacker's message.

**Fix:** extracted pure `_compute_draft_extract_targets` that sanitizes each name and asserts containment. The AppleScript save loop is byte-identical; only the (now sanitized) target paths change.

## Not changed (investigated, not vulnerable)
- **Template `vformat` format-string** — Python `str.format` can't *call* anything and every render value is a `str` (no `__globals__` reachable); a hardening gap, not an exploit.
- **IMAP TLS** — `IMAPClient(ssl=True)` uses the verified default context. **Keychain subprocess** — list-argv, no `shell=True`, password never logged. **`parse_date_filter`** — would be injectable but is dead code (live path `_build_date_filter_clauses` is regex-validated); recommend deleting it separately.

## Testing
- **+37 unit tests**, all green; full suite **1113 passed**. Security logic is proven by deterministic unit tests on the pure helpers (no AppleScript/Mail.app needed).
- `lint`, `mypy --strict`, complexity (all new fns ≤ CC 10), client/server parity, version-sync, and `check_applescript_safety.sh` all pass.
- Added an integration test exercising the real `save_attachments` two-pass AppleScript with a containment assertion (`tests/integration/`, gated; requires a Mail.app test account — not run in CI sandbox).
- Pre-existing `delete_mailbox` e2e failure (elicitation/MCP-session harness, in untouched `server.py`) is unchanged — it also fails on `main`.

No version bump / CHANGELOG entry (feature-branch convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #238 (save_attachments path traversal)
Closes #255 (IMAP CRLF command injection)
Closes #256 (extract_draft_attachments path traversal)

Surfaced during PR review but not addressed by this PR:
- #236 (save_attachments byte cap) — out of scope, stays open
- #257 (delete_mailbox e2e test failure + CI process gap) — separate work
- #258 (delete unused parse_date_filter) — separate cleanup PR per maintainer's preference