### PR TITLE
docs(#220): refresh contributor + security guides (PR B of 2)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -32,11 +32,21 @@ The Apple Mail MCP server provides programmatic access to your email through Cla
 - Potential for unintended actions through miscommunication
 - Prompt injection risks from malicious email content
 
+**Security docs:** this file is the user-facing posture & privacy guide;
+[`guides/THREAT_MODEL.md`](guides/THREAT_MODEL.md) is the canonical STRIDE trust-boundary analysis;
+[`guides/SECURITY_CHECKLIST.md`](guides/SECURITY_CHECKLIST.md) is the per-feature contributor
+checklist; the repo-root [`SECURITY.md`](../SECURITY.md) is the vulnerability-reporting policy.
+
+**Destructive operations require confirmation.** These tools prompt the user via MCP elicitation
+before acting (fail-closed — no confirmation context means the operation is blocked):
+`delete_messages`, `delete_mailbox`, `delete_draft`, `delete_rule`, `delete_template`, `create_rule`
+when it has a move/forward/delete action, and `create_draft` with `send_now=true`.
+
 ---
 
 ## Attack Surface Analysis
 
-> **For the canonical trust-boundary breakdown and STRIDE analysis, see [`docs/guides/THREAT_MODEL.md`](guides/THREAT_MODEL.md).** The narrative below is preserved for continuity and will be reconciled with the threat model in #220.
+> **The canonical analysis lives in [`docs/guides/THREAT_MODEL.md`](guides/THREAT_MODEL.md)** — a STRIDE pass per trust boundary with the attacker model and tracked open gaps. The narrative below is the *user-facing* counterpart: the same risks in plain language, with how-to-use-safely guidance. When the two differ, the threat model is authoritative.
 
 ### 1. Prompt Injection
 

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -1,214 +1,82 @@
-# Setup Guide
+# Development Workflow
 
-This guide will help you set up the Apple Mail MCP server for use with Claude Desktop.
+How to develop on the Apple Mail MCP server. For *installing/configuring* the server as a user, see
+the [README](../../README.md). For coding standards and the PR process, see
+[CONTRIBUTING.md](../../CONTRIBUTING.md).
 
-## Prerequisites
+## Environment
 
-- macOS 10.15 (Catalina) or later
-- Python 3.10 or later
-- Apple Mail configured with at least one email account
-- Claude Desktop installed
-
-## Installation
-
-### Option 1: Install from PyPI (Coming Soon)
+The project uses [`uv`](https://docs.astral.sh/uv/). One command sets up a virtualenv with all dev
+dependencies:
 
 ```bash
-pip install apple-mail-mcp
+uv sync --dev
 ```
 
-### Option 2: Install from Source
+Run anything in that environment with `uv run …` (e.g. `uv run pytest`, `uv run python -m
+apple_mail_mcp.server`). `uv sync` also installs the `apple-mail-mcp` console script into
+`.venv/bin/`.
+
+## The canonical check: `make check-all`
+
+`make check-all` is the single pre-push gate. It runs, stopping on the first failure:
+
+| Step | Command | Notes |
+|------|---------|-------|
+| Lint | `uv run ruff check src/ tests/` | blocking |
+| Type check | `uv run mypy src/` | blocking (strict) |
+| Unit tests | `uv run pytest -m "not integration and not e2e and not benchmark"` | blocking; coverage ≥ 90% |
+| Complexity | `./scripts/check_complexity.sh` | blocking — see below |
+| Version sync | `./scripts/check_version_sync.sh` | versions consistent across files |
+| Client/server parity | `./scripts/check_client_server_parity.sh` | every public connector method is exposed |
+
+CI runs the same lint / type / unit / complexity / version / parity gates (`.github/workflows/test.yml`).
+**Integration, e2e, and benchmark tests are *not* in CI** (they need real Mail.app) — run those
+locally; see [TESTING.md](TESTING.md).
+
+## Core conventions
+
+- **TDD always** — RED → GREEN → REFACTOR. Write the failing test first.
+- **Backend + frontend together** — a feature touches *both* `mail_connector.py` (the connector
+  method) and `server.py` (the MCP tool). The parity script (`check_client_server_parity.sh`) enforces
+  that every public connector method is exposed as a tool.
+- **Structured responses** — every tool returns `{"success": bool, …}`; errors carry `error` +
+  `error_type`. No exception reaches the LLM.
+- **Sanitize twice** — all user input goes through `sanitize_input()` then
+  `escape_applescript_string()` before it touches AppleScript. See
+  [SECURITY_CHECKLIST.md](SECURITY_CHECKLIST.md).
+- **Touched AppleScript → integration test** — unit tests mock `_run_applescript()` and cannot catch
+  AppleScript bugs (see [TESTING.md](TESTING.md)).
+
+## Cyclomatic-complexity gate
+
+`./scripts/check_complexity.sh` fails any function over **CC 20** (via `radon`, run through `uv`).
+Genuinely-complex functions can be admitted via the per-function `ALLOWLIST` in that script — a
+`(filename, qualified_name) → max_CC` map that ratchets (lowering an entry after a refactor is free;
+raising one needs justification). See [COMPLEXITY.md](COMPLEXITY.md).
+
+## Branch & changelog conventions
+
+- Branch names: `{type}/issue-{num}-{description}` — e.g. `fix/issue-99-timeout`,
+  `feature/issue-42-thread-support`.
+- **`CHANGELOG.md` is only updated on release branches**, never on feature branches (the release
+  skill owns it).
+
+## Common make targets
 
 ```bash
-# Clone the repository
-git clone https://github.com/s-morgan-jeffries/apple-mail-mcp.git
-cd apple-mail-mcp
-
-# Create virtual environment
-python3 -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-
-# Install package
-pip install -e .
+make test              # unit tests (~1s, mocked AppleScript)
+make test-integration  # real Mail.app (needs a test account; MAIL_TEST_MODE=true)
+make test-e2e          # MCP tool dispatch tests
+make lint / format / typecheck
+make coverage
+make benchmark         # perf benchmarks (opt-in; needs real Mail) — see BENCHMARKING.md
+make eval-descriptions # regenerate the blind-eval tool descriptions from the live server
 ```
 
-## Configuration
+## See also
 
-### Claude Desktop Setup
-
-1. Locate your Claude Desktop configuration file:
-   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-2. Add the Apple Mail MCP server configuration:
-
-```json
-{
-  "mcpServers": {
-    "apple-mail": {
-      "command": "python",
-      "args": ["-m", "apple_mail_mcp.server"]
-    }
-  }
-}
-```
-
-If you installed from source, use the full path to the venv:
-
-```json
-{
-  "mcpServers": {
-    "apple-mail": {
-      "command": "/path/to/apple-mail-mcp/venv/bin/python",
-      "args": ["-m", "apple_mail_mcp.server"]
-    }
-  }
-}
-```
-
-3. Restart Claude Desktop
-
-## Permissions
-
-When you first use the MCP server, macOS will prompt you for permissions:
-
-### Automation Permission
-
-1. A dialog will appear: **"python" would like to control "Mail"**
-2. Click **OK** to grant permission
-
-If you accidentally denied permission:
-
-1. Open **System Settings** (or System Preferences)
-2. Go to **Privacy & Security** → **Automation**
-3. Find **python** or **Terminal** in the list
-4. Check the box next to **Mail**
-
-### Full Disk Access (Optional)
-
-Only needed for Phase 4 analytics features using SQLite database access.
-
-1. Open **System Settings** → **Privacy & Security** → **Full Disk Access**
-2. Click the **+** button
-3. Navigate to your Python executable
-4. Enable Full Disk Access
-
-## Verification
-
-### Test the Installation
-
-1. Open Claude Desktop
-2. Start a new conversation
-3. Try a simple command:
-
-```
-List my mailboxes
-```
-
-You should see a list of your Mail.app mailboxes.
-
-### Test Basic Operations
-
-Try these commands to verify everything works:
-
-```
-# Search for unread emails
-Show me my unread emails
-
-# Get mailbox information
-List all my mail folders
-
-# Search with filters
-Find emails from john@example.com in the last week
-```
-
-## Troubleshooting
-
-### "Command not found" Error
-
-**Problem:** Claude Desktop can't find the Python command.
-
-**Solutions:**
-1. Use the full path to Python in the config:
-   ```json
-   "command": "/usr/local/bin/python3"
-   ```
-2. Or use the venv path:
-   ```json
-   "command": "/path/to/venv/bin/python"
-   ```
-
-### "Permission Denied" Error
-
-**Problem:** Automation permission not granted.
-
-**Solution:**
-1. Check System Settings → Privacy & Security → Automation
-2. Grant permission for Python/Terminal to control Mail
-
-### "Account Not Found" Error
-
-**Problem:** The MCP server can't access your mail account.
-
-**Solutions:**
-1. Verify Mail.app is open and configured
-2. Check the account name (use exact name from Mail.app preferences)
-3. Try using a different account name
-
-### No Response from MCP Server
-
-**Problem:** The server isn't starting or responding.
-
-**Solutions:**
-1. Check Claude Desktop logs:
-   - macOS: `~/Library/Logs/Claude/mcp.log`
-2. Verify Python installation:
-   ```bash
-   python3 --version
-   ```
-3. Test the server directly:
-   ```bash
-   python -m apple_mail_mcp.server
-   ```
-
-### "Module not found" Error
-
-**Problem:** Dependencies not installed.
-
-**Solution:**
-```bash
-pip install fastmcp
-```
-
-## Configuration Options
-
-### Custom Timeout
-
-Set a custom timeout for AppleScript operations:
-
-```python
-from apple_mail_mcp.mail_connector import AppleMailConnector
-
-connector = AppleMailConnector(timeout=120)  # 2 minutes
-```
-
-### Logging
-
-Enable debug logging:
-
-```bash
-export LOGLEVEL=DEBUG
-python -m apple_mail_mcp.server
-```
-
-## Next Steps
-
-- Read the [Tools Documentation](TOOLS.md) to learn about available operations
-- Review [Security Considerations](SECURITY.md)
-- Check out [Examples](EXAMPLES.md) for common use cases
-
-## Getting Help
-
-- **Issues**: [GitHub Issues](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/s-morgan-jeffries/apple-mail-mcp/discussions)
-- **Documentation**: [Full Documentation](../README.md)
+- [ARCHITECTURE.md](../reference/ARCHITECTURE.md) — dispatch model, dual-emit IDs, drafts lifecycle, thread tiers
+- [APPLESCRIPT_GOTCHAS.md](../reference/APPLESCRIPT_GOTCHAS.md) — JSON-via-ASObjC, escaping, known limits
+- [TESTING.md](TESTING.md) — test categories, the manual-e2e policy, benchmarks, blind evals
+- [TOOLS.md](../reference/TOOLS.md) — full tool reference

--- a/docs/guides/SECURITY_CHECKLIST.md
+++ b/docs/guides/SECURITY_CHECKLIST.md
@@ -2,6 +2,8 @@
 
 Every new feature should be reviewed against the five concerns below before opening a PR. Each section names the canonical implementation in the codebase — reuse it rather than rolling your own. Linked file:line numbers are stable references; if a function moves, update this doc.
 
+For *why* these concerns matter — the trust boundaries and the STRIDE analysis they defend — see [`THREAT_MODEL.md`](THREAT_MODEL.md). This checklist is the per-feature "did I cover it?"; the threat model is the architectural rationale.
+
 ## Input sanitization
 
 Any string that originates from an MCP tool argument, an environment variable, or any other external source must pass through [`sanitize_input`](../../src/apple_mail_mcp/utils.py#L156) before further processing. It strips null bytes, truncates oversized strings (currently 10000 chars), and coerces non-strings to strings.

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -4,17 +4,29 @@
 
 | Level | Command | Purpose |
 |-------|---------|---------|
-| Unit | `make test` | Python logic with mocked AppleScript (~1s) |
-| Integration | `make test-integration` | Real Mail.app operations (~30s) |
-| E2E | `make test-e2e` | FastMCP dispatch layer in-process |
-| Benchmarks | `pytest tests/benchmarks/ -v` | Performance regression detection |
+| Unit | `make test` | Python logic with mocked AppleScript (~1s) — **in CI** |
+| Integration | `make test-integration` | Real Mail.app operations — local only |
+| E2E | `make test-e2e` | FastMCP dispatch layer — local only |
+| Benchmarks | `make benchmark` | Performance regression detection (opt-in) — see [BENCHMARKING.md](BENCHMARKING.md) |
+| Blind agent eval | (see below) | Whether models can use the tools from descriptions alone — see [`evals/agent_tool_usability/`](../../evals/agent_tool_usability/) |
+
+**CI runs unit tests only.** Integration / e2e / benchmark tests need real Mail.app (and, for some,
+IMAP credentials), so CI can't run them — they're manual. See **Manual e2e policy** below.
 
 ### E2E Scope
 
 `make test-e2e` covers two layers:
 
-1. **In-process FastMCP dispatch** ([tests/e2e/test_mcp_tools.py](../../tests/e2e/test_mcp_tools.py)) — tool registration, schemas, and happy-path invocation for all 17 tools, with the connector mocked.
-2. **Real stdio transport** ([tests/e2e/test_stdio_transport.py](../../tests/e2e/test_stdio_transport.py)) — spawns the server as a subprocess, completes the MCP handshake over stdio, and asserts `list_tools` returns the expected 17 tools. Catches startup errors, banner/stdout contamination, and JSON-RPC framing bugs that the in-process layer cannot surface.
+1. **In-process FastMCP dispatch** ([tests/e2e/test_mcp_tools.py](../../tests/e2e/test_mcp_tools.py)) — tool registration, schemas, and happy-path invocation across the tool set, with the connector mocked. (Elicitation-gated tools are run with a patched accept so the happy-path exercises dispatch, not the confirmation flow.)
+2. **Real stdio transport** ([tests/e2e/test_stdio_transport.py](../../tests/e2e/test_stdio_transport.py)) — spawns the server as a subprocess, completes the MCP handshake over stdio, and asserts `list_tools` returns the full tool set. Catches startup errors, banner/stdout contamination, and JSON-RPC framing bugs that the in-process layer cannot surface.
+
+### Manual e2e policy
+
+CI does not run e2e (it needs Mail.app). **If your PR touches IMAP or AppleScript code paths** —
+`imap_connector.py`, `mail_connector.py` AppleScript bodies/wrappers, or any tool gated by
+`_elicit_confirmation` — run `make test-e2e` (and, where relevant, `make test-integration`) **before
+pushing**. A stale e2e failure on `main` is only caught by someone running it locally. `make
+test-e2e` is also a mandatory pre-release gate.
 
 ## Running Tests
 
@@ -31,6 +43,13 @@ MAIL_TEST_ACCOUNT="Gmail" make test-integration
 # Specific test file
 uv run pytest tests/unit/test_utils.py -v
 ```
+
+**Safety gate.** Integration/e2e runs that go through `server.py` tools set `MAIL_TEST_MODE=true`
+(the `make` targets do this) and `MAIL_TEST_ACCOUNT=<account>`. The gate (`check_test_mode_safety` in
+`security.py`) blocks destructive operations on any account other than the designated test account
+and blocks sends to non-reserved recipient domains (must be `@example.com`, `.test`, `.invalid`,
+`.localhost`, …). Point `MAIL_TEST_ACCOUNT` at an account you don't mind being mutated — integration
+benchmarks move real messages into an isolated bench mailbox and drain them back.
 
 ## Writing Tests
 

--- a/docs/reference/APPLESCRIPT_GOTCHAS.md
+++ b/docs/reference/APPLESCRIPT_GOTCHAS.md
@@ -1,54 +1,95 @@
 # Apple Mail AppleScript Gotchas
 
-Known issues, limitations, and workarounds for Apple Mail automation via AppleScript.
+Known issues, limitations, and workarounds for Apple Mail automation via AppleScript. The
+`applescript-mail` skill (`.claude/skills/applescript-mail/`) is the deeper reference for
+contributors writing connector AppleScript.
 
-## Pipe-Delimited Output Parsing
+## JSON output via ASObjC (not pipe-delimited)
 
-AppleScript results are returned as `field1|field2|field3` with newline-separated records. This breaks if any field contains a `|` character (common in email subjects).
+Scripts emit JSON via ASObjC + `NSJSONSerialization`, not fragile `field1|field2` text. Wrap a
+tell-block body with `_wrap_as_json_script(body, timeout=…)` and parse the result with
+`parse_applescript_json()` (both in `mail_connector.py` / `utils.py`). The body must assign its
+result to a variable named `resultData` (a record/list/scalar) inside the `tell` block.
 
-**Current workaround:** Check `len(parts) >= expected_count` before accessing fields.
-
-**Planned fix:** Migrate to JSON output with inline helpers.
-
-## Gmail Label-Based System
-
-Gmail doesn't support standard IMAP move. Use `gmail_mode=True` for copy+delete:
-
-```python
-connector.move_messages(ids, "Archive", gmail_mode=True)
+```applescript
+-- body passed to _wrap_as_json_script:
+tell application "Mail"
+    set resultData to {|id|:(id of msg as text), |subject|:(subject of msg)}
+end tell
+-- the wrapper appends the NSJSONSerialization epilogue and returns a JSON string
 ```
 
-## Message ID Lookup is O(accounts x mailboxes)
+### Quote the `|name|:` record key — always
 
-Finding a message by ID searches all accounts and mailboxes. Accept optional `account` and `mailbox` parameters to narrow the search.
+Use `|name|:(name of acc)`, **never** bare `name:`. The bare form collides with NSObject's `name`
+selector and is **silently dropped** during the NSDictionary→JSON conversion, leaving records missing
+their name field. This applies to any key that shadows a Cocoa selector; quoting with `|…|` is the
+safe default for all record keys.
 
-## String Escaping is Critical
+### Coerce `missing value` before serializing
 
-Always use `escape_applescript_string()` for user text. Unescaped quotes/backslashes cause silent failures with generic "Can't make" errors.
+`NSJSONSerialization` rejects AppleScript's `missing value`. Coerce optional properties to safe
+defaults *before* building the record, or the whole script errors:
 
-## Known Mail.app Limitations
+```applescript
+set accEmails to email addresses of acc
+if accEmails is missing value then set accEmails to {}
+```
+
+## `whose id is` vs `whose message id is`
+
+Two different identifiers, two very different costs:
+
+- `whose id is "<n>"` — Mail.app's **internal numeric id** (the AppleScript-path `id`). Indexed; fast.
+- `whose message id is "<rfc>"` — the **RFC 5322 `Message-ID`** header. **Not indexed** (~20s per
+  lookup on a real mailbox), so always subject-prefilter first before matching on it.
+
+This is why the dual-emit ID model (#148) matters — read tools return both `id` (path-native) and
+`rfc_message_id`, and lookups pick the cheap path. See
+[ARCHITECTURE.md](ARCHITECTURE.md#dual-emit-message-id-model-148).
+
+## String escaping is critical
+
+Always run user text through `escape_applescript_string()` (after `sanitize_input()`). Unescaped
+quotes/backslashes fail silently with a generic "Can't make" error and no indication of the cause.
+
+## Gmail label-based system
+
+Gmail doesn't support standard IMAP move. `update_message` / `move_messages` use `gmail_mode=true`
+(copy + delete) for Gmail accounts.
+
+## Attachment paths
+
+Use POSIX file references — `POSIX file "/path/to/file"`. Convert Python `Path` objects via
+`.as_posix()`. Never concatenate an attacker-influenced attachment `name` into a path inside
+AppleScript (path-traversal → arbitrary write); sanitize and compute the target path on the Python
+side first.
+
+## Error parsing
+
+AppleScript errors surface on stderr; the connector maps them to typed exceptions (note macOS uses
+curly apostrophes — they're normalized before matching):
+- `Can't get account` → `MailAccountNotFoundError`
+- `Can't get mailbox` → `MailMailboxNotFoundError`
+- `Can't get message` → `MailMessageNotFoundError`
+- `Can't get rule` → `MailRuleNotFoundError`
+
+## Timeout
+
+Default 60 s. Mail's own AppleEvent timeout (also 60 s) is overridden inside the generated scripts via
+`with timeout of N seconds`, so server-bound operations on slow accounts don't trip `AppleEvent timed
+out (-1712)` before the connector's subprocess timer. Configurable via `AppleMailConnector(timeout=N)`.
+
+## Known Mail.app limitations
 
 | Feature | Status |
 |---------|--------|
-| Scheduled sending | Not available via AppleScript |
-| Thread/conversation grouping | Not exposed to AppleScript |
-| Mail rules management | Not accessible |
-| Smart mailbox access | Not exposed |
-| HTML body reading | Plain text only via `content of message` |
-| Read receipts | Not accessible |
-| Draft management | Limited support |
+| Scheduled / delayed sending | Not available via AppleScript |
+| Conversation grouping | No native `thread` class — reconstructed via headers (IMAP) or subject+references (AppleScript) |
+| Smart mailbox access | Not exposed to AppleScript |
+| HTML body reading | `content of message` returns plain text only |
+| Read receipts | Cannot request or detect |
+| Permanent delete | No primitive bypasses Trash (#111) |
 
-## Attachment Paths
-
-Use POSIX file references: `POSIX file "/path/to/file"`. Convert Python `Path` objects via `.as_posix()`.
-
-## Error Parsing
-
-AppleScript errors appear in stderr. The connector parses them into typed exceptions:
-- `"Can't get account"` -> `MailAccountNotFoundError`
-- `"Can't get mailbox"` -> `MailMailboxNotFoundError`
-- `"Can't get message"` -> `MailMessageNotFoundError`
-
-## Timeout Considerations
-
-Default: 60 seconds. Large mailboxes (10k+ messages) may need `timeout=120` or higher. Configurable via `AppleMailConnector(timeout=N)`.
+(Rules and drafts *are* manageable — see the `*_rule` and `*_draft` tools — though rules have no
+stable id and are addressed positionally.)


### PR DESCRIPTION
## Summary

PR **B of 2** for the #220 docs sweep — contributor + security guides. (PR A #289: README / ARCHITECTURE / TOOLS.)

### docs/guides/DEVELOPMENT.md (rewrite)
Was a stale *install* guide (pip/venv, "PyPI coming soon", broken links) duplicating the README. Now a **dev-workflow guide**: `uv` setup, `make check-all` as the canonical gate (with the CI-vs-local split), TDD, backend-+-frontend + parity script, the complexity gate + `ALLOWLIST` (→ COMPLEXITY.md), branch + CHANGELOG-on-release conventions, and the make targets.

### docs/reference/APPLESCRIPT_GOTCHAS.md
Replaced the stale "pipe-delimited output (planned JSON migration)" with the **actual JSON-via-ASObjC pattern** (`_wrap_as_json_script` / `parse_applescript_json`), the **`|name|:` quoted-record-key** convention, **missing-value coercion**, and **`whose id is` vs `whose message id is`**. Fixed the limitations table (rules + drafts *are* manageable now).

### docs/guides/TESTING.md
"17 tools" → current set; benchmark row → `make benchmark` + link BENCHMARKING.md; added the blind-eval pointer, the **`MAIL_TEST_MODE`/`MAIL_TEST_ACCOUNT` safety-gate** explanation, the **manual-e2e policy**, and the "CI runs unit only" note.

### docs/SECURITY.md + SECURITY_CHECKLIST.md
Settled the literal "will be reconciled with the threat model in #220" placeholder (THREAT_MODEL is canonical; SECURITY.md is the user-facing counterpart); added the security-doc hierarchy and the enumerated elicitation-gated destructive-ops list; cross-linked SECURITY_CHECKLIST → THREAT_MODEL. (THREAT_MODEL.md already back-links SECURITY.md.)

## Verification
- All cross-references in the changed files resolve (scripted check).
- No stale tool names.

Closes #220