### PR TITLE
fix(#233): thread connector timeout into non-JSON AppleScript paths

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -411,6 +411,31 @@ end using terms from
 '''
 
 
+def _wrap_with_timeout(body: str, *, timeout: int) -> str:
+    """Wrap an AppleScript tell-block in `with timeout … end timeout`.
+
+    Threads the connector's configured timeout into the script so Mail's
+    default 60s AppleEvent timeout does not fire before the subprocess-level
+    kill timer — see issues #227 (JSON paths) and #233 (the non-JSON mutation
+    paths). Without this, server-bound operations on slow accounts (Exchange/
+    EWS) can trip `AppleEvent timed out (-1712)` and the user's
+    ``AppleMailConnector(timeout=N)`` knob silently doesn't apply.
+
+    The `body` must NOT contain top-level `use` statements or handler
+    definitions — AppleScript forbids both inside a `with timeout` block.
+    Keep handlers (e.g. ``_MAILBOX_RESOLVER_HANDLERS``) OUTSIDE this wrapper,
+    prepended to the wrapped result by the caller.
+
+    Args:
+        body: AppleScript source (typically a `tell application "Mail"` block).
+        timeout: AppleEvent timeout in seconds. Callers pass ``self.timeout``.
+
+    Returns:
+        The body wrapped in a `with timeout` block.
+    """
+    return f"with timeout of {timeout} seconds\n{body}\nend timeout\n"
+
+
 def _wrap_as_json_script(
     body: str, *, timeout: int, handlers: str = ""
 ) -> str:
@@ -462,9 +487,7 @@ def _wrap_as_json_script(
         "use scripting additions\n"
         "\n"
         f"{handlers_block}"
-        f"with timeout of {timeout} seconds\n"
-        f"{body}\n"
-        "end timeout\n"
+        f"{_wrap_with_timeout(body, timeout=timeout)}"
         "\n"
         "set jsonData to (current application's NSJSONSerialization's "
         "dataWithJSONObject:resultData options:0 |error|:(missing value))\n"
@@ -859,9 +882,10 @@ class AppleMailConnector:
                 f"rule_index must be 1-based and positive, got {rule_index}"
             )
         enabled_str = "true" if enabled else "false"
-        script = (
+        script = _wrap_with_timeout(
             f'tell application "Mail" to '
-            f"set enabled of rule {rule_index} to {enabled_str}"
+            f"set enabled of rule {rule_index} to {enabled_str}",
+            timeout=self.timeout,
         )
         self._run_applescript(script)
 
@@ -1062,9 +1086,9 @@ class AppleMailConnector:
             f"set enabled of newRule to {enabled_str}\n"
             f"return (count of rules) as text"
         )
-        script = (
-            f'{_MAILBOX_RESOLVER_HANDLERS}'
-            f'tell application "Mail"\n{body}\nend tell'
+        script = f"{_MAILBOX_RESOLVER_HANDLERS}" + _wrap_with_timeout(
+            f'tell application "Mail"\n{body}\nend tell',
+            timeout=self.timeout,
         )
         return int(self._run_applescript(script))
 
@@ -1178,11 +1202,11 @@ class AppleMailConnector:
         if len(body_parts) == 1:
             # Only the rule lookup, no actual updates — caller passed nothing.
             return
-        script = (
-            f"{_MAILBOX_RESOLVER_HANDLERS}"
+        script = f"{_MAILBOX_RESOLVER_HANDLERS}" + _wrap_with_timeout(
             'tell application "Mail"\n'
             + "\n".join(body_parts)
-            + "\nend tell"
+            + "\nend tell",
+            timeout=self.timeout,
         )
         self._run_applescript(script)
 
@@ -1260,12 +1284,13 @@ class AppleMailConnector:
             raise MailRuleNotFoundError(
                 f"rule_index must be 1-based and positive, got {rule_index}"
             )
-        script = (
+        script = _wrap_with_timeout(
             f'tell application "Mail"\n'
             f"    set deletedName to name of rule {rule_index}\n"
             f"    delete rule {rule_index}\n"
             f"    return deletedName\n"
-            f"end tell"
+            f"end tell",
+            timeout=self.timeout,
         )
         return self._run_applescript(script)
 
@@ -2004,16 +2029,17 @@ class AppleMailConnector:
             for mid in message_ids
         )
 
-        script = f"""{_MAILBOX_RESOLVER_HANDLERS}
-        tell application "Mail"
+        script = f"{_MAILBOX_RESOLVER_HANDLERS}\n" + _wrap_with_timeout(
+            f"""tell application "Mail"
             set idList to {{{id_list}}}
             set updateCount to 0
 
 {repeat_block}
 
             return updateCount
-        end tell
-        """
+        end tell""",
+            timeout=self.timeout,
+        )
 
         result = self._run_applescript(script)
         return int(result) if result.isdigit() else 0
@@ -2872,8 +2898,8 @@ class AppleMailConnector:
             f'"{escape_applescript_string(str(path))}"' for _, path in targets
         )
 
-        script = f"""
-        tell application "Mail"
+        script = _wrap_with_timeout(
+            f"""tell application "Mail"
             -- Search all accounts for message
             repeat with acc in accounts
                 repeat with mb in mailboxes of acc
@@ -2899,8 +2925,9 @@ class AppleMailConnector:
             end repeat
 
             error "Message not found"
-        end tell
-        """
+        end tell""",
+            timeout=self.timeout,
+        )
 
         result = self._run_applescript(script)
         return int(result) if result.isdigit() else 0
@@ -2964,8 +2991,8 @@ class AppleMailConnector:
             counter_var="moveCount",
         )
 
-        script = f"""{_MAILBOX_RESOLVER_HANDLERS}
-        tell application "Mail"
+        script = f"{_MAILBOX_RESOLVER_HANDLERS}\n" + _wrap_with_timeout(
+            f"""tell application "Mail"
             set accountRef to {account_clause}
             set destMailbox to my resolveMailbox(accountRef, "{mailbox_safe}")
             set idList to {{{id_list}}}
@@ -2974,8 +3001,9 @@ class AppleMailConnector:
 {repeat_block}
 
             return moveCount
-        end tell
-        """
+        end tell""",
+            timeout=self.timeout,
+        )
 
         result = self._run_applescript(script)
         return int(result) if result.isdigit() else 0
@@ -3032,16 +3060,17 @@ class AppleMailConnector:
             counter_var="flagCount",
         )
 
-        script = f"""{_MAILBOX_RESOLVER_HANDLERS}
-        tell application "Mail"
+        script = f"{_MAILBOX_RESOLVER_HANDLERS}\n" + _wrap_with_timeout(
+            f"""tell application "Mail"
             set idList to {{{id_list}}}
             set flagCount to 0
 
 {repeat_block}
 
             return flagCount
-        end tell
-        """
+        end tell""",
+            timeout=self.timeout,
+        )
 
         result = self._run_applescript(script)
         return int(result) if result.isdigit() else 0
@@ -3180,8 +3209,8 @@ class AppleMailConnector:
                 f'            set destMailbox to my resolveMailbox(accountRef, "{mb_safe}")'
             )
 
-        script = f"""{_MAILBOX_RESOLVER_HANDLERS}
-        tell application "Mail"
+        script = f"{_MAILBOX_RESOLVER_HANDLERS}\n" + _wrap_with_timeout(
+            f"""tell application "Mail"
             {dest_setup}
             set idList to {{{id_list}}}
             set updateCount to 0
@@ -3189,8 +3218,9 @@ class AppleMailConnector:
 {repeat_block}
 
             return updateCount
-        end tell
-        """
+        end tell""",
+            timeout=self.timeout,
+        )
 
         result = self._run_applescript(script)
         return int(result) if result.isdigit() else 0
@@ -3273,8 +3303,8 @@ class AppleMailConnector:
             name_safe = escape_applescript_string(sanitize_input(name))
             new_name_safe = escape_applescript_string(sanitized_new_name)
 
-            script = f"""{_MAILBOX_RESOLVER_HANDLERS}
-            tell application "Mail"
+            script = f"{_MAILBOX_RESOLVER_HANDLERS}\n" + _wrap_with_timeout(
+                f"""tell application "Mail"
                 set accountRef to {account_clause}
                 try
                     set mb to my resolveMailbox(accountRef, "{name_safe}")
@@ -3283,8 +3313,9 @@ class AppleMailConnector:
                 end try
                 set name of mb to "{new_name_safe}"
                 return "success"
-            end tell
-            """
+            end tell""",
+                timeout=self.timeout,
+            )
 
             try:
                 result = self._run_applescript(script)
@@ -3442,22 +3473,24 @@ class AppleMailConnector:
 
         if parent_mailbox:
             parent_safe = escape_applescript_string(sanitize_input(parent_mailbox))
-            script = f"""{_MAILBOX_RESOLVER_HANDLERS}
-            tell application "Mail"
+            script = f"{_MAILBOX_RESOLVER_HANDLERS}\n" + _wrap_with_timeout(
+                f"""tell application "Mail"
                 set accountRef to {account_clause}
                 set parentMailbox to my resolveMailbox(accountRef, "{parent_safe}")
                 make new mailbox at parentMailbox with properties {{name:"{name_safe}"}}
                 return "success"
-            end tell
-            """
+            end tell""",
+                timeout=self.timeout,
+            )
         else:
-            script = f"""
-            tell application "Mail"
+            script = _wrap_with_timeout(
+                f"""tell application "Mail"
                 set accountRef to {account_clause}
                 make new mailbox at accountRef with properties {{name:"{name_safe}"}}
                 return "success"
-            end tell
-            """
+            end tell""",
+                timeout=self.timeout,
+            )
 
         result = self._run_applescript(script)
         return result == "success"
@@ -3550,16 +3583,17 @@ class AppleMailConnector:
             counter_var="deleteCount",
         )
 
-        script = f"""{_MAILBOX_RESOLVER_HANDLERS}
-        tell application "Mail"
+        script = f"{_MAILBOX_RESOLVER_HANDLERS}\n" + _wrap_with_timeout(
+            f"""tell application "Mail"
             set idList to {{{id_list}}}
             set deleteCount to 0
 
 {repeat_block}
 
             return deleteCount
-        end tell
-        """
+        end tell""",
+            timeout=self.timeout,
+        )
 
         result = self._run_applescript(script)
         return int(result) if result.isdigit() else 0
@@ -3643,8 +3677,8 @@ class AppleMailConnector:
         """
         _validate_draft_id(draft_id)
 
-        script = f"""
-        tell application "Mail"
+        script = _wrap_with_timeout(
+            f"""tell application "Mail"
             set didDelete to false
             repeat with acc in accounts
                 try
@@ -3666,8 +3700,9 @@ class AppleMailConnector:
             else
                 return "NOT_FOUND"
             end if
-        end tell
-        """
+        end tell""",
+            timeout=self.timeout,
+        )
 
         result = self._run_applescript(script).strip()
         if result == "OK":
@@ -3710,8 +3745,8 @@ class AppleMailConnector:
         safe_bare = escape_applescript_string(sanitize_input(bare))
         safe_bracketed = escape_applescript_string(sanitize_input(bracketed))
 
-        script = f"""
-        tell application "Mail"
+        script = _wrap_with_timeout(
+            f"""tell application "Mail"
             set foundId to ""
             repeat with acc in accounts
                 try
@@ -3730,8 +3765,9 @@ class AppleMailConnector:
             else
                 return foundId
             end if
-        end tell
-        """
+        end tell""",
+            timeout=self.timeout,
+        )
 
         result = self._run_applescript(script).strip()
         if result == "NOT_FOUND" or not result:
@@ -4151,8 +4187,8 @@ class AppleMailConnector:
                 end repeat
             """
 
-        script = f"""
-        tell application "Mail"
+        script = _wrap_with_timeout(
+            f"""tell application "Mail"
             {snapshot_block}
 
             {creation_block}
@@ -4166,8 +4202,9 @@ class AppleMailConnector:
             {attachment_block}
 
             {terminal_block}
-        end tell
-        """
+        end tell""",
+            timeout=self.timeout,
+        )
 
         try:
             result = self._run_applescript(script).strip()
@@ -4238,8 +4275,8 @@ class AppleMailConnector:
             f'"{escape_applescript_string(str(p))}"' for p in target_paths
         )
 
-        script = f"""
-        tell application "Mail"
+        script = _wrap_with_timeout(
+            f"""tell application "Mail"
             set targetId to "{draft_id}"
             set foundDraft to missing value
             repeat with acc in accounts
@@ -4274,8 +4311,9 @@ class AppleMailConnector:
                 end try
             end repeat
             return saved as text
-        end tell
-        """
+        end tell""",
+            timeout=self.timeout,
+        )
 
         result = self._run_applescript(script).strip()
         if result == "ERR_NOT_FOUND":

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -17,7 +17,11 @@ from pathlib import Path
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from apple_mail_mcp.mail_connector import AppleMailConnector
+from apple_mail_mcp.mail_connector import (
+    _MAILBOX_RESOLVER_HANDLERS,
+    AppleMailConnector,
+    _wrap_with_timeout,
+)
 
 # Skip all integration tests by default
 # Run with: pytest --run-integration
@@ -1562,3 +1566,42 @@ class TestFindMessageByMessageIdIntegration:
             pass
         finally:
             connector.delete_draft(draft_id)
+
+
+class TestTimeoutWrappingCompiles:
+    """#233 — the non-JSON mutation paths now prepend top-level handlers and
+    wrap the tell-block in `with timeout … end timeout`. AppleScript forbids
+    handler definitions inside a `with timeout` block, so this structure could
+    only be a compile error or valid — a failure mode that unit tests (which
+    mock subprocess.run) cannot catch. Run the real structure through
+    osascript to prove it compiles and executes.
+    """
+
+    def test_handler_prefixed_timeout_script_executes(
+        self, connector: AppleMailConnector
+    ) -> None:
+        # Mirror the handler-prefixed shape used by mark_as_read / move_messages
+        # / create_rule etc.: handlers OUTSIDE the timeout block, a trivial
+        # tell-block INSIDE. A syntax error (handler inside `with timeout`)
+        # would surface here as a non-zero osascript exit.
+        script = f"{_MAILBOX_RESOLVER_HANDLERS}\n" + _wrap_with_timeout(
+            'tell application "Mail"\n'
+            "    return (count of accounts) as text\n"
+            "end tell",
+            timeout=connector.timeout,
+        )
+        result = connector._run_applescript(script)
+        assert result.isdigit()
+
+    def test_no_handler_timeout_script_executes(
+        self, connector: AppleMailConnector
+    ) -> None:
+        # Mirror the no-handler shape (set_rule_enabled / save_attachments etc.).
+        script = _wrap_with_timeout(
+            'tell application "Mail"\n'
+            "    return (count of accounts) as text\n"
+            "end tell",
+            timeout=connector.timeout,
+        )
+        result = connector._run_applescript(script)
+        assert result.isdigit()

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -3,6 +3,7 @@
 import logging
 import time
 import warnings
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -21,7 +22,11 @@ from apple_mail_mcp.exceptions import (
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
 )
-from apple_mail_mcp.mail_connector import AppleMailConnector, _wrap_as_json_script
+from apple_mail_mcp.mail_connector import (
+    AppleMailConnector,
+    _wrap_as_json_script,
+    _wrap_with_timeout,
+)
 
 
 class TestAppleMailConnector:
@@ -4667,6 +4672,192 @@ class TestConnectorThreadsTimeoutIntoScripts:
         )
         script = mock_run.call_args.kwargs.get("input") or mock_run.call_args.args[0]
         assert "with timeout of 300 seconds" in script
+
+
+class TestWrapWithTimeoutHelper:
+    """Issue #233 — _wrap_with_timeout is the single source of truth for the
+    `with timeout … end timeout` clause shared by JSON and non-JSON paths."""
+
+    def test_wraps_body_in_timeout_block(self) -> None:
+        body = 'tell application "Mail"\n    return 1\nend tell'
+        wrapped = _wrap_with_timeout(body, timeout=90)
+        assert wrapped == (
+            "with timeout of 90 seconds\n"
+            'tell application "Mail"\n    return 1\nend tell\n'
+            "end timeout\n"
+        )
+
+    def test_json_wrapper_reuses_helper_format(self) -> None:
+        # The JSON wrapper must embed the exact clause the helper produces,
+        # so the two never drift apart.
+        body = 'tell application "Mail"\n    set resultData to {}\nend tell'
+        json_script = _wrap_as_json_script(body, timeout=120)
+        assert _wrap_with_timeout(body, timeout=120) in json_script
+
+
+class TestNonJsonPathsThreadTimeout:
+    """Issue #233 — mutation paths that build AppleScript directly (not via
+    _wrap_as_json_script) must also honor AppleMailConnector(timeout=N) by
+    emitting a `with timeout` clause, so Mail's 60s AppleEvent default does
+    not fire before the connector's subprocess timeout."""
+
+    @staticmethod
+    def _script_from(mock_run: MagicMock) -> str:
+        return mock_run.call_args.kwargs.get("input") or mock_run.call_args.args[0]
+
+    @patch("subprocess.run")
+    def test_set_rule_enabled(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=111)
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        connector.set_rule_enabled(1, True)
+        assert "with timeout of 111 seconds" in self._script_from(mock_run)
+
+    @patch("subprocess.run")
+    def test_delete_rule(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=112)
+        mock_run.return_value = MagicMock(returncode=0, stdout="Junk", stderr="")
+        connector.delete_rule(1)
+        assert "with timeout of 112 seconds" in self._script_from(mock_run)
+
+    @patch("subprocess.run")
+    def test_mark_as_read(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=113)
+        mock_run.return_value = MagicMock(returncode=0, stdout="1", stderr="")
+        connector.mark_as_read(["123"])
+        script = self._script_from(mock_run)
+        assert "with timeout of 113 seconds" in script
+        # Handlers must stay OUTSIDE the timeout block (AppleScript forbids
+        # handler definitions inside `with timeout`).
+        assert script.index("on resolveMailbox") < script.index("with timeout")
+
+    @patch("subprocess.run")
+    def test_move_messages(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=114)
+        mock_run.return_value = MagicMock(returncode=0, stdout="1", stderr="")
+        connector.move_messages(["123"], "Archive", "TestAcct")
+        script = self._script_from(mock_run)
+        assert "with timeout of 114 seconds" in script
+        assert script.index("on resolveMailbox") < script.index("with timeout")
+
+    @patch("subprocess.run")
+    def test_flag_message(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=115)
+        mock_run.return_value = MagicMock(returncode=0, stdout="1", stderr="")
+        connector.flag_message(["123"], "red")
+        script = self._script_from(mock_run)
+        assert "with timeout of 115 seconds" in script
+        assert script.index("on resolveMailbox") < script.index("with timeout")
+
+    @patch("subprocess.run")
+    def test_update_message(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=116)
+        mock_run.return_value = MagicMock(returncode=0, stdout="1", stderr="")
+        connector.update_message(["123"], read_status=True)
+        script = self._script_from(mock_run)
+        assert "with timeout of 116 seconds" in script
+        assert script.index("on resolveMailbox") < script.index("with timeout")
+
+    @patch("subprocess.run")
+    def test_update_mailbox_rename(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=117)
+        mock_run.return_value = MagicMock(returncode=0, stdout="success", stderr="")
+        connector.update_mailbox("TestAcct", "Old", new_name="New")
+        script = self._script_from(mock_run)
+        assert "with timeout of 117 seconds" in script
+        assert script.index("on resolveMailbox") < script.index("with timeout")
+
+    @patch("subprocess.run")
+    def test_create_mailbox_with_parent(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=118)
+        mock_run.return_value = MagicMock(returncode=0, stdout="success", stderr="")
+        connector.create_mailbox("TestAcct", "Child", parent_mailbox="Parent")
+        script = self._script_from(mock_run)
+        assert "with timeout of 118 seconds" in script
+        assert script.index("on resolveMailbox") < script.index("with timeout")
+
+    @patch("subprocess.run")
+    def test_create_mailbox_without_parent(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=119)
+        mock_run.return_value = MagicMock(returncode=0, stdout="success", stderr="")
+        connector.create_mailbox("TestAcct", "TopLevel")
+        assert "with timeout of 119 seconds" in self._script_from(mock_run)
+
+    @patch("subprocess.run")
+    def test_delete_messages(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=120)
+        mock_run.return_value = MagicMock(returncode=0, stdout="1", stderr="")
+        connector.delete_messages(["123"])
+        script = self._script_from(mock_run)
+        assert "with timeout of 120 seconds" in script
+        assert script.index("on resolveMailbox") < script.index("with timeout")
+
+    @patch("subprocess.run")
+    def test_delete_draft(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=121)
+        mock_run.return_value = MagicMock(returncode=0, stdout="OK", stderr="")
+        connector.delete_draft("draft123")
+        assert "with timeout of 121 seconds" in self._script_from(mock_run)
+
+    @patch("subprocess.run")
+    def test_find_message_by_message_id(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=122)
+        mock_run.return_value = MagicMock(returncode=0, stdout="42", stderr="")
+        connector.find_message_by_message_id("<abc@example.com>")
+        assert "with timeout of 122 seconds" in self._script_from(mock_run)
+
+    @patch("subprocess.run")
+    def test_extract_draft_attachments(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        connector = AppleMailConnector(timeout=123)
+        mock_run.return_value = MagicMock(returncode=0, stdout="1", stderr="")
+        connector.extract_draft_attachments("draft123", ["file.pdf"], tmp_path)
+        assert "with timeout of 123 seconds" in self._script_from(mock_run)
+
+    @patch("subprocess.run")
+    def test_create_rule(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=124)
+        mock_run.return_value = MagicMock(returncode=0, stdout="1", stderr="")
+        connector.create_rule(
+            name="X",
+            conditions=[{"field": "from", "operator": "contains", "value": "@x.com"}],
+            actions={"mark_read": True},
+        )
+        script = self._script_from(mock_run)
+        assert "with timeout of 124 seconds" in script
+        assert script.index("on resolveMailbox") < script.index("with timeout")
+
+    @patch.object(AppleMailConnector, "_check_supported_actions")
+    @patch("subprocess.run")
+    def test_update_rule(
+        self, mock_run: MagicMock, mock_check: MagicMock
+    ) -> None:
+        connector = AppleMailConnector(timeout=125)
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        connector.update_rule(rule_index=1, name="Renamed")
+        script = self._script_from(mock_run)
+        assert "with timeout of 125 seconds" in script
+        assert script.index("on resolveMailbox") < script.index("with timeout")
+
+    @patch.object(AppleMailConnector, "_get_attachments_applescript")
+    @patch("subprocess.run")
+    def test_save_attachments(
+        self, mock_run: MagicMock, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        connector = AppleMailConnector(timeout=126)
+        mock_get.return_value = [{"name": "a.pdf"}]
+        mock_run.return_value = MagicMock(returncode=0, stdout="1", stderr="")
+        connector.save_attachments("123", tmp_path)
+        assert "with timeout of 126 seconds" in self._script_from(mock_run)
+
+    @patch("subprocess.run")
+    def test_create_draft(self, mock_run: MagicMock) -> None:
+        connector = AppleMailConnector(timeout=127)
+        mock_run.return_value = MagicMock(returncode=0, stdout="draft123", stderr="")
+        connector.create_draft(
+            seed="new", to=["x@example.com"], subject="Hi", body="x"
+        )
+        assert "with timeout of 127 seconds" in self._script_from(mock_run)
 
 
 class TestAutoTemplateVars:


### PR DESCRIPTION
## Summary

PR #228 (closing #227) wrapped every **JSON-returning** AppleScript path in `with timeout of N seconds … end timeout` so `AppleMailConnector(timeout=N)` is honored instead of Mail's hard-coded 60s AppleEvent default. But **17 mutation paths** build AppleScript as raw f-strings (returning a count/status string, not JSON) and bypassed that wrapping. Any of them could still fail with `AppleEvent timed out (-1712)` on a slow account (Exchange/EWS), and the user's `timeout` knob silently didn't apply.

This closes that gap.

## Approach

The issue leaned toward "Option A" — blanket-wrap the whole script inside `_run_applescript`. **That's unsafe:** 9 of the direct sites prefix the script with top-level `_MAILBOX_RESOLVER_HANDLERS` handler definitions, and AppleScript forbids handler definitions (and `use` statements) *inside* a `with timeout` block — a blanket wrap would be a compile error on those paths.

Instead (the issue's "Option B", refined):

- Add a shared module-level helper `_wrap_with_timeout(body, *, timeout)` — the single source of truth for the `with timeout … end timeout` clause.
- Refactor `_wrap_as_json_script` to reuse it (byte-identical output; guarded by existing tests).
- Apply it at every direct site, keeping handlers **outside** the wrapper.

`_run_applescript` itself is unchanged — no auto-wrapping, no double-wrap risk.

## Sites wrapped (17)

**Handler-prefixed** (handlers stay outside): `create_rule`, `update_rule`, `mark_as_read`, `move_messages`, `flag_message`, `update_message`, `update_mailbox` (rename), `create_mailbox` (with-parent), `delete_messages`

**No handlers** (whole script wrapped): `set_rule_enabled`, `delete_rule`, `create_mailbox` (no-parent), `delete_draft`, `find_message_by_message_id`, `extract_draft_attachments`, `save_attachments`, `create_draft`

> Note: the issue's enumerated list undercounted — `create_rule`, `update_rule`, `save_attachments`, and `create_draft` were found via an exhaustive sweep of every `_run_applescript` call site.

## Tests

- **Unit** (`TestNonJsonPathsThreadTimeout`, `TestWrapWithTimeoutHelper`): per-site assertions that the connector timeout reaches the emitted script (mirrors `TestConnectorThreadsTimeoutIntoScripts`), plus handler-before-`with timeout` ordering checks and a helper/JSON-wrapper consistency check.
- **Integration** (`TestTimeoutWrappingCompiles`): runs the handler+timeout and no-handler+timeout structures through real `osascript` to prove they compile and execute — the failure mode mocked unit tests cannot catch. Both pass against real Mail.app.

`make check-all` passes (lint, typecheck, 1132 unit tests, complexity, version-sync, parity).

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)