### PR TITLE
fix(#252): replace stale morgancoopercom URLs with s-morgan-jeffries

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -486,6 +486,6 @@ Security fixes are released as soon as possible:
 
 If you have security questions or concerns:
 
-- **General**: [GitHub Discussions](https://github.com/morgancoopercom/apple-mail-mcp/discussions)
+- **General**: [GitHub Discussions](https://github.com/s-morgan-jeffries/apple-mail-mcp/discussions)
 - **Vulnerabilities**: security@[domain] (private)
-- **Best Practices**: [GitHub Issues](https://github.com/morgancoopercom/apple-mail-mcp/issues)
+- **Best Practices**: [GitHub Issues](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues)

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -21,7 +21,7 @@ pip install apple-mail-mcp
 
 ```bash
 # Clone the repository
-git clone https://github.com/morgancoopercom/apple-mail-mcp.git
+git clone https://github.com/s-morgan-jeffries/apple-mail-mcp.git
 cd apple-mail-mcp
 
 # Create virtual environment
@@ -209,6 +209,6 @@ python -m apple_mail_mcp.server
 
 ## Getting Help
 
-- **Issues**: [GitHub Issues](https://github.com/morgancoopercom/apple-mail-mcp/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/morgancoopercom/apple-mail-mcp/discussions)
+- **Issues**: [GitHub Issues](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/s-morgan-jeffries/apple-mail-mcp/discussions)
 - **Documentation**: [Full Documentation](../README.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,9 @@ dev = [
 apple-mail-mcp = "apple_mail_mcp.server:main"
 
 [project.urls]
-Homepage = "https://github.com/morgancoopercom/apple-mail-mcp"
-Repository = "https://github.com/morgancoopercom/apple-mail-mcp"
-Issues = "https://github.com/morgancoopercom/apple-mail-mcp/issues"
+Homepage = "https://github.com/s-morgan-jeffries/apple-mail-mcp"
+Repository = "https://github.com/s-morgan-jeffries/apple-mail-mcp"
+Issues = "https://github.com/s-morgan-jeffries/apple-mail-mcp/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/apple_mail_mcp"]


### PR DESCRIPTION
## Summary
- `morgancoopercom` GitHub org doesn't exist; real repo is `s-morgan-jeffries/apple-mail-mcp`
- 8 stale references across `pyproject.toml`, `docs/SECURITY.md`, `docs/guides/DEVELOPMENT.md` all replaced
- No behavioral change; clears 404s in package metadata + user-facing docs

## Closes
Closes #252

## Test plan
- [x] `git grep morgancoopercom` returns no results
- [x] `make check-all` passes
- [ ] Visual: post-merge, confirm Homepage / Repository / Issues in PyPI-style metadata point at the real repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)