### PR TITLE
fix(#239): gate delete_messages behind confirmation elicitation

### DIFF
--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -1807,14 +1807,18 @@ async def delete_mailbox(
     {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
     mutating=True,
 )
-def delete_messages(
+async def delete_messages(
     message_ids: list[str],
     permanent: bool = False,
     account: str | None = None,
     source_mailbox: str | None = None,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
     Delete messages (always moves to the account's Trash mailbox).
+
+    Destructive: gated behind user confirmation via MCP elicitation
+    (issue #239), matching delete_rule / delete_mailbox / delete_template.
 
     Args:
         message_ids: List of message IDs to delete
@@ -1862,6 +1866,27 @@ def delete_messages(
                 "error": f"Cannot delete {len(message_ids)} messages at once (max: 100)",
                 "error_type": "validation_error",
             }
+
+        # Destructive: confirm before moving to Trash. Show the count and
+        # source (not every message-id — too noisy for 100-item calls).
+        # account/source_mailbox are either both set or both None (the
+        # connector rejects a partial pair), so the two-way split is total.
+        location = (
+            f"{account}/{source_mailbox}"
+            if account and source_mailbox
+            else "across all mailboxes"
+        )
+        summary = (
+            f"Move {len(message_ids)} message(s) to Trash from {location}?\n\n"
+            f"Recoverable from the account's Trash until that mailbox is emptied."
+        )
+        cancel_err = await _elicit_confirmation(
+            ctx, summary, "delete_messages",
+            {"count": len(message_ids), "account": account,
+             "source_mailbox": source_mailbox, "permanent": permanent},
+        )
+        if cancel_err:
+            return cancel_err
 
         logger.info(f"Deleting {len(message_ids)} message(s) to trash")
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2239,14 +2239,20 @@ class TestDeleteMailboxTool:
 
 
 class TestDeleteMessages:
-    def test_success(self, mock_mail: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_success(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
         mock_mail.delete_messages.return_value = 2
 
-        result = delete_messages(["1", "2"], permanent=False)
+        result = await delete_messages(
+            ["1", "2"], permanent=False, ctx=mock_ctx_accept
+        )
 
         assert result["success"] is True
         assert result["count"] == 2
         assert result["permanent"] is False
+        mock_ctx_accept.elicit.assert_awaited_once()
         mock_mail.delete_messages.assert_called_once_with(
             message_ids=["1", "2"],
             permanent=False,
@@ -2255,9 +2261,14 @@ class TestDeleteMessages:
             source_mailbox=None,
         )
 
-    def test_passes_source_mailbox_through(self, mock_mail: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_passes_source_mailbox_through(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
         mock_mail.delete_messages.return_value = 1
-        delete_messages(["1"], account="Gmail", source_mailbox="INBOX")
+        await delete_messages(
+            ["1"], account="Gmail", source_mailbox="INBOX", ctx=mock_ctx_accept
+        )
         mock_mail.delete_messages.assert_called_once_with(
             message_ids=["1"],
             permanent=False,
@@ -2266,52 +2277,94 @@ class TestDeleteMessages:
             source_mailbox="INBOX",
         )
 
-    def test_empty_list_early_exit(self, mock_mail: MagicMock) -> None:
-        result = delete_messages([])
+    @pytest.mark.asyncio
+    async def test_empty_list_early_exit(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
+        result = await delete_messages([], ctx=mock_ctx_accept)
 
         assert result["success"] is True
         assert result["count"] == 0
         mock_mail.delete_messages.assert_not_called()
+        # No prompt for a no-op call.
+        mock_ctx_accept.elicit.assert_not_awaited()
 
-    def test_over_limit_validation_error(self, mock_mail: MagicMock) -> None:
-        result = delete_messages([str(i) for i in range(101)])
+    @pytest.mark.asyncio
+    async def test_over_limit_validation_error(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
+        result = await delete_messages(
+            [str(i) for i in range(101)], ctx=mock_ctx_accept
+        )
 
         assert result["success"] is False
         assert result["error_type"] == "validation_error"
         mock_mail.delete_messages.assert_not_called()
+        # No prompt for an invalid (over-limit) call.
+        mock_ctx_accept.elicit.assert_not_awaited()
 
-    def test_value_error_from_connector(self, mock_mail: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_declined_elicitation_blocks_delete(
+        self, mock_mail: MagicMock, mock_ctx_decline: MagicMock
+    ) -> None:
+        result = await delete_messages(["1", "2"], ctx=mock_ctx_decline)
+
+        assert result["success"] is False
+        assert result["error_type"] == "cancelled"
+        mock_mail.delete_messages.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_ctx_blocks_delete_with_confirmation_required(
+        self, mock_mail: MagicMock
+    ) -> None:
+        result = await delete_messages(["1", "2"], ctx=None)
+
+        assert result["success"] is False
+        assert result["error_type"] == "confirmation_required"
+        mock_mail.delete_messages.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_value_error_from_connector(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
         mock_mail.delete_messages.side_effect = ValueError("bad")
 
-        result = delete_messages(["1"])
+        result = await delete_messages(["1"], ctx=mock_ctx_accept)
 
         assert result["success"] is False
         assert result["error_type"] == "validation_error"
 
-    def test_message_not_found(self, mock_mail: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_message_not_found(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
         mock_mail.delete_messages.side_effect = MailMessageNotFoundError("x")
 
-        result = delete_messages(["999"])
+        result = await delete_messages(["999"], ctx=mock_ctx_accept)
 
         assert result["success"] is False
         assert result["error_type"] == "message_not_found"
 
-    def test_unexpected_exception_maps_to_unknown(self, mock_mail: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_maps_to_unknown(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
         mock_mail.delete_messages.side_effect = RuntimeError("boom")
 
-        result = delete_messages(["1"])
+        result = await delete_messages(["1"], ctx=mock_ctx_accept)
 
         assert result["success"] is False
         assert result["error_type"] == "unknown"
 
-    def test_permanent_true_threads_through_to_connector(
-        self, mock_mail: MagicMock
+    @pytest.mark.asyncio
+    async def test_permanent_true_threads_through_to_connector(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
     ) -> None:
         """Issue #111: the connector emits a DeprecationWarning when
         permanent=True; the server's job is just to forward the flag
         unchanged so the warning fires from the user's call frame."""
         mock_mail.delete_messages.return_value = 1
-        result = delete_messages(["1"], permanent=True)
+        result = await delete_messages(["1"], permanent=True, ctx=mock_ctx_accept)
         assert result["success"] is True
         # Server still echoes the (now-meaningless) flag in its response
         # for backwards compatibility with existing callers.


### PR DESCRIPTION
## Summary

`delete_messages` was the only destructive MCP tool that was **sync and ungated** — it moved messages to Trash without `_elicit_confirmation`, unlike `delete_rule` / `delete_mailbox` / `delete_template` / `create_draft(send_now=True)`. That left THREAT_MODEL §5's claim ("Existing elicitation gates cover send / delete") **false** for bulk deletion, and the LLM-laundering path (hostile email content → "delete all marketing" → 100 messages to Trash, noticed only after Trash auto-empties) unguarded.

## Change
- `delete_messages` is now `async`, takes `ctx: Context | None = None`, and elicits confirmation **after** validation (empty-list / rate-limit / >100 checks) and **before** the connector call — so no-op and invalid calls don't prompt.
- Summary shows **count + source mailbox** (`Move N message(s) to Trash from <account>/<mailbox>?`), not every message-id (too noisy at 100 items, per the issue).
- Fail-closed via `_elicit_confirmation`: declined → `cancelled`; `ctx=None` / elicit-unavailable → `confirmation_required`; connector not called in either case.

## Scope
- Connector `delete_messages` unchanged — **no AppleScript touched**, so no new integration test.
- THREAT_MODEL §5 needs no wording change — this fix makes the existing claim true.
- Pre-context prompt-injection scanning (raised in the issue thread) stays out of scope → planning issue #225.

## Tests
- `TestDeleteMessages` migrated to async (await + accepting `ctx` where the connector is reached; asserts **no prompt** for empty/over-limit calls).
- New gate cases: declined → `cancelled` (connector not called), `ctx=None` → `confirmation_required`, accepted → proceeds + `elicit` awaited.
- `make check-all` green (incl. the now-blocking complexity/mypy gates from #274).

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)