### PR TITLE
fix(#258): delete unused parse_date_filter (latent AS injection vector)

### DIFF
--- a/src/apple_mail_mcp/utils.py
+++ b/src/apple_mail_mcp/utils.py
@@ -107,38 +107,6 @@ def format_applescript_list(items: list[str]) -> str:
     return "{" + ", ".join(escaped_items) + "}"
 
 
-def parse_date_filter(date_str: str) -> str:
-    """
-    Convert human-readable date to AppleScript date expression.
-
-    Args:
-        date_str: Date string like "7 days ago", "2024-01-01", "last week"
-
-    Returns:
-        AppleScript date expression
-    """
-    # Handle relative dates
-    pattern = r"(\d+)\s+(day|week|month|year)s?\s+ago"
-    match = re.match(pattern, date_str.lower())
-
-    if match:
-        amount = int(match.group(1))
-        unit = match.group(2)
-        return f"(current date) - ({amount} * {unit}s)"
-
-    # Handle "last X"
-    if date_str.lower().startswith("last "):
-        unit = date_str[5:].strip().rstrip("s") + "s"
-        return f"(current date) - (1 * {unit})"
-
-    # Handle ISO dates (YYYY-MM-DD)
-    if re.match(r"\d{4}-\d{2}-\d{2}", date_str):
-        return f'date "{date_str}"'
-
-    # Default: return as is
-    return f'date "{date_str}"'
-
-
 def validate_email(email: str) -> bool:
     """
     Validate email address format.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,7 +15,6 @@ from apple_mail_mcp.utils import (
     normalize_subject,
     parse_applescript_json,
     parse_applescript_list,
-    parse_date_filter,
     parse_rfc822_ids,
     sanitize_input,
     validate_email,
@@ -81,26 +80,6 @@ class TestFormatAppleScriptList:
     def test_escapes_special_chars(self) -> None:
         result = format_applescript_list(['hello "world"'])
         assert result == '{"hello \\"world\\""}'
-
-
-class TestParseDateFilter:
-    """Tests for parse_date_filter."""
-
-    def test_days_ago(self) -> None:
-        result = parse_date_filter("7 days ago")
-        assert result == "(current date) - (7 * days)"
-
-    def test_weeks_ago(self) -> None:
-        result = parse_date_filter("2 weeks ago")
-        assert result == "(current date) - (2 * weeks)"
-
-    def test_last_week(self) -> None:
-        result = parse_date_filter("last week")
-        assert result == "(current date) - (1 * weeks)"
-
-    def test_iso_date(self) -> None:
-        result = parse_date_filter("2024-01-15")
-        assert result == 'date "2024-01-15"'
 
 
 class TestValidateEmail:


### PR DESCRIPTION
## Summary
- Removes `parse_date_filter()` from `utils.py` — dead code with no live caller.
- Removes its 4-method `TestParseDateFilter` class from `test_utils.py`.
- Removes the matching import line from `test_utils.py`.
- The danger was its last line: `return f'date "{date_str}"'` — direct interpolation into an AppleScript string literal with no escaping. Latent CWE-78 if anyone revived it.
- If human-readable-date parsing is ever wanted, it gets added fresh with proper escaping.

## Closes
Closes #258

## Test plan
- [x] `git grep parse_date_filter` returns no results
- [x] `make check-all` passes — full suite green minus the 4 deleted test methods

## Credit
@allenpan05 flagged this latent injection vector in their #254 PR's "Not changed" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)