### PR TITLE
fix: IMAP attachment enumeration on multipart messages (+ rfc822 consistency)

### DIFF
--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -509,7 +509,20 @@ def _bodystructure_has_attachment(structure: Any) -> bool:
                 return True
         return False
 
-    # Leaf — scan for a disposition tuple whose first element is
+    # Leaf. A message/rfc822 part (forwarded email) counts as an attachment,
+    # matching _bodystructure_extract_attachments — otherwise the
+    # has_attachment search filter and the attachment list disagree (a
+    # forwarded-only message would be filtered out yet report an attachment).
+    type_ = structure[0] if isinstance(structure[0], bytes) else b""
+    subtype = (
+        structure[1]
+        if len(structure) > 1 and isinstance(structure[1], bytes)
+        else b""
+    )
+    if type_.lower() == b"message" and subtype.lower() == b"rfc822":
+        return True
+
+    # Scan for a disposition tuple whose first element is
     # b"attachment" or b"inline".
     for elem in structure:
         if (

--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -414,7 +414,15 @@ def _bodystructure_extract_attachments(
         if not isinstance(s, tuple) or not s:
             return
 
-        # Multipart: first element is a child part (also a tuple).
+        # Multipart: IMAPClient groups the child parts in a LIST at
+        # position 0 — ``([child1, child2, ...], subtype, params, ...)``.
+        # (Real iCloud/Gmail BODYSTRUCTUREs take this shape; missing it
+        # silently dropped attachments on every multipart message.)
+        if isinstance(s[0], list):
+            for child in s[0]:
+                _walk(child)
+            return
+        # Defensive: some inputs nest children as direct tuple elements.
         if isinstance(s[0], tuple):
             for child in s:
                 if isinstance(child, tuple):
@@ -489,7 +497,12 @@ def _bodystructure_has_attachment(structure: Any) -> bool:
     if not isinstance(structure, tuple) or not structure:
         return False
 
-    # Multipart — first element is a nested tuple (sub-part).
+    # Multipart — children grouped in a list at position 0 (IMAPClient).
+    if isinstance(structure[0], list):
+        return any(
+            _bodystructure_has_attachment(child) for child in structure[0]
+        )
+    # Defensive: children nested as direct tuple elements.
     if isinstance(structure[0], tuple):
         for child in structure:
             if isinstance(child, tuple) and _bodystructure_has_attachment(child):

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -398,6 +398,23 @@ class TestHasAttachment:
         fetch_keys = mock_client.fetch.call_args[0][1]
         assert b"BODYSTRUCTURE" in fetch_keys
 
+    def test_message_rfc822_part_counts_as_attachment(self) -> None:
+        """A forwarded-email (message/rfc822) part must register as an
+        attachment, consistent with _bodystructure_extract_attachments —
+        otherwise has_attachment search and the attachment list disagree.
+        Uses the real IMAPClient list-at-0 multipart shape."""
+        from apple_mail_mcp.imap_connector import (
+            _bodystructure_extract_attachments,
+            _bodystructure_has_attachment,
+        )
+
+        structure = (
+            [_BS_PLAIN_TEXT, _BS_FORWARDED_EMAIL_NO_DISP],
+            b"mixed", (b"BOUNDARY", b"X"), None, None, None,
+        )
+        assert _bodystructure_has_attachment(structure) is True
+        assert len(_bodystructure_extract_attachments(structure)) == 1
+
 
 class TestEnvelopeTranslation:
     @patch("apple_mail_mcp.imap_connector.IMAPClient")

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -972,6 +972,33 @@ _BS_MANGLED_FILENAME = (
     (b"attachment", (b"filename", b"\xff\xfe\xff.pdf")),
 )
 
+# A BODYSTRUCTURE captured verbatim from a real iCloud message (a
+# multipart/mixed with a multipart/alternative body + an application/pdf
+# attachment). The crucial shape detail: IMAPClient groups multipart
+# children in a LIST at position 0 — ([child1, child2], b"mixed", ...) —
+# NOT as bare tuple elements. The other multipart fixtures above use the
+# bare-tuple shape, which imapclient never actually emits.
+_BS_REAL_ICLOUD_MIXED_PDF = (
+    [
+        (
+            [
+                (b"text", b"plain", (b"CHARSET", b"UTF-8"), None, None,
+                 b"quoted-printable", 454, 27, None, None, None, None),
+                (b"text", b"html", (b"CHARSET", b"UTF-8"), None, None,
+                 b"quoted-printable", 1915, 33, None, None, None, None),
+            ],
+            b"alternative", (b"BOUNDARY", b"000000000000578ec60652f6a8ad"),
+            None, None, None,
+        ),
+        (
+            b"application", b"pdf", (b"NAME", b"04 FS.pdf"),
+            b"<f_mpr37zve0>", None, b"base64", 289236, None,
+            (b"ATTACHMENT", (b"FILENAME", b"04 FS.pdf")), None, None,
+        ),
+    ],
+    b"mixed", (b"BOUNDARY", b"000000000000578ec70652f6a8af"), None, None, None,
+)
+
 
 class TestGetAttachments:
     """ImapConnector.get_attachments — Message-ID lookup + BODYSTRUCTURE walk."""
@@ -990,6 +1017,29 @@ class TestGetAttachments:
             (uids or [42])[0]: {b"BODYSTRUCTURE": bodystructure},
         }
         return client
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_real_imapclient_multipart_list_shape_enumerates_pdf(
+        self, mock_cls: MagicMock
+    ) -> None:
+        """Regression: IMAPClient groups multipart children in a list at
+        position 0. Walking only the bare-tuple shape (as the walker did
+        before) misreads a real multipart/mixed as a leaf and drops the
+        attachment. Uses a BODYSTRUCTURE captured verbatim from real iCloud,
+        and also checks the sibling has-attachment walker agrees."""
+        from apple_mail_mcp.imap_connector import _bodystructure_has_attachment
+
+        self._setup_client(mock_cls, bodystructure=_BS_REAL_ICLOUD_MIXED_PDF)
+
+        result = ImapConnector("h", 993, "u@e.com", "pw").get_attachments(
+            "abc@x", mailbox="INBOX",
+        )
+
+        assert len(result) == 1
+        assert result[0]["name"] == "04 FS.pdf"
+        assert result[0]["mime_type"] == "application/pdf"
+        assert result[0]["size"] == 289236
+        assert _bodystructure_has_attachment(_BS_REAL_ICLOUD_MIXED_PDF) is True
 
     @patch("apple_mail_mcp.imap_connector.IMAPClient")
     def test_search_uses_bracketed_message_id(


### PR DESCRIPTION
Two related fixes to IMAP attachment enumeration, found while working on a downstream fork. Listed with their confidence levels so you can weigh each independently.

## Commit 1 — multipart attachments dropped (observed on real data)

`_bodystructure_extract_attachments` and `_bodystructure_has_attachment` detect multipart by testing `isinstance(s[0], tuple)`, but **IMAPClient groups multipart child parts in a list** at position 0 — `([child1, child2, ...], subtype, params, ...)`. A real `multipart/mixed` message has its top node misread as a leaf, its children are never walked, and enumeration returns `[]` even when a child carries `Content-Disposition: attachment`.

**Impact:** `get_messages(include_attachments=True)`, `get_attachments`, and the `has_attachment` filter silently drop attachments on the IMAP path for any multipart message.

**Why tests didn't catch it:** the existing fixtures (e.g. `_MULTIPART_WITH_ATTACHMENT = (_LEAF_TEXT, _LEAF_PDF_ATTACHMENT, b"mixed")`) encode children as bare tuple elements — a shape IMAPClient never emits. Verified: `imapclient`'s `BodyData.create` always rewrites multipart children into a list at position 0.

**Evidence:** captured a `BODYSTRUCTURE` verbatim from a real iCloud `multipart/mixed` message (alternative body + `application/pdf` attachment); the PDF leaf carries `(b'ATTACHMENT', (b'FILENAME', b'04 FS.pdf'))` yet enumeration returned `[]`. Confirmed live against an iCloud account: `get_attachments` returned the PDF after the fix, `[]` before. Regression test `_BS_REAL_ICLOUD_MIXED_PDF` is the captured structure.

## Commit 2 — has_attachment vs extract disagree on message/rfc822 (consistency fix)

`_bodystructure_extract_attachments` treats a `message/rfc822` (forwarded email) part as an attachment; `_bodystructure_has_attachment` did not. So a forwarded-email-only message would be filtered out of `has_attachment=True` search yet listed by `get_attachments`. Adds the same rule to `_bodystructure_has_attachment`.

**Confidence:** code-level consistency fix between two sibling functions, demonstrated by a unit test. I have **not** observed it on a live forwarded-email message — flagging that honestly. The disagreement only surfaces once multipart traversal works (commit 1), which is why it's bundled here.

## Test plan

- Full unit suite green locally (1134 passed); `ruff` + `mypy` clean.
- New regression tests use real list-shaped multipart structures, not the bare-tuple shape.

Happy to split commit 2 out, drop it, or adjust naming to match your conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)