### PR TITLE
fix(#247): AS mailbox resolver — nested paths + Gmail custom labels

### DIFF
--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -285,6 +285,8 @@ List all mailboxes (folders) for a specific account.
 
 **Returns:**
 
+Each mailbox includes both `name` (leaf only) and `path` (full slash-separated path from the account root). For top-level mailboxes `name == path`; for nested mailboxes (Gmail labels under `[Gmail]`, custom folder hierarchies, etc.) the two differ. The `path` field is what `search_messages.mailbox` and `move_messages.destination_mailbox` accept for unambiguous addressing of nested or custom-label mailboxes; the leaf `name` works whenever it's unique.
+
 ```json
 {
   "success": true,
@@ -292,14 +294,17 @@ List all mailboxes (folders) for a specific account.
   "mailboxes": [
     {
       "name": "INBOX",
+      "path": "INBOX",
       "unread_count": 5
     },
     {
-      "name": "Sent",
-      "unread_count": 0
+      "name": "Important",
+      "path": "[Gmail]/Important",
+      "unread_count": 267
     },
     {
       "name": "Archive",
+      "path": "Archive",
       "unread_count": 2
     }
   ]

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -335,7 +335,85 @@ _RULE_OPERATOR_MAP = {
 }
 
 
-def _wrap_as_json_script(body: str, *, timeout: int) -> str:
+# Shared AppleScript handlers for mailbox lookup (#247).
+#
+# Mail.app's `mailboxes of account` returns a FLAT list of every mailbox
+# belonging to the account — each one has a leaf `name` (no slash separators)
+# and a `container` reference (a mailbox, a container class, or
+# `missing value` at the top). Direct reference (`mailbox "X" of acctRef`)
+# only resolves canonical mailboxes like INBOX and Mail.app system names;
+# Gmail custom labels, nested folders, and most user-created hierarchies
+# return error -1728. The reliable resolution pattern is:
+#
+#   1. Iterate `mailboxes of acctRef` once.
+#   2. For each candidate, build its full slash-separated path via the
+#      container chain (`buildMailboxPath`).
+#   3. Match either by leaf `name` (single-component input) or by computed
+#      full path (slash-bearing input).
+#
+# The class check on `container` accepts both `mailbox` and `container`
+# (Gmail's [Gmail] folder is `container` class, not `mailbox`) and stops
+# at the account boundary so paths don't include the account name.
+#
+# Empirically verified against a real Gmail account: this handler resolves
+# Gmail's `Important` label (30k messages, previously unreachable via
+# direct reference) and the full path `[Gmail]/Important` to the same
+# mailbox.
+_MAILBOX_RESOLVER_HANDLERS = '''using terms from application "Mail"
+    on buildMailboxPath(mb)
+        set parts to {name of mb}
+        set current to mb
+        repeat
+            try
+                set parentRef to container of current
+                if parentRef is missing value then exit repeat
+                set parentClass to class of parentRef
+                if parentClass is not mailbox and parentClass is not container then exit repeat
+                set parts to {(name of parentRef)} & parts
+                set current to parentRef
+            on error
+                exit repeat
+            end try
+        end repeat
+        set tid to AppleScript's text item delimiters
+        set AppleScript's text item delimiters to "/"
+        set fullPath to parts as text
+        set AppleScript's text item delimiters to tid
+        return fullPath
+    end buildMailboxPath
+
+    on resolveMailbox(acctRef, targetPath)
+        if targetPath is "" then error "mailbox path is empty"
+        set hasSlash to (targetPath contains "/")
+        repeat with mb in (mailboxes of acctRef)
+            if hasSlash then
+                if my buildMailboxPath(mb) is targetPath then return mb
+            else
+                if (name of mb) is targetPath then return mb
+            end if
+        end repeat
+        error "mailbox not found: " & targetPath
+    end resolveMailbox
+
+    on collectMailboxesWithPaths(acctRef)
+        set results to {}
+        repeat with mb in (mailboxes of acctRef)
+            set mbName to name of mb
+            set mbPath to my buildMailboxPath(mb)
+            set mbUnread to unread count of mb
+            if mbUnread is missing value then set mbUnread to 0
+            set rec to {|name|:mbName, |path|:mbPath, |unread_count|:mbUnread}
+            set end of results to rec
+        end repeat
+        return results
+    end collectMailboxesWithPaths
+end using terms from
+'''
+
+
+def _wrap_as_json_script(
+    body: str, *, timeout: int, handlers: str = ""
+) -> str:
     """Wrap a tell-block body with ASObjC imports and an NSJSONSerialization return.
 
     The `body` must:
@@ -351,6 +429,10 @@ def _wrap_as_json_script(body: str, *, timeout: int) -> str:
 
     The wrapper:
       - Prepends `use framework "Foundation"` and `use scripting additions`.
+      - Optionally inserts top-level `handlers` (e.g. ``_MAILBOX_RESOLVER_HANDLERS``)
+        between the `use` statements and the `with timeout` block. Handlers
+        must be defined at script top level (outside any `tell` block) so
+        the body inside the tell can call them with ``my handlerName(...)``.
       - Wraps the body in `with timeout of {timeout} seconds ... end timeout`
         so Mail's default 60 s AppleEvent timeout does not fire before the
         connector's subprocess timeout — see issue #227. Without this,
@@ -368,14 +450,18 @@ def _wrap_as_json_script(body: str, *, timeout: int) -> str:
         timeout: AppleEvent timeout in seconds for the wrapped tell block.
             Callers should pass ``self.timeout`` so the in-script timeout
             matches the subprocess-level kill timer.
+        handlers: Optional AppleScript handler block to inject at script
+            top level (before `with timeout`). Empty string = no handlers.
 
     Returns:
         Full AppleScript source ready for osascript.
     """
+    handlers_block = f"{handlers}\n" if handlers else ""
     return (
         'use framework "Foundation"\n'
         "use scripting additions\n"
         "\n"
+        f"{handlers_block}"
         f"with timeout of {timeout} seconds\n"
         f"{body}\n"
         "end timeout\n"
@@ -433,7 +519,7 @@ def _bulk_repeat_block(
         account_clause = applescript_account_clause(account)
         mb_safe = escape_applescript_string(sanitize_input(source_mailbox))
         return (
-            f'            set sourceMb to mailbox "{mb_safe}" of {account_clause}\n'
+            f'            set sourceMb to my resolveMailbox({account_clause}, "{mb_safe}")\n'
             f"            repeat with msgId in idList\n"
             f"                try\n"
             f"                    set msg to first message of sourceMb whose id is msgId\n"
@@ -865,8 +951,8 @@ class AppleMailConnector:
             )
             lines.append("set should move message of newRule to true")
             lines.append(
-                f'set move message of newRule to mailbox "{mb_safe}" '
-                f"of {acct_clause}"
+                f"set move message of newRule to "
+                f'(my resolveMailbox({acct_clause}, "{mb_safe}"))'
             )
         if actions.get("copy_to"):
             mb_safe = escape_applescript_string(
@@ -877,8 +963,8 @@ class AppleMailConnector:
             )
             lines.append("set should copy message of newRule to true")
             lines.append(
-                f'set copy message of newRule to mailbox "{mb_safe}" '
-                f"of {acct_clause}"
+                f"set copy message of newRule to "
+                f'(my resolveMailbox({acct_clause}, "{mb_safe}"))'
             )
         if actions.get("mark_read"):
             lines.append("set mark read of newRule to true")
@@ -976,7 +1062,10 @@ class AppleMailConnector:
             f"set enabled of newRule to {enabled_str}\n"
             f"return (count of rules) as text"
         )
-        script = f'tell application "Mail"\n{body}\nend tell'
+        script = (
+            f'{_MAILBOX_RESOLVER_HANDLERS}'
+            f'tell application "Mail"\n{body}\nend tell'
+        )
         return int(self._run_applescript(script))
 
     def update_rule(
@@ -1090,6 +1179,7 @@ class AppleMailConnector:
             # Only the rule lookup, no actual updates — caller passed nothing.
             return
         script = (
+            f"{_MAILBOX_RESOLVER_HANDLERS}"
             'tell application "Mail"\n'
             + "\n".join(body_parts)
             + "\nend tell"
@@ -1183,10 +1273,21 @@ class AppleMailConnector:
         """List all mailboxes for an account.
 
         Args:
-            account: Account name.
+            account: Account name (or UUID).
 
         Returns:
-            List of dicts with keys: name, unread_count.
+            List of dicts with keys ``name`` (leaf), ``path`` (full
+            slash-separated path from account root — usable directly in
+            ``search_messages.mailbox`` / ``move_messages.destination_mailbox``
+            for nested addressing), and ``unread_count``.
+
+            Mail.app exposes mailboxes as a flat list with leaf names; the
+            ``path`` field is computed by walking each mailbox's container
+            chain (see ``_MAILBOX_RESOLVER_HANDLERS``). For top-level
+            mailboxes, ``name == path``. For nested mailboxes (Gmail labels
+            under ``[Gmail]``, user-created folder hierarchies, etc.) the
+            two differ — ``path`` is what ``resolveMailbox`` matches against
+            for unambiguous addressing.
 
         Raises:
             MailAccountNotFoundError: If account doesn't exist.
@@ -1196,18 +1297,15 @@ class AppleMailConnector:
         tell_body = f'''
         tell application "Mail"
             set accountRef to {account_clause}
-            set resultData to {{}}
-
-            repeat with mb in mailboxes of accountRef
-                set mbUnread to unread count of mb
-                if mbUnread is missing value then set mbUnread to 0
-                set mbRecord to {{|name|:(name of mb), |unread_count|:mbUnread}}
-                set end of resultData to mbRecord
-            end repeat
+            set resultData to my collectMailboxesWithPaths(accountRef)
         end tell
         '''
 
-        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
+        script = _wrap_as_json_script(
+            tell_body,
+            timeout=self.timeout,
+            handlers=_MAILBOX_RESOLVER_HANDLERS,
+        )
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
@@ -1655,7 +1753,7 @@ class AppleMailConnector:
         tell_body = f'''
         tell application "Mail"
             set accountRef to {account_clause}
-            set mailboxRef to mailbox "{mailbox_safe}" of accountRef
+            set mailboxRef to my resolveMailbox(accountRef, "{mailbox_safe}")
             set msgs to messages of mailboxRef
             set total to count of msgs
             {date_preamble}
@@ -1678,7 +1776,11 @@ class AppleMailConnector:
         end tell
         '''
 
-        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
+        script = _wrap_as_json_script(
+            tell_body,
+            timeout=self.timeout,
+            handlers=_MAILBOX_RESOLVER_HANDLERS,
+        )
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
@@ -1902,7 +2004,7 @@ class AppleMailConnector:
             for mid in message_ids
         )
 
-        script = f"""
+        script = f"""{_MAILBOX_RESOLVER_HANDLERS}
         tell application "Mail"
             set idList to {{{id_list}}}
             set updateCount to 0
@@ -2862,10 +2964,10 @@ class AppleMailConnector:
             counter_var="moveCount",
         )
 
-        script = f"""
+        script = f"""{_MAILBOX_RESOLVER_HANDLERS}
         tell application "Mail"
             set accountRef to {account_clause}
-            set destMailbox to mailbox "{mailbox_safe}" of accountRef
+            set destMailbox to my resolveMailbox(accountRef, "{mailbox_safe}")
             set idList to {{{id_list}}}
             set moveCount to 0
 
@@ -2930,7 +3032,7 @@ class AppleMailConnector:
             counter_var="flagCount",
         )
 
-        script = f"""
+        script = f"""{_MAILBOX_RESOLVER_HANDLERS}
         tell application "Mail"
             set idList to {{{id_list}}}
             set flagCount to 0
@@ -3075,10 +3177,10 @@ class AppleMailConnector:
             mb_safe = escape_applescript_string(sanitize_input(destination_mailbox))
             dest_setup = (
                 f'set accountRef to {account_clause}\n'
-                f'            set destMailbox to mailbox "{mb_safe}" of accountRef'
+                f'            set destMailbox to my resolveMailbox(accountRef, "{mb_safe}")'
             )
 
-        script = f"""
+        script = f"""{_MAILBOX_RESOLVER_HANDLERS}
         tell application "Mail"
             {dest_setup}
             set idList to {{{id_list}}}
@@ -3171,11 +3273,11 @@ class AppleMailConnector:
             name_safe = escape_applescript_string(sanitize_input(name))
             new_name_safe = escape_applescript_string(sanitized_new_name)
 
-            script = f"""
+            script = f"""{_MAILBOX_RESOLVER_HANDLERS}
             tell application "Mail"
                 set accountRef to {account_clause}
                 try
-                    set mb to mailbox "{name_safe}" of accountRef
+                    set mb to my resolveMailbox(accountRef, "{name_safe}")
                 on error
                     error "MAILBOX_NOT_FOUND"
                 end try
@@ -3340,10 +3442,10 @@ class AppleMailConnector:
 
         if parent_mailbox:
             parent_safe = escape_applescript_string(sanitize_input(parent_mailbox))
-            script = f"""
+            script = f"""{_MAILBOX_RESOLVER_HANDLERS}
             tell application "Mail"
                 set accountRef to {account_clause}
-                set parentMailbox to mailbox "{parent_safe}" of accountRef
+                set parentMailbox to my resolveMailbox(accountRef, "{parent_safe}")
                 make new mailbox at parentMailbox with properties {{name:"{name_safe}"}}
                 return "success"
             end tell
@@ -3448,7 +3550,7 @@ class AppleMailConnector:
             counter_var="deleteCount",
         )
 
-        script = f"""
+        script = f"""{_MAILBOX_RESOLVER_HANDLERS}
         tell application "Mail"
             set idList to {{{id_list}}}
             set deleteCount to 0

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -510,10 +510,16 @@ class TestAppleMailConnector:
         )
         script = mock_run.call_args[0][0]
         assert "set should move message of newRule to true" in script
+        # #247: mailbox lookup now uses the resolveMailbox handler (which
+        # iterates by name/path, robust against Gmail labels and nested
+        # paths). Old direct-reference form `mailbox "X" of account "Y"`
+        # silently failed for custom Gmail labels.
         assert (
-            'set move message of newRule to mailbox "Archive" of '
-            'account "Gmail"' in script
+            'set move message of newRule to '
+            '(my resolveMailbox(account "Gmail", "Archive"))' in script
         )
+        # Guard against regression to the broken direct-reference form.
+        assert 'mailbox "Archive" of account "Gmail"' not in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_create_rule_mark_flagged_with_color_sets_flag_index(
@@ -833,11 +839,21 @@ class TestAppleMailConnector:
     def test_list_mailboxes_script_quotes_name_key(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """The AppleScript must use |name| so NSJSONSerialization preserves it."""
+        """The AppleScript must use |name| so NSJSONSerialization preserves it.
+
+        Post-#247: the record construction now lives in the
+        `collectMailboxesWithPaths` handler (which also emits the new
+        `path` field).
+        """
         mock_run.return_value = "[]"
         connector.list_mailboxes("Gmail")
         script = mock_run.call_args[0][0]
-        assert "|name|:(name of mb)" in script
+        # The handler emits records with |name|, |path|, and |unread_count|.
+        assert "|name|:mbName" in script
+        assert "|path|:mbPath" in script
+        assert "|unread_count|:mbUnread" in script
+        # Caller invokes the handler with the resolved account.
+        assert "my collectMailboxesWithPaths(accountRef)" in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_list_mailboxes_with_name_uses_account_clause(
@@ -4322,12 +4338,12 @@ class TestBulkOpsSourceMailbox:
             ["abc", "def"], account="Gmail", source_mailbox="INBOX"
         )
         script = mock_run.call_args[0][0]
-        # Narrow scope: single mailbox of a specific account.
-        assert 'mailbox "INBOX" of' in script
-        assert 'account "Gmail"' in script
-        # Cross-scan loops MUST be gone.
+        # Narrow scope: resolveMailbox lookup against the specified account (#247).
+        assert (
+            'set sourceMb to my resolveMailbox(account "Gmail", "INBOX")' in script
+        )
+        # Cross-scan path's signature loop MUST be gone.
         assert "repeat with acc in accounts" not in script
-        assert "repeat with mb in mailboxes" not in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_mark_as_read_no_params_keeps_cross_scan_path(
@@ -4370,11 +4386,14 @@ class TestBulkOpsSourceMailbox:
             source_mailbox="INBOX",
         )
         script = mock_run.call_args[0][0]
-        # Source narrowed to a single mailbox; destination unchanged.
-        assert 'mailbox "INBOX" of' in script
-        assert 'mailbox "Archive" of' in script  # destination still set
+        # Source + destination both go through resolveMailbox (#247).
+        assert (
+            'set sourceMb to my resolveMailbox(account "Gmail", "INBOX")' in script
+        )
+        assert (
+            'set destMailbox to my resolveMailbox(accountRef, "Archive")' in script
+        )
         assert "repeat with acc in accounts" not in script
-        assert "repeat with mb in mailboxes" not in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_move_messages_narrow_path_gmail_branch(
@@ -4389,7 +4408,14 @@ class TestBulkOpsSourceMailbox:
             source_mailbox="INBOX",
         )
         script = mock_run.call_args[0][0]
-        assert 'mailbox "INBOX" of' in script
+        # Source lookup via resolveMailbox; nested path destination passed as-is.
+        assert (
+            'set sourceMb to my resolveMailbox(account "Gmail", "INBOX")' in script
+        )
+        assert (
+            'set destMailbox to my resolveMailbox(accountRef, "[Gmail]/All Mail")'
+            in script
+        )
         # Gmail-mode body: duplicate + delete instead of set mailbox
         assert "duplicate msg to destMailbox" in script
         assert "delete msg" in script
@@ -4418,7 +4444,9 @@ class TestBulkOpsSourceMailbox:
             ["abc"], "red", account="iCloud", source_mailbox="Archive"
         )
         script = mock_run.call_args[0][0]
-        assert 'mailbox "Archive" of' in script
+        assert (
+            'set sourceMb to my resolveMailbox(account "iCloud", "Archive")' in script
+        )
         assert "set flag index of msg to" in script
         assert "set flagged status of msg to" in script
         assert "repeat with acc in accounts" not in script
@@ -4444,7 +4472,9 @@ class TestBulkOpsSourceMailbox:
             ["abc"], account="iCloud", source_mailbox="Trash"
         )
         script = mock_run.call_args[0][0]
-        assert 'mailbox "Trash" of' in script
+        assert (
+            'set sourceMb to my resolveMailbox(account "iCloud", "Trash")' in script
+        )
         assert "delete msg" in script
         assert "repeat with acc in accounts" not in script
 
@@ -4468,7 +4498,9 @@ class TestBulkOpsSourceMailbox:
         # Script shape unchanged from the non-permanent path: `delete msg`
         # always moves to the account's Trash mailbox today.
         script = mock_run.call_args[0][0]
-        assert 'mailbox "Junk" of' in script
+        assert (
+            'set sourceMb to my resolveMailbox(account "iCloud", "Junk")' in script
+        )
         assert "delete msg" in script
         assert "repeat with acc in accounts" not in script
 
@@ -5532,20 +5564,23 @@ class TestUpdateMailbox:
         )
         script = mock_run.call_args[0][0]
         assert 'set name of mb to "New"' in script
-        assert 'mailbox "Old"' in script
+        # Mailbox lookup uses the resolveMailbox handler (#247).
+        assert 'set mb to my resolveMailbox(accountRef, "Old")' in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_script_handles_nested_path(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        """Slash-separated path passes through to Mail.app's
-        `mailbox "Parent/Child"` form."""
+        """Slash-separated path passes through to the resolveMailbox handler,
+        which walks the container chain to find the nested mailbox (#247)."""
         mock_run.return_value = "success"
         connector.update_mailbox(
             account="Gmail", name="Archive/2024", new_name="Archive2024"
         )
         script = mock_run.call_args[0][0]
-        assert 'mailbox "Archive/2024"' in script
+        assert (
+            'set mb to my resolveMailbox(accountRef, "Archive/2024")' in script
+        )
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_mailbox_not_found_raises(
@@ -6391,3 +6426,103 @@ class TestKeychainDualFormLookup:
         monkeypatch.setattr(c, "list_accounts", lambda: [])
         with pytest.raises(MailKeychainEntryNotFoundError):
             c._get_imap_password_with_fallback("Unknown", "alice@example.com")
+
+
+# =============================================================================
+# Mailbox resolver shape (#247)
+# =============================================================================
+
+
+class TestMailboxResolverShape:
+    """Tests for the shared AS mailbox resolver handlers (#247).
+
+    The resolver replaces direct-reference `mailbox "X" of accountRef`
+    with iterate-and-match logic that handles BOTH (a) Gmail-style custom
+    labels that fail direct reference with error -1728, and (b) nested
+    paths like `[Gmail]/All Mail` that aren't addressable via Mail.app's
+    direct-reference syntax in any form.
+
+    These tests assert on emitted-script shape (the handler block is
+    present and the call sites use `my resolveMailbox(...)` instead of
+    the broken direct-reference form). Behavior-level verification is
+    intentionally done out of band via live probes against a real
+    Gmail account — Mail.app's mailbox class hierarchy (mailbox vs
+    container) is too provider-specific to mock realistically.
+    """
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_search_messages_emits_resolver_handler_block(
+        self, mock_run: MagicMock
+    ) -> None:
+        connector = AppleMailConnector()
+        mock_run.return_value = "[]"
+        connector._search_messages_applescript("Gmail", "Important", limit=5)
+        script = mock_run.call_args[0][0]
+        # Handler declaration is present.
+        assert 'using terms from application "Mail"' in script
+        assert "on resolveMailbox(acctRef, targetPath)" in script
+        assert "on buildMailboxPath(mb)" in script
+        # Call site uses the handler, not the broken direct reference.
+        assert (
+            'set mailboxRef to my resolveMailbox(accountRef, "Important")'
+            in script
+        )
+        assert 'mailbox "Important" of accountRef' not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_mailboxes_uses_collect_handler(
+        self, mock_run: MagicMock
+    ) -> None:
+        connector = AppleMailConnector()
+        mock_run.return_value = "[]"
+        connector.list_mailboxes("Gmail")
+        script = mock_run.call_args[0][0]
+        # Handler declaration is present.
+        assert "on collectMailboxesWithPaths(acctRef)" in script
+        # Call site invokes the handler.
+        assert (
+            "set resultData to my collectMailboxesWithPaths(accountRef)"
+            in script
+        )
+        # Old flat enumeration pattern is gone.
+        assert "repeat with mb in mailboxes of accountRef" not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_list_mailboxes_path_field_round_trips(
+        self, mock_run: MagicMock
+    ) -> None:
+        """When the AS handler returns records with name + path, the
+        connector returns them as dicts with both fields preserved."""
+        connector = AppleMailConnector()
+        # Simulate AS output for a nested Gmail label.
+        mock_run.return_value = (
+            '[{"name":"INBOX","path":"INBOX","unread_count":5},'
+            '{"name":"Important","path":"[Gmail]/Important","unread_count":0},'
+            '{"name":"Sent Mail","path":"[Gmail]/Sent Mail","unread_count":0}]'
+        )
+        result = connector.list_mailboxes("Gmail")
+        assert len(result) == 3
+        assert result[0] == {"name": "INBOX", "path": "INBOX", "unread_count": 5}
+        # Nested label: path differs from leaf name.
+        assert result[1]["name"] == "Important"
+        assert result[1]["path"] == "[Gmail]/Important"
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolver_handler_class_check_is_locale_independent(
+        self, mock_run: MagicMock
+    ) -> None:
+        """The buildMailboxPath handler compares parent class against the
+        AS class constants `mailbox` and `container` directly (not as
+        localized text). This is important because `class of X as text`
+        would return a localized string (e.g. 'Postfach' in German)
+        that would silently break path construction outside en-US locales.
+        """
+        connector = AppleMailConnector()
+        mock_run.return_value = "[]"
+        connector.list_mailboxes("Gmail")
+        script = mock_run.call_args[0][0]
+        # Comparison against class constants.
+        assert "is not mailbox" in script
+        assert "is not container" in script
+        # NOT a localized string comparison.
+        assert 'is not "mailbox"' not in script


### PR DESCRIPTION
## Summary

Two related failure modes on the AppleScript fallback path, fixed together because they share the same code surface:

1. **Gmail custom labels fail direct reference** — `mailbox "Important" of acctRef` returns error `-1728` even when `Important` is in `mailboxes of acctRef`. Mail.app's flat-list mailbox exposure makes direct reference unreliable for non-canonical names. *(kemotaha's fork surfaced this.)*
2. **Nested paths not addressable** — `list_mailboxes` returned leaf names only, and no Mail.app syntax accepts `[Gmail]/All Mail` directly. *(jason21wc's fork surfaced this.)*

## Approach

Shared AS resolver in `_MAILBOX_RESOLVER_HANDLERS` (handler block constant), injected via the new `handlers` parameter on `_wrap_as_json_script` (or prepended manually for sites that build scripts without the JSON wrapper).

Three handlers:

- **`buildMailboxPath(mb)`** — walks container chain (allowing both `mailbox` and `container` classes; Gmail's `[Gmail]` is the latter) and returns the slash-separated full path. Stops at the account boundary.
- **`resolveMailbox(acctRef, targetPath)`** — iterates `mailboxes of acctRef`. Single-component target matches against leaf `name` (handles Gmail labels); slash-bearing target matches against computed full path. Raises if nothing matches.
- **`collectMailboxesWithPaths(acctRef)`** — used by `list_mailboxes`. Returns `{name, path, unread_count}` records.

8 call sites migrated. `list_mailboxes` gains a `path` field alongside `name` (backward-compatible).

## Closes
Closes #247

## Test plan
- [x] `make check-all` green (365 unit tests)
- [x] Live probe against real Gmail (AS path forced):
  - `list_mailboxes`: 97 mailboxes with `path` field; 85 have nested paths
  - `search_messages(mailbox="Important")`: 3 results in 2.1s (was -1728)
  - `search_messages(mailbox="[Gmail]/Important")`: 3 results in 2.0s
  - `search_messages(mailbox="INBOX")`: regression-safe

## Credit
@kemotaha (kemotaha/apple-mail-mcp@51ab809) and @jason21wc (jason21wc/apple-mail-mcp@b1054c2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)