### PR TITLE
fix(#222): gate create_rule behind confirmation for dangerous actions

### DIFF
--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -286,6 +286,17 @@ def _resolve_rule_name(rule_index: int) -> str | None:
     return None
 
 
+_DANGEROUS_RULE_ACTIONS = ("delete", "forward_to", "move_to", "copy_to")
+
+
+def _rule_actions_require_confirmation(actions: dict[str, Any]) -> bool:
+    """True when a rule's actions can move, disclose, or delete mail
+    (delete / forward_to / move_to / copy_to) — those require user
+    confirmation. Purely organizational actions (mark_read, mark_flagged,
+    flag_color) do not. (#222)"""
+    return any(actions.get(name) for name in _DANGEROUS_RULE_ACTIONS)
+
+
 @_tool(
     {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": True},
     mutating=True,
@@ -372,19 +383,24 @@ async def delete_rule(
     {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False},
     mutating=True,
 )
-def create_rule(
+async def create_rule(
     name: str,
     conditions: list[dict[str, Any]],
     actions: dict[str, Any],
     match_logic: str = "all",
     enabled: bool = True,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
     Create a new Mail.app rule.
 
-    Additive — no confirmation prompt. Mail.app appends new rules to the
-    end of the rule list, so the returned ``rule_index`` equals the new
-    total rule count.
+    Rules with actions that can move, forward, or delete mail
+    (delete / forward_to / move_to / copy_to) require user confirmation —
+    a single create can install automation that auto-forwards or deletes
+    all future mail (#222). Organizational-only rules (mark_read,
+    mark_flagged, flag_color) are created without a prompt. Mail.app
+    appends new rules to the end of the rule list, so the returned
+    ``rule_index`` equals the new total rule count.
 
     Args:
         name: Rule display name. Need not be unique.
@@ -420,6 +436,24 @@ def create_rule(
         )
         if safety_err:
             return safety_err
+
+        # Destructive-automation gate (#222): confirm before installing a
+        # rule that can move, forward, or delete mail. Organizational-only
+        # rules (mark_read / mark_flagged / flag_color) skip the prompt.
+        if _rule_actions_require_confirmation(actions):
+            dangerous = [a for a in _DANGEROUS_RULE_ACTIONS if actions.get(a)]
+            summary = (
+                f"Create Mail rule '{name}'? It will run automatically on "
+                f"incoming mail and can move, forward, or delete messages "
+                f"(actions: {', '.join(dangerous)}). This is a destructive "
+                f"automation — confirm before installing."
+            )
+            cancel_err = await _elicit_confirmation(
+                ctx, summary, "create_rule",
+                {"name": name, "dangerous_actions": dangerous},
+            )
+            if cancel_err:
+                return cancel_err
 
         new_index = mail.create_rule(
             name=name,

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -375,47 +375,107 @@ class TestDeleteRule:
         mock_mail.delete_rule.assert_not_called()
 
 
+_COND = [{"field": "subject", "operator": "contains", "value": "X"}]
+
+# (label, actions-dict) for each action that can move/disclose/delete mail.
+_DANGEROUS_RULE_ACTION_CASES = [
+    ("delete", {"delete": True}),
+    ("forward_to", {"forward_to": ["a@example.com"]}),
+    ("move_to", {"move_to": {"account": "Gmail", "mailbox": "X"}}),
+    ("copy_to", {"copy_to": {"account": "Gmail", "mailbox": "X"}}),
+]
+
+
 class TestCreateRule:
-    def test_success_returns_new_index(self, mock_mail: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_success_returns_new_index(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
         mock_mail.create_rule.return_value = 6
-        result = create_rule(
+        result = await create_rule(
             name="My New Rule",
-            conditions=[
-                {"field": "subject", "operator": "contains", "value": "X"}
-            ],
+            conditions=_COND,
             actions={"mark_read": True},
+            ctx=mock_ctx_accept,
         )
         assert result["success"] is True
         assert result["rule_index"] == 6
         assert result["name"] == "My New Rule"
+        # Organizational-only rule: no confirmation prompt.
+        mock_ctx_accept.elicit.assert_not_awaited()
 
-    def test_no_elicitation_for_create(
-        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("label,actions", _DANGEROUS_RULE_ACTION_CASES)
+    async def test_dangerous_action_prompts_then_creates(
+        self,
+        label: str,
+        actions: dict,
+        mock_mail: MagicMock,
+        mock_ctx_accept: MagicMock,
     ) -> None:
-        """create_rule is additive — no confirmation prompt."""
-        # create_rule is sync, takes no ctx, so this just confirms it
-        # works without one.
-        mock_mail.create_rule.return_value = 1
-        result = create_rule(
-            name="X",
-            conditions=[
-                {"field": "subject", "operator": "contains", "value": "Y"}
-            ],
-            actions={"delete": True},
+        """delete / forward_to / move_to / copy_to require confirmation (#222)."""
+        mock_mail.create_rule.return_value = 3
+        result = await create_rule(
+            name=f"rule-{label}",
+            conditions=_COND,
+            actions=actions,
+            ctx=mock_ctx_accept,
         )
         assert result["success"] is True
-        # No elicit call possible — sync function doesn't accept ctx.
+        mock_ctx_accept.elicit.assert_awaited_once()
+        mock_mail.create_rule.assert_called_once()
 
-    def test_validation_error_returns_validation_type(
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "actions",
+        [{"mark_read": True}, {"mark_flagged": True, "flag_color": "red"}],
+    )
+    async def test_organizational_only_skips_prompt(
+        self, actions: dict, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
+        mock_mail.create_rule.return_value = 2
+        result = await create_rule(
+            name="organize", conditions=_COND, actions=actions, ctx=mock_ctx_accept
+        )
+        assert result["success"] is True
+        mock_ctx_accept.elicit.assert_not_awaited()
+        mock_mail.create_rule.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_declined_dangerous_action_blocks_create(
+        self, mock_mail: MagicMock, mock_ctx_decline: MagicMock
+    ) -> None:
+        result = await create_rule(
+            name="X", conditions=_COND, actions={"delete": True}, ctx=mock_ctx_decline
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "cancelled"
+        mock_mail.create_rule.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_ctx_blocks_dangerous_create(
         self, mock_mail: MagicMock
     ) -> None:
+        result = await create_rule(
+            name="X", conditions=_COND, actions={"forward_to": ["a@example.com"]},
+            ctx=None,
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "confirmation_required"
+        mock_mail.create_rule.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_validation_error_returns_validation_type(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
         mock_mail.create_rule.side_effect = ValueError("invalid field")
-        result = create_rule(
+        result = await create_rule(
             name="X",
             conditions=[
                 {"field": "bogus", "operator": "contains", "value": "Y"}
             ],
             actions={"delete": True},
+            ctx=mock_ctx_accept,
         )
         assert result["success"] is False
         assert result["error_type"] == "validation_error"


### PR DESCRIPTION
## Summary

`create_rule` was treated as "additive, no confirmation" — but *additive* describes the rule-list op, not the rule's effect. One additive create can install a rule that auto-forwards every incoming message to an attacker, auto-deletes senders, or auto-moves financial mail to Trash — running automatically on all future mail. This is the same destructive surface the delete/send gates cover (sibling of #239).

## Change
- New helper `_rule_actions_require_confirmation(actions)` — dangerous = `delete` / `forward_to` / `move_to` / `copy_to`.
- `create_rule` is now `async` with `ctx: Context | None = None`, and elicits confirmation **before** the connector call **only when a dangerous action is present**. Organizational-only rules (`mark_read` / `mark_flagged` / `flag_color`) are created without a prompt — benign automation stays frictionless.
- Fail-closed via `_elicit_confirmation`: declined → `cancelled`; `ctx=None` / elicit-unavailable → `confirmation_required`; connector not called either way.

## Scope
- Connector `create_rule` and the rule schema unchanged — pure server-layer gate (no AppleScript touched → no integration test).
- `@_tool` annotation hints unchanged (the runtime gate is the fix; flipping the static `destructiveHint` for a conditionally-destructive tool is cosmetic and out of scope).
- `update_rule` already gates *all* action/condition patches (it over-gates, which is safe) — refining it to be dangerous-action-aware is a separate ergonomics follow-up (filed, v0.10.0).

## Tests
- `TestCreateRule` migrated to async; parametrized "prompt fires + creates" for each dangerous action; organizational-only "skips prompt"; declined → `cancelled`; `ctx=None` → `confirmation_required`.
- `make check-all` green (incl. the now-blocking complexity/mypy gates from #274).

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)