### PR TITLE
fix(#236): byte caps on save_attachments (disk-fill DoS)

### DIFF
--- a/docs/guides/THREAT_MODEL.md
+++ b/docs/guides/THREAT_MODEL.md
@@ -92,7 +92,7 @@ Five boundaries, each analyzed below with a 1-paragraph prose intro followed by 
 | Tampering | Caller-supplied `dest_dir` for `save_attachments` points to a system-critical path | Caller (LLM-via-user) is trusted with this. We validate path existence and reject `..` segments in [`save_attachments`](../../src/apple_mail_mcp/mail_connector.py), but do not blocklist system paths | (informational — accepted trust assumption) |
 | Repudiation | File writes are logged | [`operation_logger`](../../src/apple_mail_mcp/security.py) covers create / save / template ops | — |
 | Information disclosure | Templates dir readable by other user-processes at the same UID | OOS | — |
-| Denial of service | Disk fill via massive attachments or template inflation | `sanitize_input` 10000-char cap on template content | ⚠️ **No byte cap on `save_attachments`** — confirmed during plan-writing (see Open gaps). File follow-up |
+| Denial of service | Disk fill via massive attachments or template inflation | `sanitize_input` 10000-char cap on template content; per-attachment (100 MB) + aggregate (500 MB) byte caps on `save_attachments` — pre-check + post-write net, configurable via `APPLE_MAIL_MCP_MAX_ATTACHMENT_BYTES` / `APPLE_MAIL_MCP_MAX_TOTAL_ATTACHMENT_BYTES` (#236) | ✅ #236 |
 | Elevation | n/a | — | — |
 
 ### 5. MCP / LLM-as-conduit
@@ -117,7 +117,6 @@ Findings flagged `⚠️` in the tables above, mapped to tracked issues:
 |---|---|---|
 | osascript / AppleScript (§1) | Non-wrapped AS paths bypass `with timeout of N` | [#233](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/233) |
 | IMAP (§2) | Audit every IMAP→AS path applies `escape_applescript_string` | [#214](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/214) (property tests) |
-| Filesystem (§4) | No byte cap on `save_attachments` | [#236](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/236) (filed from this work) |
 | MCP / LLM-as-conduit (§5) | No automated prompt-injection detection on `get_message` responses | [#225](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/225) (planning) |
 | MCP / LLM-as-conduit (§5) | `create_rule` does not gate dangerous actions (move / forward / delete / copy) | [#222](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/222) |
 

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -196,6 +196,103 @@ def _build_received_within_hours_short_circuit(
     return preamble, exit_clause
 
 
+# Byte caps for save_attachments — disk-fill DoS protection (#236). A hostile
+# email can carry a multi-GB attachment; without a cap, "save the attachment"
+# writes it in full. Defaults are overridable per-connector (constructor) and,
+# at the server layer, via env vars.
+DEFAULT_MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024        # 100 MB per attachment
+DEFAULT_MAX_TOTAL_ATTACHMENT_BYTES = 500 * 1024 * 1024  # 500 MB per call
+
+
+def _select_attachments_within_caps(
+    attachments: list[dict[str, Any]],
+    attachment_indices: list[int] | None,
+    *,
+    per_cap: int,
+    total_cap: int,
+) -> tuple[list[int], list[dict[str, Any]]]:
+    """Pre-check pass for save_attachments byte caps (#236).
+
+    Walks the selected attachments (in selection order, mirroring
+    ``_compute_attachment_save_targets``) and splits them into allowed
+    (0-based) indices and rejected records. An attachment is rejected when its
+    reported size exceeds ``per_cap`` (reason ``per_attachment_cap``) or would
+    push the running total over ``total_cap`` (``aggregate_cap``). A reported
+    size of 0/unknown is treated as under-cap and allowed (fail-open) — the
+    post-write net (:func:`_prune_oversized_written`) catches an attachment
+    Mail under-reported here.
+    """
+    if attachment_indices is not None:
+        selected = [
+            (i, attachments[i])
+            for i in attachment_indices
+            if 0 <= i < len(attachments)
+        ]
+    else:
+        selected = list(enumerate(attachments))
+
+    allowed: list[int] = []
+    rejected: list[dict[str, Any]] = []
+    total = 0
+    for i, att in selected:
+        size = int(att.get("size") or 0)
+        name = str(att.get("name") or "")
+        if size > per_cap:
+            rejected.append(
+                {"name": name, "size": size, "reason": "per_attachment_cap"}
+            )
+            continue
+        if total + size > total_cap:
+            rejected.append(
+                {"name": name, "size": size, "reason": "aggregate_cap"}
+            )
+            continue
+        total += size
+        allowed.append(i)
+    return allowed, rejected
+
+
+def _prune_oversized_written(
+    targets: list[tuple[int, Path]],
+    *,
+    per_cap: int,
+    total_cap: int,
+) -> tuple[int, list[dict[str, Any]]]:
+    """Post-write safety net for save_attachments byte caps (#236).
+
+    After the AppleScript save, stat each written file and delete (and report)
+    any that exceed ``per_cap`` on disk or push the actual running total over
+    ``total_cap`` — covering the case where Mail under-reported size before the
+    write. Only acts on paths that exist, so it is inert under mocked
+    AppleScript (no real files). Returns ``(removed_count, rejected_records)``.
+    """
+    removed = 0
+    rejected: list[dict[str, Any]] = []
+    running = 0
+    for _as_idx, path in targets:
+        if not path.is_file():
+            continue
+        actual = path.stat().st_size
+        if actual > per_cap:
+            path.unlink(missing_ok=True)
+            removed += 1
+            rejected.append(
+                {"name": path.name, "size": actual,
+                 "reason": "per_attachment_cap_postwrite"}
+            )
+            continue
+        if running + actual > total_cap:
+            path.unlink(missing_ok=True)
+            removed += 1
+            rejected.append(
+                {"name": path.name, "size": actual,
+                 "reason": "aggregate_cap_postwrite"}
+            )
+            continue
+        running += actual
+    return removed, rejected
+
+
 def _compute_attachment_save_targets(
     attachment_names: list[str],
     save_directory: Path,
@@ -587,6 +684,8 @@ class AppleMailConnector:
         timeout: int = 60,
         *,
         imap_pool: ImapConnectionPool | None = None,
+        max_attachment_bytes: int = DEFAULT_MAX_ATTACHMENT_BYTES,
+        max_total_attachment_bytes: int = DEFAULT_MAX_TOTAL_ATTACHMENT_BYTES,
     ) -> None:
         """
         Initialize the Mail connector.
@@ -599,9 +698,15 @@ class AppleMailConnector:
                 across calls, amortizing the ~400 ms TCP+TLS+LOGIN
                 overhead per call. Default None (per-call lifecycle —
                 the v0.5.0 behavior). See issue #75.
+            max_attachment_bytes: Per-attachment byte cap for
+                ``save_attachments`` (disk-fill DoS protection, #236).
+            max_total_attachment_bytes: Aggregate byte cap per
+                ``save_attachments`` call.
         """
         self.timeout = timeout
         self._imap_pool = imap_pool
+        self.max_attachment_bytes = max_attachment_bytes
+        self.max_total_attachment_bytes = max_total_attachment_bytes
         # Accounts for which we've already logged a WARNING about IMAP failure.
         # Subsequent failures for the same account are demoted to DEBUG per
         # invariant 5 in docs/research/imap-auth-options-decision.md.
@@ -2853,9 +2958,16 @@ class AppleMailConnector:
         message_id: str,
         save_directory: Path,
         attachment_indices: list[int] | None = None,
-    ) -> int:
+    ) -> dict[str, Any]:
         """
         Save attachments from a message to a directory.
+
+        Per-attachment and aggregate byte caps (``max_attachment_bytes`` /
+        ``max_total_attachment_bytes``) guard against disk-fill DoS from a
+        hostile oversized attachment (#236): oversized attachments are
+        pre-checked out before saving, and a post-write net deletes any file
+        that still lands over the cap (covering sizes Mail under-reports for
+        not-yet-downloaded attachments).
 
         Args:
             message_id: Message ID
@@ -2863,7 +2975,10 @@ class AppleMailConnector:
             attachment_indices: Indices of attachments to save (None = all)
 
         Returns:
-            Number of attachments saved
+            ``{"saved": int, "rejected": list[dict]}`` — count actually
+            written, and per-rejection records ``{name, size, reason}`` where
+            reason is ``per_attachment_cap`` / ``aggregate_cap`` (pre-check) or
+            ``*_postwrite`` (post-write net).
 
         Raises:
             FileNotFoundError: If save directory doesn't exist
@@ -2894,13 +3009,24 @@ class AppleMailConnector:
         # path. (Concatenating `name of att` into the path inside AppleScript
         # was a path-traversal → arbitrary-file-write vector.)
         attachments = self._get_attachments_applescript(message_id)
+
+        # Pre-check byte caps (#236): drop oversized attachments before saving.
+        allowed, rejected = _select_attachments_within_caps(
+            attachments,
+            attachment_indices,
+            per_cap=self.max_attachment_bytes,
+            total_cap=self.max_total_attachment_bytes,
+        )
+        if not allowed:
+            return {"saved": 0, "rejected": rejected}
+
         targets = _compute_attachment_save_targets(
             [str(a.get("name", "")) for a in attachments],
             save_directory,
-            attachment_indices,
+            allowed,
         )
         if not targets:
-            return 0
+            return {"saved": 0, "rejected": rejected}
 
         message_id_safe = escape_applescript_string(sanitize_input(message_id))
         idx_list = ", ".join(str(idx) for idx, _ in targets)
@@ -2940,7 +3066,17 @@ class AppleMailConnector:
         )
 
         result = self._run_applescript(script)
-        return int(result) if result.isdigit() else 0
+        saved = int(result) if result.isdigit() else 0
+
+        # Post-write net (#236): delete any file that landed over the cap
+        # (e.g. Mail under-reported size pre-download) and report it.
+        removed, post_rejected = _prune_oversized_written(
+            targets,
+            per_cap=self.max_attachment_bytes,
+            total_cap=self.max_total_attachment_bytes,
+        )
+        rejected.extend(post_rejected)
+        return {"saved": max(0, saved - removed), "rejected": rejected}
 
     def move_messages(
         self,

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -119,9 +119,35 @@ def _register_pool_atexit(pool: ImapConnectionPool | None) -> None:
         atexit.register(pool.close)
 
 
+def _attachment_cap_overrides() -> dict[str, int]:
+    """Read optional save_attachments byte-cap overrides from the environment
+    (#236), mirroring the APPLE_MAIL_MCP_IMAP_POOL opt-in pattern. Returns
+    kwargs for AppleMailConnector; invalid/unset values fall back to the
+    connector defaults (100 MB per attachment / 500 MB aggregate)."""
+    import os
+    overrides: dict[str, int] = {}
+    for env_name, kwarg in (
+        ("APPLE_MAIL_MCP_MAX_ATTACHMENT_BYTES", "max_attachment_bytes"),
+        ("APPLE_MAIL_MCP_MAX_TOTAL_ATTACHMENT_BYTES", "max_total_attachment_bytes"),
+    ):
+        raw = os.getenv(env_name)
+        if raw is None:
+            continue
+        try:
+            value = int(raw)
+        except ValueError:
+            logger.warning("Ignoring non-integer %s=%r", env_name, raw)
+            continue
+        if value <= 0:
+            logger.warning("Ignoring non-positive %s=%r", env_name, raw)
+            continue
+        overrides[kwarg] = value
+    return overrides
+
+
 _imap_pool = _build_imap_pool()
 _register_pool_atexit(_imap_pool)
-mail = AppleMailConnector(imap_pool=_imap_pool)
+mail = AppleMailConnector(imap_pool=_imap_pool, **_attachment_cap_overrides())
 
 
 async def _elicit_confirmation(
@@ -1384,14 +1410,19 @@ def save_attachments(
         attachment_indices: Specific attachment indices to save (0-based), None for all
 
     Returns:
-        Dictionary indicating success and number of attachments saved
+        Dict with ``success``, ``saved`` (count written), ``directory``, and
+        ``rejected`` (attachments skipped by the per-attachment / aggregate
+        byte caps, each ``{name, size, reason}``; #236).
 
     Example:
         >>> save_attachments("12345", "/Users/me/Downloads")
-        {"success": True, "saved": 2, "directory": "/Users/me/Downloads"}
+        {"success": True, "saved": 2, "directory": "/Users/me/Downloads",
+         "rejected": []}
 
         >>> save_attachments("12345", "/Users/me/Downloads", [0, 2])
-        {"success": True, "saved": 2, "directory": "/Users/me/Downloads"}
+        {"success": True, "saved": 1, "directory": "/Users/me/Downloads",
+         "rejected": [{"name": "huge.bin", "size": 2147483648,
+                       "reason": "per_attachment_cap"}]}
     """
     from pathlib import Path
 
@@ -1421,7 +1452,7 @@ def save_attachments(
             f"Saving attachments from message {message_id} to {save_directory}"
         )
 
-        count = mail.save_attachments(
+        result = mail.save_attachments(
             message_id=message_id,
             save_directory=save_path,
             attachment_indices=attachment_indices,
@@ -1439,8 +1470,10 @@ def save_attachments(
 
         return {
             "success": True,
-            "saved": count,
+            "saved": result["saved"],
             "directory": save_directory,
+            # Attachments skipped/removed by the byte caps (#236), if any.
+            "rejected": result["rejected"],
         }
 
     except (FileNotFoundError, ValueError) as e:

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -176,7 +176,7 @@ INVOCATION_CASES: list[tuple[str, dict[str, Any], str, Any]] = [
         "save_attachments",
         {"message_id": "msg-1", "save_directory": _TMP_DIR},
         "save_attachments",
-        0,
+        {"saved": 0, "rejected": []},
     ),
     (
         "create_mailbox",

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -1654,3 +1654,29 @@ class TestResolveImapConfigAppleScript:
         # Keys present (not dropped) and coerced to safe defaults.
         assert parsed.get("host") == ""
         assert parsed.get("port") == 0
+
+
+class TestSaveAttachmentsByteCapSizeSource:
+    """#236 — the save_attachments byte caps key off `file size of att`
+    (enumerated by _get_attachments_applescript). Validate against real
+    Mail.app that the size field is actually populated for real attachment
+    content, so the pre-check has something to enforce on. Skips if the test
+    account's INBOX has no attachment-bearing message."""
+
+    def test_attachment_size_is_populated(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        msgs = connector._search_messages_applescript(
+            account=test_account, mailbox="INBOX", has_attachment=True, limit=1
+        )
+        if not msgs:
+            pytest.skip("no attachment-bearing message in test INBOX")
+        atts = connector._get_attachments_applescript(str(msgs[0]["id"]))
+        if not atts:
+            pytest.skip("message reported no enumerable attachments")
+        for a in atts:
+            assert isinstance(a["size"], int)
+            assert a["size"] >= 0
+        # Meaningfully populated for real content (not all zero), so the
+        # per-attachment / aggregate caps have a real size to gate on.
+        assert any(a["size"] > 0 for a in atts)

--- a/tests/unit/test_attachments.py
+++ b/tests/unit/test_attachments.py
@@ -120,7 +120,8 @@ class TestSaveAttachments:
             attachment_indices=[0]
         )
 
-        assert result == 1
+        assert result["saved"] == 1
+        assert result["rejected"] == []
         call_args = mock_run.call_args_list[-1][0][0]
         assert str(tmp_path) in call_args
 
@@ -141,7 +142,90 @@ class TestSaveAttachments:
             save_directory=tmp_path
         )
 
-        assert result == 3
+        assert result["saved"] == 3
+        assert result["rejected"] == []
+
+    # --- Byte caps (#236) ---------------------------------------------------
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_per_attachment_cap_rejects_oversized(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """An attachment whose reported size exceeds the per-attachment cap is
+        rejected before any save runs (only the enumerate AppleScript fires)."""
+        connector = AppleMailConnector(timeout=30, max_attachment_bytes=10)
+        mock_run.side_effect = [
+            '[{"name":"huge.bin","mime_type":"application/octet-stream",'
+            '"size":100,"downloaded":true}]',
+        ]
+        result = connector.save_attachments("12345", tmp_path)
+        assert result["saved"] == 0
+        assert len(result["rejected"]) == 1
+        assert result["rejected"][0]["name"] == "huge.bin"
+        assert result["rejected"][0]["reason"] == "per_attachment_cap"
+        # No save script — enumerate only.
+        assert mock_run.call_count == 1
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_aggregate_cap_rejects_when_total_exceeded(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        connector = AppleMailConnector(
+            timeout=30, max_attachment_bytes=1000, max_total_attachment_bytes=150
+        )
+        mock_run.side_effect = [
+            '[{"name":"a.bin","mime_type":"application/octet-stream",'
+            '"size":100,"downloaded":true},'
+            '{"name":"b.bin","mime_type":"application/octet-stream",'
+            '"size":100,"downloaded":true}]',
+            "1",
+        ]
+        result = connector.save_attachments("12345", tmp_path)
+        assert result["saved"] == 1
+        assert [r["reason"] for r in result["rejected"]] == ["aggregate_cap"]
+        assert result["rejected"][0]["name"] == "b.bin"
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_fail_open_on_unknown_size(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """A reported size of 0 is treated as under-cap and saved (the
+        post-write net would still delete it if it turned out oversized)."""
+        connector = AppleMailConnector(timeout=30, max_attachment_bytes=10)
+        mock_run.side_effect = [
+            '[{"name":"unknown.bin","mime_type":"application/octet-stream",'
+            '"size":0,"downloaded":false}]',
+            "1",
+        ]
+        result = connector.save_attachments("12345", tmp_path)
+        assert result["saved"] == 1
+        assert result["rejected"] == []
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_postwrite_net_deletes_oversized_written_file(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """Even if the reported size passed the pre-check, a written file that
+        exceeds the cap on disk is deleted and reported (covers Mail
+        under-reporting size for a not-yet-downloaded attachment)."""
+        connector = AppleMailConnector(timeout=30, max_attachment_bytes=10)
+        # Reported size 5 passes the pre-check...
+        mock_run.side_effect = [
+            '[{"name":"big.bin","mime_type":"application/octet-stream",'
+            '"size":5,"downloaded":false}]',
+            "1",
+        ]
+        # ...but the actual written file is 100 bytes (> 10-byte cap).
+        written = tmp_path / "big.bin"
+        written.write_bytes(b"x" * 100)
+
+        result = connector.save_attachments("12345", tmp_path)
+
+        assert result["saved"] == 0
+        assert not written.exists()  # post-write net deleted it
+        assert [r["reason"] for r in result["rejected"]] == [
+            "per_attachment_cap_postwrite"
+        ]
 
     def test_save_to_invalid_directory(self, connector: AppleMailConnector) -> None:
         """Test error when save directory is invalid."""
@@ -275,7 +359,7 @@ class TestSaveAttachmentsPathTraversal:
         ]
         result = connector.save_attachments(message_id="123", save_directory=tmp_path)
 
-        assert result == 1
+        assert result["saved"] == 1
         save_script = mock_run.call_args_list[-1][0][0]
         # The vulnerable runtime path concatenation must be gone.
         assert "& attName" not in save_script

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1784,14 +1784,29 @@ class TestSaveAttachments:
     def test_success_returns_saved_count(
         self, mock_mail: MagicMock, mock_logger: MagicMock, tmp_path: Any
     ) -> None:
-        mock_mail.save_attachments.return_value = 2
+        mock_mail.save_attachments.return_value = {"saved": 2, "rejected": []}
 
         result = save_attachments("1", str(tmp_path))
 
         assert result["success"] is True
         assert result["saved"] == 2
         assert result["directory"] == str(tmp_path)
+        assert result["rejected"] == []
         mock_logger.log_operation.assert_called_once()
+
+    def test_surfaces_rejected_attachments(
+        self, mock_mail: MagicMock, mock_logger: MagicMock, tmp_path: Any
+    ) -> None:
+        """Byte-cap rejections (#236) are passed through to the tool payload."""
+        rejected = [{"name": "huge.bin", "size": 9_999_999_999,
+                     "reason": "per_attachment_cap"}]
+        mock_mail.save_attachments.return_value = {"saved": 1, "rejected": rejected}
+
+        result = save_attachments("1", str(tmp_path))
+
+        assert result["success"] is True
+        assert result["saved"] == 1
+        assert result["rejected"] == rejected
 
     def test_directory_not_found(
         self, mock_mail: MagicMock, mock_logger: MagicMock, tmp_path: Any


### PR DESCRIPTION
## Summary

`save_attachments` validated the destination directory and blocked path traversal but had **no size cap** — a hostile email with a multi-GB attachment was written to disk in full (disk-fill DoS by anyone who can email the user). Surfaced in the v0.9.0 threat-model writeup (#213). Adds per-attachment (**100 MB**) and aggregate-per-call (**500 MB**) byte caps.

## Two-layer enforcement
- **Pre-check** (`_select_attachments_within_caps`): drop attachments whose reported `file size` exceeds the per-attachment cap or push the running total over the aggregate cap, before any save. Size 0/unknown is **fail-open** (avoids false-rejecting legitimate not-yet-downloaded attachments).
- **Post-write net** (`_prune_oversized_written`): stat each written file and delete + report any that land over the cap on disk. This is the size-independent backstop — robust even if Mail under-reports `file size` for a not-yet-downloaded attachment. (AppleScript can't stream-cap, so the transient write is unavoidable; the net ensures no oversized file *persists*.)

## API / config
- Connector `save_attachments` now returns `{"saved": int, "rejected": [{name, size, reason}]}` instead of a bare `int`; the server tool surfaces `rejected` (reasons: `per_attachment_cap` / `aggregate_cap` / `*_postwrite`).
- Configurable: `AppleMailConnector(max_attachment_bytes=…, max_total_attachment_bytes=…)` and env vars `APPLE_MAIL_MCP_MAX_ATTACHMENT_BYTES` / `APPLE_MAIL_MCP_MAX_TOTAL_ATTACHMENT_BYTES` (mirrors the `APPLE_MAIL_MCP_IMAP_POOL` pattern).
- Two module-level helpers keep `save_attachments` under the now-blocking CC≤20 gate (#274).

## Scope
- **No AppleScript changed** — sizes come from the existing `_get_attachments_applescript` enumeration (`file size of att`).
- `THREAT_MODEL.md` §4 DoS row updated (cap now mitigates disk-fill); the Open-gaps #236 entry cleared.
- Malware scanning remains out of scope (SECURITY.md disclaims it).

## Tests
- Pre-check (per-attachment + aggregate reject), fail-open on unknown size, **post-write deletion of an oversized real file**, and the `int→dict` return migration across connector / server / e2e.
- Integration test validating `file size of att` is populated for real attachments — skips gracefully without attachment fixtures (it skipped on my test INBOX). The post-write net is the size-independent guarantee regardless.
- `make check-all` green (incl. blocking complexity/mypy).

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)