### PR TITLE
fix(#257): repair stale e2e elicitation harness + document manual e2e policy

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -49,8 +49,9 @@ Run ALL checks (stop on failure):
 2. `./scripts/check_client_server_parity.sh`
 3. `./scripts/check_complexity.sh`
 4. `make test`
-5. `./scripts/check_dependencies.sh`
-6. `./scripts/check_applescript_safety.sh`
+5. `make test-e2e` — **mandatory** (requires `MAIL_TEST_MODE=true` + a test Mail.app account). CI excludes e2e, so this is the only gate that catches a stale e2e failure. A pre-existing failure on `main` is a **release-blocker**, not a known issue to ship around (#257).
+6. `./scripts/check_dependencies.sh`
+7. `./scripts/check_applescript_safety.sh`
 
 ## Phase 10: Commit, Push, PR
 - Commit: `"release: vX.Y.Z"`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,8 @@ uv sync --dev
 2. Write tests first (TDD): RED -> GREEN -> REFACTOR
 3. Implement backend (`mail_connector.py`) and frontend (`server.py`) together
 4. Run checks: `make check-all`
-5. Open a PR against `main`
+5. **If your PR touches IMAP or AppleScript code paths** — `imap_connector.py`, `mail_connector.py` AppleScript bodies/wrappers, or tools gated by `_elicit_confirmation` — also run `make test-e2e` before pushing (requires `MAIL_TEST_MODE=true`; the happy-path dispatch tests are mocked and need no account, but the full suite needs a test Mail.app account). **CI does not run e2e** — they need Mail.app — so a stale e2e failure on `main` is only caught by someone running this locally.
+6. Open a PR against `main`
 
 ## Branch Convention
 

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -208,6 +208,23 @@ INVOCATION_CASES: list[tuple[str, dict[str, Any], str, Any]] = [
 class TestToolInvocation:
     """Invoke each tool via mcp.call_tool and verify structured response shape."""
 
+    @pytest.fixture(autouse=True)
+    def _accept_elicitation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The e2e harness invokes tools via ``mcp.call_tool`` with no live MCP
+        session, so the real ``_elicit_confirmation`` would fail closed on
+        gated tools (``delete_mailbox``, ``delete_messages``) — its
+        ``ctx.elicit()`` raises "session not available". Simulate user
+        acceptance so the happy-path test exercises tool *dispatch*, not the
+        confirmation flow (which is covered in tests/unit/test_server.py).
+        Class-scoped so it doesn't mask gate behavior elsewhere. (#257)
+        """
+        async def _accept(*_args: object, **_kwargs: object) -> None:
+            return None  # None == user accepted
+
+        monkeypatch.setattr(
+            "apple_mail_mcp.server._elicit_confirmation", _accept
+        )
+
     @pytest.mark.parametrize(
         "tool_name,call_args,connector_method,connector_return",
         INVOCATION_CASES,


### PR DESCRIPTION
## Summary

The e2e happy-path harness (`test_tool_invocation_happy_path`) invokes tools via `mcp.call_tool` with **no live MCP session**, so `_elicit_confirmation`'s `ctx.elicit()` raised ("session not available"), the gate failed closed, and elicitation-gated tools returned `success: False`. **Two** cases failed on clean `main`: `delete_mailbox` (reported by @allenpan05 during #254) and `delete_messages` (broke when #239 added its gate). It stayed invisible because **CI and `make check-all` exclude e2e** — they need Mail.app — so only a manual `make test-e2e` would catch it.

## Changes (no production code)
- **(a) Harness fix** — class-scoped autouse fixture on `TestToolInvocation` patching `_elicit_confirmation` → "accepted", so the happy-path test exercises tool *dispatch* (the confirmation flow is unit-tested in `test_server.py`). Scoped to the class so it can't mask gate behavior elsewhere.
- **(b) `CONTRIBUTING.md`** — document the manual e2e trigger: run `make test-e2e` when a PR touches IMAP/AppleScript/elicitation paths; note CI doesn't run e2e.
- **(c) release `SKILL.md` Phase 9** — `make test-e2e` is now a **mandatory** release gate; a pre-existing failure on `main` is a release-blocker.

## Verification
- `uv run pytest tests/e2e/test_mcp_tools.py -k happy_path` — was 2 failed / 12 passed, now **14 passed**.
- `make test-e2e` — **full e2e suite 19/19 green** (no other stale failures lurking).
- `make check-all` — green (no production code touched).

## Scope split
The bundled `ctx.elicit(summary, None)` `FastMCPDeprecationWarning` cleanup is **deferred to #282** — clearing it requires a non-None `response_type`, which changes confirmation UX across every gated tool and can't be validated without a real MCP client. It's a warning, not the cause of the failure.

Thanks to @allenpan05 for catching the stale failure.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)