### PR TITLE
docs(#220): refresh README + ARCHITECTURE + TOOLS (PR A of 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,17 @@ An MCP server that provides programmatic access to Apple Mail, enabling AI assis
 
 ## Tools (23)
 
-**Core:** list_mailboxes, search_messages, get_messages, update_message
-**Drafts lifecycle:** create_draft, update_draft, delete_draft
-**Mailbox CRUD:** create_mailbox, update_mailbox, delete_mailbox
-**Attachments & Management:** save_attachments, delete_messages
-**Discovery & Rules:** list_accounts, list_rules, get_thread, create_rule, update_rule, delete_rule
-**Templates:** list_templates, get_template, save_template, delete_template, render_template
+Grouped by lifecycle (9 read-only, 14 mutating):
 
-See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for full parameter and return-shape documentation.
+- **Discovery** — `list_accounts`, `list_mailboxes`, `list_rules`, `list_templates`: enumerate what's configured (no external cache — call per account).
+- **Read** — `search_messages`, `get_messages`, `get_thread`, `get_template`, `render_template`: read messages/threads and render templates.
+- **Message actions** — `update_message` (read/flag/move in one pass), `delete_messages` (→ Trash), `save_attachments` (to disk, byte-capped).
+- **Drafts** — `create_draft` (new / reply / forward, optionally `send_now`), `update_draft`, `delete_draft`.
+- **Mailbox CRUD** — `create_mailbox`, `update_mailbox` (rename or move), `delete_mailbox`.
+- **Rules** — `create_rule`, `update_rule`, `delete_rule`.
+- **Templates (write)** — `save_template`, `delete_template`.
+
+Destructive operations (`delete_*`, `create_rule` with move/forward/delete actions, `create_draft` with `send_now=true`) prompt for confirmation via MCP elicitation. See [docs/reference/TOOLS.md](docs/reference/TOOLS.md) for full parameters and return shapes.
 
 ## Prerequisites
 
@@ -37,18 +40,19 @@ uv sync --dev
 
 ## Configuration
 
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`). `uv sync` installs a console script at `.venv/bin/apple-mail-mcp`; point Claude Desktop at its **absolute path** — it's the most reliable form under Claude Desktop's restricted spawn environment (no reliance on `uv` being on `PATH`):
 
 ```json
 {
   "mcpServers": {
     "apple-mail": {
-      "command": "uv",
-      "args": ["--directory", "/path/to/apple-mail-mcp", "run", "python", "-m", "apple_mail_mcp.server"]
+      "command": "/path/to/apple-mail-mcp/.venv/bin/apple-mail-mcp"
     }
   }
 }
 ```
+
+(Equivalent alternative if you prefer driving it through uv: `"command": "uv", "args": ["--directory", "/path/to/apple-mail-mcp", "run", "apple-mail-mcp"]`.)
 
 ### Optional: split read / write servers
 
@@ -58,12 +62,11 @@ Claude Desktop prompts per-tool for permission. If you want to **batch-approve t
 {
   "mcpServers": {
     "apple-mail-read": {
-      "command": "uv",
-      "args": ["--directory", "/path/to/apple-mail-mcp", "run", "python", "-m", "apple_mail_mcp.server", "--read-only"]
+      "command": "/path/to/apple-mail-mcp/.venv/bin/apple-mail-mcp",
+      "args": ["--read-only"]
     },
     "apple-mail-write": {
-      "command": "uv",
-      "args": ["--directory", "/path/to/apple-mail-mcp", "run", "python", "-m", "apple_mail_mcp.server"]
+      "command": "/path/to/apple-mail-mcp/.venv/bin/apple-mail-mcp"
     }
   }
 }
@@ -147,14 +150,22 @@ make test-integration  # Integration tests (requires Mail.app)
 ## Architecture
 
 ```
-server.py (FastMCP tools — thin orchestration)
-  -> mail_connector.py (AppleScript bridge — domain logic)
-     -> subprocess.run(["osascript", ...])
-        -> Apple Mail.app
+server.py (FastMCP tools — thin orchestration, validation, elicitation gates)
+  -> mail_connector.py (dispatch + domain logic)
+     -> AppleScript path:  subprocess.run(["osascript", ...]) -> Apple Mail.app   (universal baseline)
+     -> IMAP fast path:    imap_connector.py -> the account's IMAP server          (when hinted + Keychain creds)
 ```
 
-- **server.py** — MCP tool registration, input validation, response formatting
-- **mail_connector.py** — All AppleScript generation and execution
+**Dispatch model.** AppleScript is the always-available baseline. When a read/mutation call supplies
+an `account` (and, where relevant, `mailbox`) hint **and** the account has Keychain IMAP credentials,
+the connector takes a server-side IMAP fast path; on any IMAP failure it falls back to AppleScript, so
+you never lose functionality — you only gain speed. See
+[docs/reference/ARCHITECTURE.md](docs/reference/ARCHITECTURE.md) for the full dispatch model, the
+dual-emit message-ID scheme, the drafts lifecycle, and the IMAP thread tiers.
+
+- **server.py** — MCP tool registration, input validation, confirmation (elicitation) gates, response formatting
+- **mail_connector.py** — AppleScript generation/execution + IMAP-fast-path dispatch
+- **imap_connector.py** — IMAP client + connection pool (search, fetch, bulk-mutation fast paths)
 - **security.py** — Input sanitization, audit logging, confirmation flows
 - **utils.py** — Pure functions: escaping, parsing, validation
 - **exceptions.py** — Typed exception hierarchy
@@ -162,11 +173,16 @@ server.py (FastMCP tools — thin orchestration)
 ## Security
 
 - Local execution only (no cloud processing)
-- Uses existing Mail.app authentication (no credential storage)
-- All inputs sanitized and AppleScript-escaped
-- Destructive operations require confirmation
-- Operation audit logging
-- See [SECURITY.md](SECURITY.md) for policy and [docs/SECURITY.md](docs/SECURITY.md) for detailed analysis
+- Uses existing Mail.app authentication; IMAP app-passwords (opt-in) live in the macOS Keychain, never in the repo or config
+- All inputs sanitized and AppleScript-escaped (defense against AppleScript injection)
+- Destructive operations require user confirmation via MCP elicitation; rate limits + audit logging on top
+- `save_attachments` is byte-capped (per-attachment + aggregate) against disk-fill DoS
+
+Docs:
+- [SECURITY.md](SECURITY.md) — vulnerability-reporting policy
+- [docs/SECURITY.md](docs/SECURITY.md) — user-facing security posture & privacy
+- [docs/guides/THREAT_MODEL.md](docs/guides/THREAT_MODEL.md) — STRIDE trust-boundary analysis
+- [docs/guides/SECURITY_CHECKLIST.md](docs/guides/SECURITY_CHECKLIST.md) — per-feature contributor checklist
 
 ## Contributing
 

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -1,47 +1,101 @@
 # Architecture
 
-## Component Diagram
+## Component diagram
 
 ```
-Claude Desktop / MCP Client
-        |
-        | (MCP JSON-RPC over stdio)
+Claude Desktop / MCP client
+        |  (MCP JSON-RPC over stdio)
         v
 server.py (FastMCP)
-  |-- 14 @mcp.tool() functions
-  |-- Input validation
-  |-- Response formatting
-  |-- Error wrapping (exceptions -> dicts)
+  |-- 23 tools (@_tool / @mcp.tool)        9 read-only, 14 mutating
+  |-- input validation + sanitization
+  |-- elicitation (confirmation) gates on destructive ops
+  |-- structured responses ({"success": bool, ...})
         |
         v
-mail_connector.py (AppleMailConnector)
-  |-- AppleScript generation
-  |-- subprocess.run(["osascript", "-"])
-  |-- Output parsing (JSON via ASObjC NSJSONSerialization)
-  |-- Error routing (stderr -> typed exceptions)
-        |
-        v
-Apple Mail.app (via macOS Automation)
+mail_connector.py (AppleMailConnector) — dispatch + domain logic
+        |                                   \
+        | AppleScript path (baseline)        | IMAP fast path (when hinted + creds)
+        v                                     v
+  subprocess.run(["osascript", "-"])    imap_connector.py (ImapConnector / pool)
+        |                                     |
+        v                                     v
+  Apple Mail.app (macOS Automation)     the account's IMAP server
 ```
 
-## Module Responsibilities
+## Dispatch model (the central v0.8.0 abstraction)
 
-| Module | Role | Dependencies |
-|--------|------|-------------|
-| `server.py` | MCP tool registration, orchestration | connector, security, exceptions |
-| `mail_connector.py` | All AppleScript I/O | utils, exceptions |
-| `security.py` | Validation, audit logging | utils, exceptions |
-| `utils.py` | Pure functions (escaping, parsing) | stdlib only |
-| `exceptions.py` | Exception class definitions | none |
+**AppleScript is the universal baseline** — every operation works through `osascript` against Mail.app,
+with no extra setup. On top of that, several read and bulk-mutation operations take an **IMAP fast
+path** when two conditions hold:
 
-## Design Decisions
+1. the caller hints the location — an `account` (and, where relevant, a `source_mailbox` / `mailbox`), and
+2. the account has Keychain IMAP credentials (opt-in via `apple-mail-mcp setup-imap`).
 
-**Two-file separation:** Server is thin (MCP plumbing), connector is thick (domain logic). Business logic never goes in server.py.
+When both hold, the connector issues server-side IMAP (e.g. `SEARCH`, `UID MOVE`, `STORE`) instead of
+driving Mail.app's per-message AppleScript loop. **On any IMAP failure** — no credentials, bad
+password, offline, capability gap — it falls back to AppleScript, so functionality is never lost; you
+only gain speed when IMAP is configured and reachable. Failures are absorbed by the
+`_IMAP_FALLBACK_EXCS` set and a **per-account circuit breaker** (`_imap_breaker_*`, ~30 s cooldown,
+#118) so a flaky account doesn't pay the connect/login cost on every call.
 
-**Single execution point:** All AppleScript runs through `_run_applescript()`. This is the mock boundary for unit tests and the single place where timeout/error handling lives.
+IMAP connections are created per call by default; an opt-in **connection pool** (`APPLE_MAIL_MCP_IMAP_POOL=1`,
+#75) amortizes the ~400 ms TCP+TLS+LOGIN across calls.
 
-**Structured responses:** Every tool returns `{"success": bool, ...}`. Errors include `error` (message) and `error_type` (category). No exceptions reach the LLM.
+Fast paths shipped in v0.8.0: search (#32-era), `get_messages` / `get_attachments` / `get_thread`
+reads, and the bulk mutations — move (#149), delete (#150), read-status (#151), flag (#152) — each
+with an AppleScript fallback. Compose/send (`create_draft` and the `send_now=true` send) is
+**always** AppleScript — it needs Mail.app's compose machinery.
 
-**Pipe-delimited output:** AppleScript returns `field1|field2|field3`. This is fragile but functional. Planned migration to JSON output.
+## Dual-emit message-ID model (#148)
 
-**Gmail compatibility:** `gmail_mode` parameter on move/archive operations handles Gmail's label-based system (copy+delete instead of move).
+A message row's `id` is **path-native**: Mail.app's internal numeric id on the AppleScript path, the
+RFC 5322 `Message-ID` (bracketless) on the IMAP path. To let callers cross paths without caring which
+produced a row, read tools also emit `rfc_message_id` (always the RFC id, or null). The mutation
+fast-paths and `create_draft(reply_to=/forward_of=)` accept **either** form — pass back the `id` a
+read tool gave you verbatim.
+
+## Drafts lifecycle (#134)
+
+Mail.app's real primitive is the draft — every outgoing message is a draft until sent. Three tools
+model the lifecycle:
+
+- `create_draft` — new / reply (`reply_to`) / forward (`forward_of`); `send_now=true` sends instead of saving.
+- `update_draft` — **delete-and-recreate** (Mail.app forbids mutating a saved draft in place); reply/forward threading headers are preserved by re-seeding from the original.
+- `delete_draft` — move a draft to Trash.
+
+## IMAP thread tiers (`get_thread`)
+
+`find_thread_members` picks the cheapest correct strategy per provider (see
+[../research/imap-thread-strategies.md](../research/imap-thread-strategies.md)):
+
+| Tier | Strategy | When | Cost |
+|------|----------|------|------|
+| 1 | Gmail `X-GM-THRID` via `[Gmail]/All Mail` | Gmail, All Mail exposed over IMAP | ~4 round-trips, mailbox-count-independent |
+| 1.5 | per-mailbox `X-GM-THRID` iteration | Gmail, All Mail hidden | ~6× faster than BFS, but ∝ label count |
+| 2 | RFC 5256 `THREAD REFERENCES` per mailbox | server advertises THREAD (e.g. Fastmail) | per-mailbox THREAD × M |
+| 3 | per-mailbox header-search BFS | universal (e.g. iCloud — no THREAD/X-GM) | M × N × 3 `SEARCH HEADER` round-trips |
+
+If IMAP isn't configured/reachable, `get_thread` reconstructs the thread via AppleScript (subject
+prefilter + `In-Reply-To`/`References` header walk).
+
+## Module responsibilities
+
+| Module | Role |
+|--------|------|
+| `server.py` | MCP tool registration, validation, elicitation gates, response formatting |
+| `mail_connector.py` | AppleScript generation/execution + IMAP-fast-path dispatch |
+| `imap_connector.py` | IMAP client, connection pool, search/fetch/bulk-mutation fast paths |
+| `security.py` | Input sanitization, rate limiting, audit logging, confirmation flows |
+| `utils.py` | Pure functions: escaping, parsing, validation |
+| `drafts.py` / `templates.py` | Draft-seed state and email-template storage under `~/.apple_mail_mcp/` |
+| `exceptions.py` | Typed exception hierarchy |
+
+## Design decisions
+
+- **Thin server, thick connector.** Business logic never lives in `server.py`; it stays in the connector.
+- **Single AppleScript execution point.** All AppleScript runs through `_run_applescript()` — the unit-test mock boundary and the one place timeout/error-routing lives (stderr → typed exceptions).
+- **JSON output via ASObjC.** AppleScript emits JSON through `NSJSONSerialization` (`_wrap_as_json_script` / `parse_applescript_json`), not fragile pipe-delimited text. See [APPLESCRIPT_GOTCHAS.md](APPLESCRIPT_GOTCHAS.md).
+- **Structured responses.** Every tool returns `{"success": bool, ...}`; errors carry `error` + `error_type`. No exception reaches the LLM.
+- **Confirmation by elicitation.** Destructive tools (`delete_*`, `create_rule` with move/forward/delete actions, `create_draft` with `send_now`) gate behind MCP elicitation, fail-closed.
+- **Gmail label mode.** `gmail_mode` uses copy+delete instead of move for Gmail's label-based system.

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -4,8 +4,7 @@ Complete reference for all MCP tools provided by the Apple Mail MCP server.
 
 ## Overview
 
-**Current Version:** v0.6.0
-**Total Tools:** 27
+**Total Tools:** 23 (9 read-only, 14 mutating — see Classification below). See the [CHANGELOG](../../CHANGELOG.md) for the version history.
 
 ## Tool annotations (`readOnlyHint` / `destructiveHint` / `idempotentHint`)
 
@@ -419,27 +418,6 @@ update_message(
 
 ---
 
-## Coming Soon (Phase 2 - v0.2.0)
-
-
-### create_mailbox
-
-Create a new mailbox/folder.
-
-**Parameters:**
-- `account`: string - Account name
-- `name`: string - Mailbox name
-- `parent_mailbox`: string (optional) - Parent for nested mailboxes
-
-### delete_messages
-
-Delete messages (move to trash).
-
-**Parameters:**
-- `message_ids`: array[string] - Messages to delete
-- `confirm`: boolean - Require confirmation
-
----
 
 ## Error Handling
 
@@ -571,14 +549,17 @@ Save attachments from a message to a directory.
 ```json
 {
   "success": true,
-  "count": 2,
+  "saved": 2,
   "directory": "/Users/me/Downloads",
-  "saved_files": [
-    "report.pdf",
-    "data.xlsx"
-  ]
+  "rejected": []
 }
 ```
+
+`saved` is the number of attachments written. `rejected` lists any attachments skipped by the byte
+caps (per-attachment default 100 MB, aggregate 500 MB per call — disk-fill DoS protection, #236),
+each as `{"name", "size", "reason"}` where reason is `per_attachment_cap` / `aggregate_cap` (pre-check)
+or `*_postwrite` (an oversized file deleted after writing). Override the caps with
+`APPLE_MAIL_MCP_MAX_ATTACHMENT_BYTES` / `APPLE_MAIL_MCP_MAX_TOTAL_ATTACHMENT_BYTES`.
 
 **Examples:**
 
@@ -1026,10 +1007,9 @@ longer treats trashed drafts as editable.
 # 1. Find all unread messages
 unread = search_messages(account="Gmail", read_status=False)
 
-# 2. For each message, get full details
-for msg in unread["messages"]:
-    full_msg = get_message(message_id=msg["id"])
-    # Process message...
+# 2. Fetch full details (get_messages takes a list of ids)
+full = get_messages(message_ids=[msg["id"] for msg in unread["messages"]])
+# Process full["messages"]...
 
 # 3. Mark processed messages as read
 processed_ids = [msg["id"] for msg in unread["messages"]]
@@ -1048,7 +1028,7 @@ results = search_messages(
 )
 
 # 2. Get full message
-original = get_message(message_id=results["messages"][0]["id"])
+original = get_messages(message_ids=[results["messages"][0]["id"]])
 
 # 3. Send reply (use create_draft with send_now=True to skip the
 #    save-then-send dance)


### PR DESCRIPTION
## Summary

PR **A of 2** for the #220 docs sweep — the user-facing reference layer. (PR B: DEVELOPMENT / APPLESCRIPT_GOTCHAS / TESTING / SECURITY reconcile.)

### README.md
- **Config block → console-script entry point**: `.venv/bin/apple-mail-mcp` (absolute path) — the reliable form under Claude Desktop's restricted spawn environment — with a `uv run apple-mail-mcp` alternative. Same fix for the split read/write config.
- **Tool surface** regrouped by lifecycle (discovery / read / message actions / drafts / mailbox CRUD / rules / templates) with the elicitation-gate note, instead of the partial 9-name list.
- **Architecture** section now describes the AppleScript-default + IMAP-fast-path dispatch and points to ARCHITECTURE.md; adds `imap_connector.py`.
- **Security** section links THREAT_MODEL.md + SECURITY_CHECKLIST.md and notes the attachment byte caps.

### docs/reference/ARCHITECTURE.md (rewrite)
Was 47 lines missing the entire IMAP layer. Now covers: the dispatch model (+ `_IMAP_FALLBACK_EXCS`, circuit breaker, opt-in pool), the **dual-emit message-ID** scheme (#148), the **drafts lifecycle** (#134), and the **IMAP thread tiers** (1/1.5/2/3). Fixes the "14 tools" and "pipe-delimited (planned JSON)" staleness.

### docs/reference/TOOLS.md (targeted fixes)
- Header `v0.6.0 / 27 tools` → version-agnostic / 23.
- Two examples calling the removed `get_message` → `get_messages`.
- Removed the stale "Coming Soon (Phase 2 - v0.2.0)" stub block (those tools shipped; the stub even listed a non-existent `confirm` param).
- Fixed the `save_attachments` return shape (`saved` + `rejected`, with the #236 byte caps).

## Verification
- All cross-references in the changed files resolve (scripted check).
- No stale tool names except the intentional "replaces the v0.6 send group" migration note.

Refs #220 (closed by PR B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)