### PR TITLE
fix(update_message): match RFC 5322 message-id, not only Mail's numeric id

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -614,8 +614,19 @@ def _bulk_repeat_block(
         account: Account name or UUID, or None.
         source_mailbox: Source mailbox name, or None.
         actions: One or more AppleScript statements to run inside the
-            loop AFTER `set msg to first message ... whose id is msgId`.
-            The counter increment is appended automatically.
+            loop once a message is matched (under `if matched then`).
+            Each id is matched in TWO sequential attempts — first by
+            Mail's internal numeric `id`, then (if that misses) by the
+            RFC 5322 `message id`. This lets callers pass either form:
+            read tools hand back the RFC Message-ID on the IMAP path,
+            which a numeric `id` never equals (the cause of silent
+            `updated:0` patches; #205-family). The two predicates are
+            kept in SEPARATE `whose` clauses on purpose — combining them
+            as `whose (id is X or message id is X)` makes Mail's query
+            compiler fail the whole filter when X is a non-numeric RFC
+            id (the `id is X` integer comparison poisons the `or`),
+            matching nothing. The counter increment is appended
+            automatically.
         counter_var: Name of the AppleScript counter variable (e.g.
             "updateCount", "moveCount") that gets incremented per success.
 
@@ -642,11 +653,22 @@ def _bulk_repeat_block(
         return (
             f'            set sourceMb to my resolveMailbox({account_clause}, "{mb_safe}")\n'
             f"            repeat with msgId in idList\n"
+            f"                set mid to (contents of msgId)\n"
+            f"                set matched to false\n"
             f"                try\n"
-            f"                    set msg to first message of sourceMb whose id is msgId\n"
+            f"                    set msg to first message of sourceMb whose id is mid\n"
+            f"                    set matched to true\n"
+            f"                end try\n"
+            f"                if not matched then\n"
+            f"                    try\n"
+            f"                        set msg to first message of sourceMb whose message id is mid\n"
+            f"                        set matched to true\n"
+            f"                    end try\n"
+            f"                end if\n"
+            f"                if matched then\n"
             f"{action_lines}\n"
             f"                    set {counter_var} to {counter_var} + 1\n"
-            f"                end try\n"
+            f"                end if\n"
             f"            end repeat"
         )
 
@@ -655,13 +677,24 @@ def _bulk_repeat_block(
     action_lines = "\n".join(action_indent + a for a in actions)
     return (
         f"            repeat with msgId in idList\n"
+        f"                set mid to (contents of msgId)\n"
         f"                repeat with acc in accounts\n"
         f"                    repeat with mb in mailboxes of acc\n"
+        f"                        set matched to false\n"
         f"                        try\n"
-        f"                            set msg to first message of mb whose id is msgId\n"
+        f"                            set msg to first message of mb whose id is mid\n"
+        f"                            set matched to true\n"
+        f"                        end try\n"
+        f"                        if not matched then\n"
+        f"                            try\n"
+        f"                                set msg to first message of mb whose message id is mid\n"
+        f"                                set matched to true\n"
+        f"                            end try\n"
+        f"                        end if\n"
+        f"                        if matched then\n"
         f"{action_lines}\n"
         f"                            set {counter_var} to {counter_var} + 1\n"
-        f"                        end try\n"
+        f"                        end if\n"
         f"                    end repeat\n"
         f"                end repeat\n"
         f"            end repeat"

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -625,8 +625,19 @@ def _bulk_repeat_block(
             as `whose (id is X or message id is X)` makes Mail's query
             compiler fail the whole filter when X is a non-numeric RFC
             id (the `id is X` integer comparison poisons the `or`),
-            matching nothing. The counter increment is appended
-            automatically.
+            matching nothing. The `message id` arm itself queries BOTH
+            the bare and `<bracketed>` forms (`message id is A or message
+            id is B` — safe, both are string comparisons), mirroring
+            `find_message_by_message_id`: IMAP-backed accounts store the
+            id bare, but other paths may store it bracketed per RFC 5322
+            (#232). The counter increment is appended automatically.
+
+            Performance: on the cross-scan path (no `source_mailbox`) the
+            `message id` fallback is NOT indexed (~20s/mailbox on a real
+            account; see APPLESCRIPT_GOTCHAS.md) and fires once per mailbox
+            for any RFC id, since the numeric `id` arm always misses for
+            those. Callers holding an RFC id should pass `account` +
+            `source_mailbox` to take the narrow single-mailbox path.
         counter_var: Name of the AppleScript counter variable (e.g.
             "updateCount", "moveCount") that gets incremented per success.
 
@@ -661,7 +672,9 @@ def _bulk_repeat_block(
             f"                end try\n"
             f"                if not matched then\n"
             f"                    try\n"
-            f"                        set msg to first message of sourceMb whose message id is mid\n"
+            f"                        set midBare to mid\n"
+            f'                        if midBare starts with "<" and midBare ends with ">" then set midBare to text 2 thru -2 of midBare\n'
+            f'                        set msg to first message of sourceMb whose (message id is midBare or message id is ("<" & midBare & ">"))\n'
             f"                        set matched to true\n"
             f"                    end try\n"
             f"                end if\n"
@@ -687,7 +700,9 @@ def _bulk_repeat_block(
         f"                        end try\n"
         f"                        if not matched then\n"
         f"                            try\n"
-        f"                                set msg to first message of mb whose message id is mid\n"
+        f"                                set midBare to mid\n"
+        f'                                if midBare starts with "<" and midBare ends with ">" then set midBare to text 2 thru -2 of midBare\n'
+        f'                                set msg to first message of mb whose (message id is midBare or message id is ("<" & midBare & ">"))\n'
         f"                                set matched to true\n"
         f"                            end try\n"
         f"                        end if\n"

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -1130,6 +1130,94 @@ class TestDraftsLifecycleIntegration:
             except Exception:
                 pass
 
+    def test_update_message_flag_via_applescript_matches_rfc_id(
+        self,
+        connector: AppleMailConnector,
+        test_account: str,
+    ) -> None:
+        """#291: update_message's AppleScript pass must match an RFC 5322
+        Message-ID, not only Mail's numeric `id`. `flag_color` can't go
+        through IMAP, so it always falls to the AppleScript pass; passing
+        the bracketless RFC id that read tools emit used to match nothing
+        and silently return 0. This forces the AppleScript path, APPENDs a
+        message with a known Message-ID, then flags it BY that RFC id and
+        asserts the patch counted 1 (pre-#291 this returned 0). Unit tests
+        only assert the generated script string and cannot catch this.
+        """
+        import time as _time
+        import uuid as _uuid
+        from datetime import datetime, timezone
+        from email.utils import format_datetime
+
+        from imapclient import IMAPClient
+
+        from apple_mail_mcp.keychain import get_imap_password
+
+        suffix = _uuid.uuid4().hex[:8]
+        src = f"ZZZ-AMM-RFC-FLAG-{suffix}"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+        bracketed = f"<{msg_id_local}>"
+
+        host, port, email = connector._resolve_imap_config(test_account)
+        pw = get_imap_password(test_account, email)
+
+        assert connector.create_mailbox(account=test_account, name=src)
+        try:
+            now = format_datetime(datetime.now(tz=timezone.utc))
+            raw = (
+                f"From: sender@apple-mail-mcp-test.invalid\r\n"
+                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"Subject: AMM #291 rfc-id flag test\r\n"
+                f"Date: {now}\r\n"
+                f"Message-ID: {bracketed}\r\n"
+                f"\r\n"
+                f"body\r\n"
+            ).encode()
+
+            append_client = IMAPClient(host, port=port, ssl=True, timeout=30)
+            append_client.login(email, pw)
+            try:
+                append_client.append(src, raw, flags=[])
+            finally:
+                append_client.logout()
+
+            # Force the AppleScript pass (flag_color can't use IMAP anyway).
+            connector._imap_failure_until[test_account] = (
+                _time.monotonic() + 60
+            )
+
+            # Mail.app's IMAP sync may lag the APPEND. Poll up to ~30s for
+            # the message to surface before we flag it by RFC id.
+            for _ in range(10):
+                rows = connector.search_messages(
+                    account=test_account, mailbox=src, limit=10,
+                )
+                if any(r.get("rfc_message_id") == msg_id_local for r in rows):
+                    break
+                _time.sleep(3)
+            else:
+                raise AssertionError(
+                    "Mail.app never surfaced the APPENDed message within 30s"
+                )
+
+            updated = connector.update_message(
+                [msg_id_local],
+                flag_color="orange",
+                account=test_account,
+                source_mailbox=src,
+            )
+            assert updated == 1, (
+                "AppleScript pass failed to match the RFC Message-ID "
+                "(pre-#291 this silently returned 0)"
+            )
+        finally:
+            try:
+                connector.delete_mailbox(
+                    account=test_account, name=src, delete_messages=True
+                )
+            except Exception:
+                pass
+
     def test_update_mailbox_renames_in_place(
         self,
         connector: AppleMailConnector,

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -4607,6 +4607,63 @@ class TestWhoseIdQuoting:
         )
 
 
+class TestUpdateMessageMatchesRfcMessageId:
+    """Bug A / #205-family: the AppleScript pass must match the RFC 5322
+    ``message id`` as well as Mail's internal numeric ``id``.
+
+    Read tools hand back the RFC 5322 Message-ID on the IMAP path. The
+    AppleScript fallback used to match only ``whose id is msgId`` (numeric
+    ``id``), which an RFC string never equals — so flag/read patches that
+    can't use the IMAP fast path (e.g. ``flag_color``, which IMAP can't
+    set) matched nothing and silently returned ``updated:0``. Matching
+    ``(id is msgId or message id is msgId)`` in the same pass fixes it
+    with no extra round-trip (no per-id all-mailbox scan).
+    """
+
+    RFC_ID = (
+        "LOVP265MB8807FC008C278E73EE7F2B678E382"
+        "@LOVP265MB8807.GBRP265.PROD.OUTLOOK.COM"
+    )
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    @patch.object(AppleMailConnector, "find_message_by_message_id")
+    def test_flag_color_matches_rfc_message_id_in_pass(
+        self,
+        mock_find: MagicMock,
+        mock_run: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        mock_run.return_value = "1"
+
+        result = connector.update_message([self.RFC_ID], flag_color="orange")
+
+        assert result == 1
+        # The pass must try the RFC message id (not only the numeric id),
+        # in the single existing AppleScript pass — no separate resolver
+        # round-trip.
+        script = mock_run.call_args[0][0]
+        assert "whose message id is mid" in script
+        assert f'"{self.RFC_ID}"' in script
+        mock_find.assert_not_called()
+        mock_run.assert_called_once()
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_numeric_id_still_matched(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "1"
+
+        connector.update_message(["12345"], flag_color="orange")
+
+        script = mock_run.call_args[0][0]
+        assert "whose id is mid" in script
+        assert '"12345"' in script
+
+
 class TestWrapAsJsonScript:
     def test_wrapper_contains_framework_directive(self) -> None:
         script = _wrap_as_json_script(

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -4646,7 +4646,12 @@ class TestUpdateMessageMatchesRfcMessageId:
         # in the single existing AppleScript pass — no separate resolver
         # round-trip.
         script = mock_run.call_args[0][0]
-        assert "whose message id is mid" in script
+        # The pass tries the RFC message id; the message-id arm queries
+        # both the bare and <bracketed> forms (mirrors #232 /
+        # find_message_by_message_id), so other providers' bracketed
+        # storage still matches.
+        assert "message id is midBare" in script
+        assert 'message id is ("<" & midBare & ">")' in script
         assert f'"{self.RFC_ID}"' in script
         mock_find.assert_not_called()
         mock_run.assert_called_once()


### PR DESCRIPTION
## Problem

`update_message` silently returns `updated: 0` (no error) whenever the patch
falls to the AppleScript pass — `flag_color`, a combined patch, or a move
without `source_mailbox` — and the caller passes an **RFC 5322 Message-ID**.

That's the id form `search_messages` / `get_messages` hand back on the IMAP
fast path, so it's the common case for IMAP-backed accounts (iCloud, Gmail):

```python
# id came from search_messages() on an iCloud account
update_message(["<abc123@mail.example.com>"], flag_color="orange")
# -> {"updated": 0}  (nothing happens, no error)
```

## Root cause

`_bulk_repeat_block` matched messages with `whose id is msgId`, i.e. Mail.app's
internal **numeric** `id`. An RFC Message-ID string never equals that numeric
id, so `first message ... whose id is msgId` raises, the `try` swallows it, and
the counter stays 0. (`get_message` works on these ids only because it has an
RFC-keyed IMAP path; `update_message`'s AppleScript pass had no equivalent.)

## Fix

Match each id in **two sequential `whose` attempts** — numeric `id` first, then
the RFC `message id` — so callers can pass either form.

The two predicates must be **separate** clauses. Combining them as
`whose (id is X or message id is X)` makes Mail's query compiler fail the whole
filter when `X` is a non-numeric RFC id: the `id is X` integer comparison
poisons the `or` and nothing matches. Verified against live iCloud Mail:

| clause | matches |
|---|---|
| `whose (id is X or message id is X)` | 0 |
| `whose message id is X` (alone) | 1 |
| sequential `id` then `message id` | 1 |

This rebases onto the `resolveMailbox` work from #247, so flag/read/move
patches now work end-to-end when callers pass the ids the read tools return.

## Testing

- New `TestUpdateMessageMatchesRfcMessageId` (RFC id is matched in-pass; numeric
  ids still matched; no extra resolver round-trip).
- Full unit suite green; ruff clean.
- Manually verified on a live iCloud account: flag-by-RFC-id via both the
  cross-scan and the `resolveMailbox` narrow path now succeed (previously `0`).

## Note

The no-`source_mailbox` AppleScript cross-scan can over-count when a stale
duplicate `.emlx` exists for an id (the end state is still correct). Supplying
`source_mailbox` routes through the exact IMAP `UID MOVE` / `STORE` fast paths
and is unaffected. Out of scope here.
