### PR TITLE
fix: _resolve_imap_config raises KeyError on accounts with no IMAP server

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -1412,7 +1412,11 @@ class AppleMailConnector:
             set acctRef to {account_clause}
             set acctEmails to email addresses of acctRef
             if acctEmails is missing value then set acctEmails to {{}}
-            set resultData to {{|host|:(server name of acctRef), |port|:(port of acctRef), |user_name|:(user name of acctRef), |email_addresses|:acctEmails}}
+            set acctHost to server name of acctRef
+            if acctHost is missing value then set acctHost to ""
+            set acctPort to port of acctRef
+            if acctPort is missing value then set acctPort to 0
+            set resultData to {{|host|:acctHost, |port|:acctPort, |user_name|:(user name of acctRef), |email_addresses|:acctEmails}}
         end tell
         '''
         script = _wrap_as_json_script(tell_body, timeout=self.timeout)
@@ -1421,9 +1425,14 @@ class AppleMailConnector:
         email_addresses = cast(list[str], parsed.get("email_addresses") or [])
         user_name = cast(str, parsed.get("user_name") or "")
         email = user_name or (email_addresses[0] if email_addresses else "")
+        # Read host/port with safe defaults: accounts without an IMAP server
+        # (POP / "On My Mac" / mid-configuration) report `server name`/`port`
+        # as `missing value`, which drops those keys from the serialized
+        # record. An empty host then fails the later connect with OSError
+        # (the graceful-fallback path) rather than KeyError-ing here.
         return (
-            cast(str, parsed["host"]),
-            cast(int, parsed["port"]),
+            cast(str, parsed.get("host") or ""),
+            cast(int, parsed.get("port") or 0),
             email,
         )
 

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -20,8 +20,10 @@ from _pytest.monkeypatch import MonkeyPatch
 from apple_mail_mcp.mail_connector import (
     _MAILBOX_RESOLVER_HANDLERS,
     AppleMailConnector,
+    _wrap_as_json_script,
     _wrap_with_timeout,
 )
+from apple_mail_mcp.utils import parse_applescript_json
 
 # Skip all integration tests by default
 # Run with: pytest --run-integration
@@ -1605,3 +1607,50 @@ class TestTimeoutWrappingCompiles:
         )
         result = connector._run_applescript(script)
         assert result.isdigit()
+
+
+class TestResolveImapConfigAppleScript:
+    """#267 / #272 — _resolve_imap_config coerces `server name` / `port`
+    for `missing value` so accounts without an IMAP server don't drop those
+    keys from NSJSONSerialization and KeyError the caller.
+
+    The real missing-value path needs a POP / "On My Mac" / mid-config
+    account, which a typical dev machine (all IMAP/iCloud accounts) can't
+    provide — so these two tests cover the change against real osascript
+    from both ends: the modified method still works on a server-bearing
+    account (no regression), and the coercion idiom genuinely survives
+    NSJSONSerialization (the mechanism the fix relies on)."""
+
+    def test_resolve_imap_config_real_account_no_regression(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """The edited tell-block still parses and runs against a real
+        server-bearing account, returning a usable (host, port, email)."""
+        host, port, email = connector._resolve_imap_config(test_account)
+        assert isinstance(host, str) and host  # non-empty server name
+        assert isinstance(port, int) and port > 0
+        assert isinstance(email, str) and email
+
+    def test_missing_value_coercion_survives_json_serialization(
+        self, connector: AppleMailConnector
+    ) -> None:
+        """The crux of the fix: a `missing value` host/port, once coerced to
+        ``""`` / ``0`` with the same idiom _resolve_imap_config uses, must
+        survive NSJSONSerialization as present keys (uncoerced, the keys are
+        silently dropped — the exact cause of the KeyError). Runs through
+        real osascript + the production JSON wrapper + parser."""
+        body = """
+        tell application "Mail"
+            set acctHost to missing value
+            if acctHost is missing value then set acctHost to ""
+            set acctPort to missing value
+            if acctPort is missing value then set acctPort to 0
+            set resultData to {|host|:acctHost, |port|:acctPort}
+        end tell
+        """
+        script = _wrap_as_json_script(body, timeout=connector.timeout)
+        parsed = parse_applescript_json(connector._run_applescript(script))
+        assert isinstance(parsed, dict)
+        # Keys present (not dropped) and coerced to safe defaults.
+        assert parsed.get("host") == ""
+        assert parsed.get("port") == 0

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -936,12 +936,33 @@ class TestAppleMailConnector:
         )
         connector._resolve_imap_config("iCloud")
         script = mock_run.call_args[0][0]
-        assert "|host|:(server name of acctRef)" in script
-        assert "|port|:(port of acctRef)" in script
+        assert "|host|:acctHost" in script
+        assert "|port|:acctPort" in script
         assert "|user_name|:(user name of acctRef)" in script
         assert "|email_addresses|:acctEmails" in script
+        # server name / port must be coerced for missing value (POP / local
+        # / mid-config accounts) so a dropped key can't KeyError the caller.
+        assert 'if acctHost is missing value then set acctHost to ""' in script
+        assert "if acctPort is missing value then set acctPort to 0" in script
         # Must assign to resultData for _wrap_as_json_script to serialize.
         assert "set resultData to" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_missing_host_port_degrades_gracefully(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """An account without an IMAP server (POP / "On My Mac" /
+        mid-config) reports `server name`/`port` as `missing value`,
+        dropping those JSON keys. The method must return ('', 0, ...) so
+        the later connect fails with OSError (the graceful-degradation
+        path) rather than KeyError-ing on bracket access here."""
+        mock_run.return_value = (
+            '{"user_name":"u@e.com","email_addresses":["u@e.com"]}'
+        )
+        host, port, email = connector._resolve_imap_config("LocalPOP")
+        assert host == ""
+        assert port == 0
+        assert email == "u@e.com"
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_resolve_imap_config_escapes_account_name(


### PR DESCRIPTION
## What

`_resolve_imap_config` coerces `email addresses` for `missing value` but not `server name` / `port`, then reads them with bracket access (`parsed["host"]` / `parsed["port"]`). An account without an IMAP server — POP, an "On My Mac" local store, or one mid-configuration — reports `server name` / `port` as `missing value`, which drops those keys from the `NSJSONSerialization` output, so the bracket access raises `KeyError`.

`KeyError` isn't in the orchestrator's fallback exception set, so instead of degrading to the AppleScript path the call crashes.

## Fix

Coerce `server name` / `port` to `""` / `0` in the AppleScript (matching the existing `email addresses` handling), and read them with `.get` defaults on the Python side. An empty host then fails the later connect with `OSError` — which *is* the graceful-degradation path.

## Confidence (stated plainly)

This is **reasoned, not observed**: it follows from the documented `missing value` → dropped-key behavior plus the unguarded bracket access, and is demonstrated by a unit test that simulates the dropped keys. **I have not reproduced it on a live POP / local account** — the machine I tested on only has IMAP accounts. The iCloud path is unaffected (host/port are present). Sharing it as a defensive fix in case it's useful; happy to drop it if you'd rather wait for a real-world repro.

## Test plan

- New unit test: dropped `host`/`port` keys → returns `("", 0, ...)` instead of `KeyError`.
- Full unit suite green locally (1133 passed); `ruff` + `mypy` clean.

Found while working on a downstream fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)