### PR TITLE
ci(#274): make complexity and mypy gates blocking in PR CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
 
       - name: Type check
         run: uv run mypy src/
-        continue-on-error: true
 
       - name: Unit tests
         run: uv run pytest tests/ -m "not integration and not e2e and not benchmark" -v --cov=apple_mail_mcp --cov-report=term-missing --cov-fail-under=90
@@ -31,7 +30,6 @@ jobs:
 
       - name: Complexity check
         run: ./scripts/check_complexity.sh
-        continue-on-error: true
 
       - name: Version sync check
         run: ./scripts/check_version_sync.sh

--- a/scripts/check_complexity.sh
+++ b/scripts/check_complexity.sh
@@ -6,21 +6,27 @@ set -euo pipefail
 THRESHOLD=20
 SRC_DIR="src/apple_mail_mcp"
 
-if ! command -v radon &> /dev/null; then
-    if command -v uv &> /dev/null; then
-        echo "Installing radon..."
-        uv pip install radon -q
-    else
-        echo "Error: radon not found. Install with: pip install radon"
-        exit 1
-    fi
+# Resolve how to invoke radon. Prefer it directly on PATH; otherwise fall
+# back to `uv run`, which provisions it from the project's dev dependencies.
+# This matters in CI: `uv sync --dev` installs radon into the project venv,
+# not onto PATH, so a bare `radon` call is "command not found" there. That
+# failure used to be masked by the complexity step's continue-on-error (#274);
+# once the gate became blocking it surfaced, so the script must invoke radon
+# in a way that works without an activated venv.
+if command -v radon &> /dev/null; then
+    RADON=(radon)
+elif command -v uv &> /dev/null; then
+    RADON=(uv run radon)
+else
+    echo "Error: radon not found. Install with: pip install radon (or use uv)."
+    exit 1
 fi
 
 echo "Checking cyclomatic complexity (threshold: CC <= $THRESHOLD)..."
 echo ""
 
 # Get complexity report
-REPORT=$(radon cc "$SRC_DIR" -n C -s 2>&1) || true
+REPORT=$("${RADON[@]}" cc "$SRC_DIR" -n C -s 2>&1) || true
 
 if [ -z "$REPORT" ]; then
     echo "All functions have complexity <= B (acceptable)."
@@ -36,7 +42,7 @@ echo ""
 # every function in the dangerous range. Until #174, this was -n F (CC
 # ≥ 41), meaning anything from CC 21 to 40 silently passed the
 # `> THRESHOLD` check below.
-FAILURES=$(radon cc "$SRC_DIR" -n D -j 2>&1 | python3 -c "
+FAILURES=$("${RADON[@]}" cc "$SRC_DIR" -n D -j 2>&1 | python3 -c "
 import json, sys
 
 THRESHOLD = $THRESHOLD


### PR DESCRIPTION
## Summary

`test.yml`'s **Complexity check** and **Type check** steps carried `continue-on-error: true` — they ran but never failed the build. That's the real reason #266's CC=25 regression merged green: the gate *reported* it and was ignored. (My original framing of #274 — "the gates are local-only" — was wrong; they were present but non-blocking.)

This removes `continue-on-error` from both steps so they block PRs, matching `release-hygiene.yml` (which already runs complexity hard on RC tags).

## Why it's safe
- Both gates are **clean on current main** (`radon` exit 0; `mypy` clean) — verified locally.
- Legitimate high-complexity functions remain admissible via the per-function `ALLOWLIST` in `scripts/check_complexity.sh` (ratchets down freely; raising needs justification).

## Out of scope
- **Parity** stays informational for now — `check_client_server_parity.sh` intentionally `exit 0`s on gaps because several connector methods are deliberately internal. Hard enforcement (via an intended-internals allowlist) is tracked as a separate follow-up.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)