### PR TITLE
fix(#242): reverse search_messages AS iteration + fix date-literal bug

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -74,17 +74,53 @@ def _now() -> _datetime:
     return _datetime.now().astimezone()
 
 
+def _construct_as_date_var(var: str, year: int, month: int, day: int) -> str:
+    """Emit AppleScript that constructs an AS date object at midnight (local
+    time) on the given (year, month, day).
+
+    Why this exists: AppleScript's `date "YYYY-MM-DD"` literal does NOT
+    parse ISO dates — `date "2026-05-28"` evaluates to year-12196, silently
+    breaking any filter that depends on it. The property-setter pattern
+    below is locale-independent and gives exactly midnight on the target
+    date.
+
+    The leading `set day of var to 1` is a defense against current-date
+    quirks: if `current date` is e.g. 2026-01-31 and we immediately
+    `set month of var to 2`, AppleScript would try to roll into Feb 31 and
+    misbehave. Resetting day to 1 first, then year/month/day in that
+    order, avoids all such edge cases. (#242)
+    """
+    indent = "\n            "
+    return indent.join([
+        f"set {var} to current date",
+        f"set day of {var} to 1",
+        f"set year of {var} to {year}",
+        f"set month of {var} to {month}",
+        f"set day of {var} to {day}",
+        f"set time of {var} to 0",
+    ])
+
+
 def _build_date_filter_clauses(
     date_from: str | None,
     date_to: str | None,
-    received_within_hours: int | None,
-) -> list[str]:
-    """Build the date-related AppleScript IF clauses for the search loop.
+) -> tuple[str, list[str]]:
+    """Build `(preamble, in_loop_clauses)` for the `date_from`/`date_to`
+    AppleScript filters.
 
-    Extracted from `_search_messages_applescript` to keep that function
-    under the cyclomatic-complexity ceiling. All three date filters
-    compose by intersection (any matching clause skips the message).
+    The preamble constructs AS date objects via property setters and
+    assigns them to `dateFromVar` / `dateToExclVar`. The loop clauses
+    reference those variables (cheap comparison per message, no per-iter
+    re-parsing of an ISO string).
+
+    Both filters compose by intersection (any matching clause skips the
+    message). Returns `("", [])` when neither bound is set.
+
+    Note: the `received_within_hours` filter is NOT handled here — it's a
+    short-circuit that lives outside the per-message filter block. See
+    `_build_received_within_hours_short_circuit`.
     """
+    preamble_parts: list[str] = []
     clauses: list[str] = []
 
     if date_from is not None:
@@ -92,9 +128,12 @@ def _build_date_filter_clauses(
             raise ValueError(
                 f"date_from must be ISO 8601 YYYY-MM-DD, got: {date_from!r}"
             )
+        d = _date.fromisoformat(date_from)
+        preamble_parts.append(
+            _construct_as_date_var("dateFromVar", d.year, d.month, d.day)
+        )
         clauses.append(
-            f'if (date received of msg) < (date "{date_from}") '
-            f'then set includeThis to false'
+            "if (date received of msg) < dateFromVar then set includeThis to false"
         )
 
     if date_to is not None:
@@ -104,29 +143,56 @@ def _build_date_filter_clauses(
             )
         # Upper bound is exclusive of the day AFTER date_to, so the full
         # day of date_to is included.
-        next_day = (
-            _date.fromisoformat(date_to) + _timedelta(days=1)
-        ).isoformat()
-        clauses.append(
-            f'if (date received of msg) >= (date "{next_day}") '
-            f'then set includeThis to false'
-        )
-
-    if received_within_hours is not None:
-        if not isinstance(received_within_hours, int) or received_within_hours <= 0:
-            raise ValueError(
-                f"received_within_hours must be > 0, got: {received_within_hours!r}"
+        excl = _date.fromisoformat(date_to) + _timedelta(days=1)
+        preamble_parts.append(
+            _construct_as_date_var(
+                "dateToExclVar", excl.year, excl.month, excl.day
             )
-        # Hour-precise filter: Mail.app computes the cutoff against its
-        # own wall clock at script-eval time. No Python timezone math
-        # needed on this path. (#230)
+        )
         clauses.append(
-            f'if (date received of msg) < ((current date) - '
-            f'({received_within_hours} * hours)) '
-            f'then set includeThis to false'
+            "if (date received of msg) >= dateToExclVar then set includeThis to false"
         )
 
-    return clauses
+    preamble = "\n            ".join(preamble_parts) if preamble_parts else ""
+    return preamble, clauses
+
+
+def _build_received_within_hours_short_circuit(
+    received_within_hours: int | None,
+) -> tuple[str, str]:
+    """Build the AS preamble + exit-clause for `received_within_hours`.
+
+    Returns ``(preamble, exit_clause)``:
+
+    - ``preamble`` is spliced ABOVE the search loop. It hoists the cutoff
+      out of the per-iteration cost: ``set cutoffDate to (current date) -
+      (N * hours)`` (computed once, not per message).
+    - ``exit_clause`` is spliced INTO the loop body, before the per-message
+      filter block. It uses ``exit repeat`` rather than the standard
+      ``set includeThis to false`` skip. That short-circuit is **only sound
+      under newest-first iteration** (#242): once a message has
+      `date received < cutoff`, every subsequent message in the loop is
+      also older than the cutoff, so we can bail out of the entire scan.
+      With the previous oldest-first iteration this `exit repeat` would
+      have terminated immediately on the first (oldest) message and
+      returned nothing.
+
+    Both strings are empty when ``received_within_hours`` is None — splicing
+    them in is a no-op at script generation.
+    """
+    if received_within_hours is None:
+        return "", ""
+    if not isinstance(received_within_hours, int) or received_within_hours <= 0:
+        raise ValueError(
+            f"received_within_hours must be > 0, got: {received_within_hours!r}"
+        )
+    preamble = (
+        f"set cutoffDate to (current date) - ({received_within_hours} * hours)"
+    )
+    exit_clause = (
+        "if (date received of msg) < cutoffDate then exit repeat"
+    )
+    return preamble, exit_clause
 
 
 def _compute_attachment_save_targets(
@@ -1508,8 +1574,22 @@ class AppleMailConnector:
                 f'then set includeThis to false'
             )
 
-        filter_checks.extend(
-            _build_date_filter_clauses(date_from, date_to, received_within_hours)
+        date_preamble, date_filter_clauses = _build_date_filter_clauses(
+            date_from, date_to
+        )
+        filter_checks.extend(date_filter_clauses)
+
+        # `received_within_hours` is handled OUTSIDE the per-message filter
+        # block (#242): a `set cutoffDate to ...` preamble is hoisted above
+        # the loop (computed once, not per message), and an `if ... then
+        # exit repeat` short-circuit is spliced into the loop body before
+        # the filter block. This is sound only because the loop iterates
+        # newest-first (see the `repeat with i from 1 to total` comment
+        # below) — once a message has date < cutoff, every subsequent
+        # iteration's message is also < cutoff, so we can bail out of the
+        # entire scan.
+        cutoff_preamble, cutoff_exit_clause = (
+            _build_received_within_hours_short_circuit(received_within_hours)
         )
 
         if has_attachment is True:
@@ -1552,9 +1632,12 @@ class AppleMailConnector:
         # Render filter checks each on their own line, indented for the loop.
         filter_block = "\n                ".join(filter_checks) if filter_checks else ""
 
-        # Per-match limit short-circuits the loop. With no limit, we collect
-        # everything (newest-first) — same observable behavior as before
-        # except for ordering (was oldest-first).
+        # Per-match limit short-circuits the loop once enough hits accrue.
+        # Iteration is newest-first (#242): Mail.app exposes `item 1 of
+        # msgs` as the newest message and `item total of msgs` as the
+        # oldest, so the `repeat with i from 1 to total` form below visits
+        # newest first and naturally bounds the scan to ~limit iterations
+        # for limit-bounded queries.
         effective_limit = str(limit) if limit else "999999999"
 
         if include_attachments:
@@ -1575,12 +1658,15 @@ class AppleMailConnector:
             set mailboxRef to mailbox "{mailbox_safe}" of accountRef
             set msgs to messages of mailboxRef
             set total to count of msgs
+            {date_preamble}
+            {cutoff_preamble}
 
             set resultData to {{}}
             set matchCount to 0
-            repeat with i from total to 1 by -1
+            repeat with i from 1 to total
                 if matchCount >= {effective_limit} then exit repeat
                 set msg to item i of msgs
+                {cutoff_exit_clause}
                 set includeThis to true
                 {filter_block}
                 if includeThis then{attachments_clause}

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -3125,10 +3125,11 @@ class TestAppleMailConnector:
 
         Per #32, filters are now applied as per-message IF expressions
         instead of a `whose` clause — `whose` is unusably slow against
-        large IMAP mailboxes (>120s timeout on 8000+ messages). The new
-        pattern iterates messages in reverse (newest-first) and checks
-        each filter against the message; the script short-circuits when
-        matchCount reaches the limit.
+        large IMAP mailboxes (>120s timeout on 8000+ messages). The
+        pattern iterates messages newest-first (Mail.app exposes
+        `item 1 of msgs` as the newest, per #242) and checks each filter
+        against the message; the script short-circuits when matchCount
+        reaches the limit.
         """
         mock_run.return_value = "[]"
 
@@ -3161,8 +3162,10 @@ class TestAppleMailConnector:
         # Limit is enforced by accumulating matches and exiting the repeat
         # when matchCount reaches the bound.
         assert "if matchCount >= 10 then exit repeat" in call_args
-        # Reverse iteration (newest first).
-        assert "repeat with i from total to 1 by -1" in call_args
+        # Newest-first iteration: item 1 of msgs is the newest (per #242).
+        assert "repeat with i from 1 to total" in call_args
+        # Guard against regression to the old reverse-index pattern.
+        assert "repeat with i from total to 1 by -1" not in call_args
         # No `whose` clause anywhere.
         assert "whose" not in call_args
 
@@ -3223,23 +3226,44 @@ class TestAppleMailConnector:
     def test_search_messages_date_range_filter(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """date_from/date_to are applied via inverted IF expressions inside the loop."""
+        """date_from/date_to are constructed as AppleScript date objects via
+        property setters in a preamble above the loop, then referenced as
+        variables in IF expressions inside the loop. (#242)
+
+        The `date "YYYY-MM-DD"` literal form does NOT work in AppleScript —
+        it parses 2026-05-28 as arithmetic and yields year-12196, silently
+        filtering out every real-world message. The construction pattern is
+        locale-independent and gives exactly midnight local time on the
+        target date.
+        """
         mock_run.return_value = "[]"
         connector._search_messages_applescript(
             "Gmail", "INBOX", date_from="2026-04-01", date_to="2026-04-15"
         )
         script = mock_run.call_args[0][0]
-        # The IF expressions are the inverse of the inclusion condition: skip if BEFORE
-        # date_from, skip if ON-OR-AFTER date_to+1.
+        # Preamble: construct dateFromVar via property setters.
+        assert "set dateFromVar to current date" in script
+        assert "set year of dateFromVar to 2026" in script
+        assert "set month of dateFromVar to 4" in script
+        assert "set day of dateFromVar to 1" in script
+        # Preamble: construct dateToExclVar at the day AFTER date_to (exclusive
+        # upper bound so the full date_to day is inclusive).
+        assert "set dateToExclVar to current date" in script
+        assert "set year of dateToExclVar to 2026" in script
+        assert "set month of dateToExclVar to 4" in script
+        assert "set day of dateToExclVar to 16" in script
+        # In-loop clauses reference the variables.
         assert (
-            'if (date received of msg) < (date "2026-04-01") then set includeThis to false'
+            "if (date received of msg) < dateFromVar then set includeThis to false"
             in script
         )
-        # date_to gets +1 day so the full day is inclusive
         assert (
-            'if (date received of msg) >= (date "2026-04-16") then set includeThis to false'
+            "if (date received of msg) >= dateToExclVar then set includeThis to false"
             in script
         )
+        # Guard against regression to the broken date literal form.
+        assert 'date "2026-04-01"' not in script
+        assert 'date "2026-04-16"' not in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_search_messages_rejects_malformed_date_from(
@@ -5968,11 +5992,13 @@ class TestReceivedWithinHours:
     """
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_applescript_emits_relative_hours_clause(
+    def test_applescript_emits_relative_hours_short_circuit(
         self, mock_run: MagicMock
     ) -> None:
-        """AS path should embed `(current date) - (N * hours)` directly so
-        Mail.app does the hour-precise comparison server-side."""
+        """AS path hoists the cutoff out of the loop AND uses `exit repeat`
+        instead of a filter-skip. With newest-first iteration (#242), once a
+        message is older than the cutoff, every subsequent iteration would
+        also be older — so we exit the loop entirely instead of skipping."""
         from apple_mail_mcp.mail_connector import AppleMailConnector
         connector = AppleMailConnector()
         mock_run.return_value = "[]"
@@ -5980,10 +6006,18 @@ class TestReceivedWithinHours:
             "Gmail", "INBOX", received_within_hours=6
         )
         script = mock_run.call_args[0][0]
+        # Hoisted cutoff: computed once before the loop.
+        assert "set cutoffDate to (current date) - (6 * hours)" in script
+        # Short-circuit: exit the loop on the first message older than cutoff.
+        assert (
+            "if (date received of msg) < cutoffDate then exit repeat"
+        ) in script
+        # Guard: the old per-iteration inline form must NOT appear in the
+        # filter block — that pattern was the performance bug fixed by #242.
         assert (
             "if (date received of msg) < ((current date) - (6 * hours)) "
             "then set includeThis to false"
-        ) in script
+        ) not in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_applescript_rejects_zero_hours(


### PR DESCRIPTION
## Summary

Two stacked correctness bugs on the AppleScript fallback path of `search_messages`, fixed together because they share the same code path and produce the same user-visible symptom.

### Bug 1: iteration direction inverted
`_search_messages_applescript` iterated `total to 1 by -1` thinking that was newest-first. Empirical probe against live Gmail confirms Mail.app exposes `item 1` as newest, `item total` as oldest — so the loop was iterating oldest → newest. Consequences: `search_messages(limit=N)` returned N oldest, and `received_within_hours=24` scanned all 32k+ messages before finding hits → 60s timeout.

**Fix:** loop becomes `repeat with i from 1 to total`. New helper `_build_received_within_hours_short_circuit` hoists the cutoff above the loop and uses `exit repeat` (sound under newest-first invariant).

### Bug 2: AS date literal doesn't parse ISO (discovered while verifying Bug 1)
`date "2026-05-28"` in AppleScript parses as `Wednesday, October 5, 12196 at 12:00:00 AM` — arithmetic interpretation of the dash-separated string. Every message is < year-12196, so `date_from`/`date_to` filters excluded everything. Worse, the outer `search_messages` desugars `received_within_hours` → `date_from`, so the Bug 1 fix alone wasn't enough end-to-end.

**Fix:** new `_construct_as_date_var(var, year, month, day)` emits a property-setter pattern (locale-independent, midnight local time). `_build_date_filter_clauses` now returns `(preamble, in_loop_clauses)` where the preamble constructs `dateFromVar` / `dateToExclVar`.

## Closes
Closes #242

## Test plan
- [x] `make check-all` passes (lint, mypy, complexity, version-sync, parity, unit tests)
- [x] Live probe against real Gmail INBOX, AS path forced: `received_within_hours=24, limit=50` returns 15 correct results in 3.5s (was: 60s timeout, 0 results)
- [x] Bare `limit=5` returns 5 newest, completes in 2.3s
- [x] Tests assert on the new script shape AND guard against regression to the broken forms (`total to 1 by -1`, `date "2026-04-01"`, inline `(current date) - (N * hours)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)