### PR TITLE
fix(#245): clean reply/forward drafts via IMAP APPEND (no iOS cite-blockquote)

### DIFF
--- a/src/apple_mail_mcp/draft_builder.py
+++ b/src/apple_mail_mcp/draft_builder.py
@@ -12,10 +12,23 @@ shape is unit-testable in isolation.
 
 from __future__ import annotations
 
+import email
 import mimetypes
+import re
+from dataclasses import dataclass, field
 from email.message import EmailMessage
-from email.utils import formatdate, make_msgid
+from email.policy import default as _default_policy
+from email.utils import formataddr, formatdate, getaddresses, make_msgid, parseaddr
 from pathlib import Path
+
+# A single forwarded attachment carried over from the original message:
+# (filename, maintype, subtype, payload_bytes).
+ForwardedAttachment = tuple[str, str, str, bytes]
+
+_RE_PREFIX = re.compile(r"^\s*re:\s*", re.IGNORECASE)
+_FWD_PREFIX = re.compile(r"^\s*(?:fwd?|forward):\s*", re.IGNORECASE)
+# Message-ID tokens inside a References header (angle-bracketed, no spaces).
+_TAG_TOKENS = re.compile(r"<[^>\s]+>")
 
 
 def _sanitize_header(value: str) -> str:
@@ -37,12 +50,25 @@ def build_draft_mime(
     cc: list[str] | None = None,
     bcc: list[str] | None = None,
     attachments: list[Path] | None = None,
+    in_reply_to: str | None = None,
+    references: list[str] | None = None,
+    forwarded_attachments: list[ForwardedAttachment] | None = None,
 ) -> tuple[str, bytes]:
     """Build a plain-text draft message.
 
     Returns ``(message_id, raw_bytes)`` where ``message_id`` is the
     generated RFC 5322 Message-ID (angle-bracketed) and ``raw_bytes`` is
     the serialized message suitable for ``IMAPClient.append``.
+
+    Reply/forward extras (issue #245 follow-up):
+
+    - ``in_reply_to`` / ``references`` set the threading headers so the
+      drafted reply/forward stays in the original conversation. Pass the
+      values bracketed (``<id@host>``); they are header-sanitized but not
+      otherwise reshaped.
+    - ``forwarded_attachments`` are ``(filename, maintype, subtype,
+      payload)`` tuples carried over from the original message, used when
+      forwarding so the original's files travel with the draft.
     """
     msg = EmailMessage()
     message_id = make_msgid()
@@ -55,6 +81,10 @@ def build_draft_mime(
         msg["Bcc"] = ", ".join(_sanitize_header(a) for a in bcc)
     msg["Subject"] = _sanitize_header(subject)
     msg["Date"] = formatdate(localtime=True)
+    if in_reply_to:
+        msg["In-Reply-To"] = _sanitize_header(in_reply_to)
+    if references:
+        msg["References"] = " ".join(_sanitize_header(r) for r in references)
     msg.set_content(body)
 
     for path in attachments or []:
@@ -68,4 +98,202 @@ def build_draft_mime(
             filename=path.name,
         )
 
+    for filename, maintype, subtype, payload in forwarded_attachments or []:
+        msg.add_attachment(
+            payload,
+            maintype=maintype or "application",
+            subtype=subtype or "octet-stream",
+            filename=_sanitize_header(filename) or "attachment",
+        )
+
     return message_id, msg.as_bytes()
+
+
+def reply_subject(original_subject: str) -> str:
+    """``Re:``-prefix a subject, without stacking a second ``Re:``."""
+    s = (original_subject or "").strip()
+    if _RE_PREFIX.match(s):
+        return s
+    return f"Re: {s}" if s else "Re:"
+
+
+def forward_subject(original_subject: str) -> str:
+    """``Fwd:``-prefix a subject, without stacking a second ``Fwd:``."""
+    s = (original_subject or "").strip()
+    if _FWD_PREFIX.match(s):
+        return s
+    return f"Fwd: {s}" if s else "Fwd:"
+
+
+def _email_of(addr: str) -> str:
+    return parseaddr(addr)[1].lower()
+
+
+def derive_reply_recipients(
+    *,
+    from_header: str,
+    reply_to_header: str = "",
+    to_header: str = "",
+    cc_header: str = "",
+    self_addresses: list[str] | None = None,
+    reply_all: bool = False,
+) -> tuple[list[str], list[str]]:
+    """Derive (to, cc) for a reply from the original message's headers.
+
+    - Primary recipient is the original ``Reply-To`` if present, else
+      ``From``.
+    - ``reply_all`` adds the original ``To`` + ``Cc`` as Cc, minus any of
+      the account's own ``self_addresses`` and minus the primary (so the
+      replier isn't cc'ing themselves or duplicating the To).
+    - Address display names are preserved (``Name <email>``).
+
+    Returns ``(to, cc)`` as lists of formatted address strings.
+    """
+    selves = {a.lower() for a in (self_addresses or [])}
+
+    primary_pairs = getaddresses([reply_to_header or from_header])
+    to_list = [formataddr(p) for p in primary_pairs if p[1]]
+    primary_emails = {p[1].lower() for p in primary_pairs if p[1]}
+
+    cc_list: list[str] = []
+    if reply_all:
+        seen = set(primary_emails) | selves
+        for name, email_addr in getaddresses([to_header, cc_header]):
+            if not email_addr:
+                continue
+            key = email_addr.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            cc_list.append(formataddr((name, email_addr)))
+    return to_list, cc_list
+
+
+def _quote_lines(text: str) -> str:
+    """Prefix each line of ``text`` with ``> `` (email plain-text quoting)."""
+    return "\n".join(
+        (f"> {line}" if line else ">") for line in (text or "").splitlines()
+    )
+
+
+def build_reply_body(
+    *,
+    new_body: str,
+    original_from: str,
+    original_date: str,
+    original_text: str,
+) -> str:
+    """Compose a plain-text reply body: the new text, then an attribution
+    line, then the original quoted with ``> ``.
+    """
+    attribution = f"On {original_date.strip()}, {original_from.strip()} wrote:"
+    return (
+        f"{new_body.rstrip()}\n\n"
+        f"{attribution}\n"
+        f"{_quote_lines(original_text)}\n"
+    )
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"[ \t]+")
+
+
+def _html_to_text(html: str) -> str:
+    """Crude HTML→text fallback for messages with no text/plain part.
+
+    Drops tags and collapses runs of spaces. Good enough to quote in a
+    reply; we are not trying to faithfully render HTML.
+    """
+    text = re.sub(r"(?i)<br\s*/?>", "\n", html)
+    text = re.sub(r"(?i)</p>", "\n\n", text)
+    text = _TAG_RE.sub("", text)
+    text = (
+        text.replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", '"')
+    )
+    return _WS_RE.sub(" ", text).strip()
+
+
+@dataclass
+class OriginalMessage:
+    """The fields of an original message needed to rebuild a clean
+    reply/forward draft. Produced by :func:`parse_original_message`.
+    """
+
+    message_id: str = ""
+    from_header: str = ""
+    reply_to_header: str = ""
+    to_header: str = ""
+    cc_header: str = ""
+    subject: str = ""
+    date: str = ""
+    references: list[str] = field(default_factory=list)
+    text: str = ""
+    attachments: list[ForwardedAttachment] = field(default_factory=list)
+
+
+def parse_original_message(raw: bytes) -> OriginalMessage:
+    """Parse a raw RFC 822 message into the pieces needed for a reply or
+    forward. Prefers the ``text/plain`` body; falls back to a crude
+    text rendering of ``text/html`` when that's all the message has.
+    """
+    msg = email.message_from_bytes(raw, policy=_default_policy)
+
+    text = ""
+    plain = msg.get_body(preferencelist=("plain",))
+    if plain is not None:
+        text = plain.get_content()
+    else:
+        html = msg.get_body(preferencelist=("html",))
+        if html is not None:
+            text = _html_to_text(html.get_content())
+
+    attachments: list[ForwardedAttachment] = []
+    for part in msg.iter_attachments():
+        decoded = part.get_payload(decode=True)
+        payload = bytes(decoded) if isinstance(decoded, (bytes, bytearray)) else b""
+        maintype, _, subtype = part.get_content_type().partition("/")
+        attachments.append(
+            (part.get_filename() or "attachment", maintype, subtype, payload)
+        )
+
+    refs_raw = msg.get("References", "") or ""
+    references = _TAG_TOKENS.findall(refs_raw)
+
+    return OriginalMessage(
+        message_id=(msg.get("Message-ID", "") or "").strip(),
+        from_header=str(msg.get("From", "") or ""),
+        reply_to_header=str(msg.get("Reply-To", "") or ""),
+        to_header=str(msg.get("To", "") or ""),
+        cc_header=str(msg.get("Cc", "") or ""),
+        subject=str(msg.get("Subject", "") or ""),
+        date=str(msg.get("Date", "") or ""),
+        references=references,
+        text=text,
+        attachments=attachments,
+    )
+
+
+def build_forward_body(
+    *,
+    new_body: str,
+    original_from: str,
+    original_date: str,
+    original_subject: str,
+    original_to: str,
+    original_text: str,
+) -> str:
+    """Compose a plain-text forward body: the new text, then a standard
+    forwarded-message header block, then the original text (unquoted).
+    """
+    header_block = (
+        "---------- Forwarded message ----------\n"
+        f"From: {original_from.strip()}\n"
+        f"Date: {original_date.strip()}\n"
+        f"Subject: {original_subject.strip()}\n"
+        f"To: {original_to.strip()}\n"
+    )
+    return f"{new_body.rstrip()}\n\n{header_block}\n{original_text}\n"

--- a/src/apple_mail_mcp/drafts.py
+++ b/src/apple_mail_mcp/drafts.py
@@ -31,10 +31,16 @@ from typing import Literal
 
 from .exceptions import MailDraftInvalidIdError
 
-# Mail.app internal message ids are numeric strings in practice
-# (e.g. "160991"). Allow alphanumerics + - _ for safety. The 128
-# char cap is generous for any conceivable id format.
-_DRAFT_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
+# A draft_id is EITHER a Mail.app internal numeric id (e.g. "160991")
+# OR a bare RFC 5322 Message-ID (e.g. "abc.123@host", returned by the
+# IMAP-APPEND draft path, #245). The charset therefore allows the
+# Message-ID atext characters that occur in practice (. @ + = _ -) but
+# deliberately EXCLUDES path separators ("/", "\") and angle brackets so
+# the value remains safe to use as a seed-store filename — without a
+# separator no input can escape the drafts directory. Bracketed
+# Message-IDs are normalized to bare form at the boundary before reaching
+# here. The 255-char cap is generous for any real Message-ID.
+_DRAFT_ID_RE = re.compile(r"^[A-Za-z0-9._@+=-]{1,255}$")
 _EXT = ".json"
 
 SeedKind = Literal["reply", "forward"]

--- a/src/apple_mail_mcp/exceptions.py
+++ b/src/apple_mail_mcp/exceptions.py
@@ -152,7 +152,8 @@ class MailDraftError(MailError):
 
 class MailDraftInvalidIdError(MailDraftError):
     """Draft id failed validation (path traversal, invalid chars, too long,
-    or empty). Ids must match ^[a-zA-Z0-9_-]{1,128}$."""
+    or empty). Ids must match ^[A-Za-z0-9._@+=-]{1,255}$ — a Mail.app
+    numeric id or a bare RFC 5322 Message-ID, with no path separators."""
 
     pass
 

--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -788,6 +788,46 @@ class ImapConnector:
                 )
             return result
 
+    def fetch_raw_message(
+        self, message_id: str, mailbox: str = "INBOX"
+    ) -> bytes:
+        """Fetch the full raw RFC 822 bytes of a message by Message-ID.
+
+        Used to rebuild a clean reply/forward draft (#245 follow-up):
+        parsing the raw original yields headers, body, and attachment
+        payloads in a single fetch.
+
+        Args:
+            message_id: RFC 5322 Message-ID, with or without ``<>``.
+            mailbox: Folder to SELECT and search. The caller supplies the
+                seed message's folder (or defaults to INBOX); a miss
+                raises so the orchestrator can fall back to AppleScript,
+                which resolves the message across all folders.
+
+        Raises:
+            MailMessageNotFoundError: No message in ``mailbox`` matches.
+            IMAPClientError: Login / SELECT / SEARCH / FETCH failed.
+        """
+        bracketed = _bracket_message_id(message_id)
+        _reject_control_chars(mailbox, "mailbox")
+        with self._session() as client:
+            client.select_folder(mailbox, readonly=True)
+            uids = client.search(["HEADER", "Message-ID", bracketed])
+            if not uids:
+                raise MailMessageNotFoundError(
+                    f"Message-ID {message_id!r} not found in mailbox "
+                    f"{mailbox!r} on {self._host}."
+                )
+            fetched = client.fetch(uids[:1], [b"BODY[]"])
+            entry = next(iter(fetched.values()))
+            raw = entry.get(b"BODY[]") or b""
+            if not raw:
+                raise MailMessageNotFoundError(
+                    f"Message-ID {message_id!r} in {mailbox!r} returned an "
+                    f"empty body on {self._host}."
+                )
+            return bytes(raw)
+
     def get_attachments(
         self,
         message_id: str,

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -16,7 +16,15 @@ from typing import Any, cast
 
 from imapclient.exceptions import IMAPClientError, LoginError
 
-from .draft_builder import build_draft_mime
+from .draft_builder import (
+    build_draft_mime,
+    build_forward_body,
+    build_reply_body,
+    derive_reply_recipients,
+    forward_subject,
+    parse_original_message,
+    reply_subject,
+)
 from .drafts import _validate_draft_id
 from .exceptions import (
     MailAccountNotFoundError,
@@ -4239,11 +4247,114 @@ class AppleMailConnector:
         self._imap_clear_breaker(from_account)
         return {"draft_id": message_id, "sent_message_id": ""}
 
+    def _create_reply_forward_draft_via_imap(
+        self,
+        *,
+        seed: str,
+        seed_id: str,
+        seed_mailbox: str,
+        from_account: str,
+        to: list[str] | None,
+        cc: list[str] | None,
+        bcc: list[str] | None,
+        subject: str | None,
+        body: str,
+        reply_all: bool,
+        attachment_paths: list[Path] | None,
+    ) -> dict[str, str]:
+        """Create a clean reply/forward save-as-draft via IMAP APPEND
+        (issue #245 follow-up).
+
+        Fetches the original's raw RFC 822 from ``seed_mailbox`` over IMAP,
+        rebuilds a clean text/plain reply/forward (no Mail.app
+        cite-blockquote) with proper ``In-Reply-To`` / ``References``
+        threading, and APPENDs it to Drafts. For forwards, the original's
+        attachments travel with the draft.
+
+        Raises the standard ``_IMAP_FALLBACK_EXCS`` and
+        ``MailMessageNotFoundError`` (when the original isn't in
+        ``seed_mailbox``) which ``create_draft`` catches to fall back to
+        the AppleScript path — AppleScript resolves the message across all
+        folders, so a folder-guess miss degrades gracefully.
+        """
+        sender = self._resolve_account_to_sender(from_account)
+        host, port, email = self._resolve_imap_config(from_account)
+        password = self._get_imap_password_with_fallback(from_account, email)
+        imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
+
+        raw = imap.fetch_raw_message(seed_id, seed_mailbox)
+        orig = parse_original_message(raw)
+
+        # Threading: In-Reply-To = the original's Message-ID; References =
+        # the original's References chain plus the original's Message-ID.
+        in_reply_to = orig.message_id or None
+        references = list(orig.references)
+        if orig.message_id and orig.message_id not in references:
+            references.append(orig.message_id)
+
+        final_to: list[str]
+        final_cc: list[str] | None
+        if seed == "reply":
+            derived_to, derived_cc = derive_reply_recipients(
+                from_header=orig.from_header,
+                reply_to_header=orig.reply_to_header,
+                to_header=orig.to_header,
+                cc_header=orig.cc_header,
+                self_addresses=[email],
+                reply_all=reply_all,
+            )
+            final_to = to if to is not None else derived_to
+            final_cc = cc if cc is not None else derived_cc
+            final_subject = (
+                subject if subject is not None else reply_subject(orig.subject)
+            )
+            final_body = build_reply_body(
+                new_body=body,
+                original_from=orig.from_header,
+                original_date=orig.date,
+                original_text=orig.text,
+            )
+            forwarded_attachments = None
+        else:  # forward
+            final_to = to if to is not None else []
+            final_cc = cc
+            final_subject = (
+                subject if subject is not None else forward_subject(orig.subject)
+            )
+            final_body = build_forward_body(
+                new_body=body,
+                original_from=orig.from_header,
+                original_date=orig.date,
+                original_subject=orig.subject,
+                original_to=orig.to_header,
+                original_text=orig.text,
+            )
+            forwarded_attachments = orig.attachments or None
+
+        message_id, draft_raw = build_draft_mime(
+            sender=sender,
+            to=final_to,
+            cc=final_cc,
+            bcc=bcc,
+            subject=final_subject or "",
+            body=final_body,
+            attachments=(
+                [Path(p) for p in attachment_paths] if attachment_paths else None
+            ),
+            in_reply_to=in_reply_to,
+            references=references or None,
+            forwarded_attachments=forwarded_attachments,
+        )
+        imap.append_draft(draft_raw)
+        self._imap_clear_breaker(from_account)
+        return {"draft_id": message_id, "sent_message_id": ""}
+
     def create_draft(
         self,
         *,
         seed: str = "new",
         seed_id: str | None = None,
+        seed_mailbox: str | None = None,
         to: list[str] | None = None,
         cc: list[str] | None = None,
         bcc: list[str] | None = None,
@@ -4261,8 +4372,17 @@ class AppleMailConnector:
         RFC 822 message rather than Mail.app's AppleScript ``content``
         setter, which wraps the body in a cite-blockquote that renders as
         a quote on iOS (Mail.app bug FB11734014, #245). Falls back to the
-        AppleScript path when IMAP isn't configured. Reply/forward and
-        ``send_now=True`` still use AppleScript.
+        AppleScript path when IMAP isn't configured.
+
+        ``seed="reply"`` / ``seed="forward"`` save-as-draft also use the
+        clean IMAP path when ``seed_id`` is an RFC Message-ID and
+        ``from_account`` is known: the original is fetched from
+        ``seed_mailbox`` (default INBOX), and the quoted body + ``Re:``/
+        ``Fwd:`` subject + ``In-Reply-To``/``References`` threading are
+        rebuilt in plain text (forwards carry the original's attachments).
+        Falls back to AppleScript when IMAP isn't configured or the
+        original isn't in ``seed_mailbox``. ``send_now=True`` still uses
+        AppleScript.
 
         Args:
             seed: ``"new"``, ``"reply"``, or ``"forward"``.
@@ -4272,6 +4392,11 @@ class AppleMailConnector:
                 is what read tools (``search_messages`` / ``get_messages``)
                 emit as ``id`` on the IMAP path (#148), so callers can
                 forward those ids verbatim. Required when ``seed != "new"``.
+            seed_mailbox: Folder the seed message lives in, used by the
+                clean reply/forward IMAP path to fetch the original
+                (default INBOX). Supply it for replies to filed mail; a
+                miss falls back to AppleScript (which resolves across all
+                folders). Ignored for ``seed="new"``.
             to/cc/bcc: Recipient lists. For reply/forward, ``None`` keeps
                 Mail's auto-derived recipients; an empty list explicitly
                 clears that group; a populated list replaces.
@@ -4325,6 +4450,44 @@ class AppleMailConnector:
                     attachment_paths=attachment_paths,
                 )
             except _IMAP_FALLBACK_EXCS as exc:
+                self._log_imap_fallback(from_account, exc)
+            # fall through to the AppleScript path
+
+        # IMAP-APPEND path for REPLY / FORWARD save-as-draft (issue #245
+        # follow-up): same cite-blockquote avoidance as compose, but we
+        # rebuild the quoted original + threading ourselves from the
+        # original's raw RFC 822 (fetched by Message-ID from seed_mailbox).
+        # Requires an RFC Message-ID seed (the form read tools emit) and a
+        # known account. On IMAP degradation OR a folder-guess miss
+        # (MailMessageNotFoundError), fall back to the AppleScript path,
+        # which resolves the seed across all folders.
+        if (
+            seed in ("reply", "forward")
+            and not send_now
+            and seed_id is not None
+            and "@" in seed_id
+            and from_account is not None
+            and not self._imap_breaker_open(from_account)
+        ):
+            try:
+                return self._create_reply_forward_draft_via_imap(
+                    seed=seed,
+                    seed_id=seed_id,
+                    seed_mailbox=seed_mailbox or "INBOX",
+                    from_account=from_account,
+                    to=to,
+                    cc=cc,
+                    bcc=bcc,
+                    subject=subject,
+                    body=body,
+                    reply_all=reply_all,
+                    attachment_paths=attachment_paths,
+                )
+            except _IMAP_FALLBACK_EXCS as exc:
+                self._log_imap_fallback(from_account, exc)
+            except MailMessageNotFoundError as exc:
+                # Original not in seed_mailbox (or wrong folder hint) — the
+                # AppleScript path resolves the seed across all folders.
                 self._log_imap_fallback(from_account, exc)
             # fall through to the AppleScript path
 

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -83,6 +83,20 @@ def _now() -> _datetime:
     return _datetime.now().astimezone()
 
 
+def _bare_message_id(message_id: str) -> str:
+    """Strip surrounding angle brackets from an RFC 5322 Message-ID.
+
+    ``make_msgid()`` (and raw ``Message-ID`` headers) produce the
+    bracketed form ``<id@host>``, but Mail.app and the read tools store
+    and emit the bare ``id@host``. The IMAP-APPEND draft path returns the
+    bare form as ``draft_id`` so it round-trips through draft-id
+    validation and the ``delete_draft`` / ``update_draft`` lookups (#245)."""
+    mid = message_id.strip()
+    if mid.startswith("<") and mid.endswith(">"):
+        return mid[1:-1]
+    return mid
+
+
 def _construct_as_date_var(var: str, year: int, month: int, day: int) -> str:
     """Emit AppleScript that constructs an AS date object at midnight (local
     time) on the given (year, month, day).
@@ -3859,6 +3873,26 @@ class AppleMailConnector:
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
+    def _resolve_draft_lookup_id(self, draft_id: str) -> str:
+        """Map a ``draft_id`` to Mail.app's internal numeric id for the
+        AppleScript ``whose id is`` lookups used by ``delete_draft`` /
+        ``get_draft_state``.
+
+        IMAP-APPEND drafts (#245) are keyed by a bare RFC 5322 Message-ID
+        (contains ``@``); Mail.app's ``id`` property is its own internal id,
+        not the Message-ID, so resolve the Message-ID to that internal id
+        first. Numeric ids pass through unchanged.
+
+        Raises:
+            MailDraftNotFoundError: a Message-ID that matches no message.
+        """
+        if "@" not in draft_id:
+            return draft_id
+        internal = self.find_message_by_message_id(draft_id)
+        if internal is None:
+            raise MailDraftNotFoundError(f"no draft with id {draft_id!r}")
+        return internal
+
     def delete_draft(self, draft_id: str) -> bool:
         """Move a draft to Trash (lifecycle endpoint for cancellation).
 
@@ -3878,6 +3912,7 @@ class AppleMailConnector:
             MailDraftNotFoundError: no draft with that id exists.
         """
         _validate_draft_id(draft_id)
+        lookup_id = self._resolve_draft_lookup_id(draft_id)
 
         script = _wrap_with_timeout(
             f"""tell application "Mail"
@@ -3887,7 +3922,7 @@ class AppleMailConnector:
                     repeat with mb in mailboxes of acc
                         if name of mb contains "Drafts" then
                             try
-                                set m to first message of mb whose id is "{draft_id}"
+                                set m to first message of mb whose id is "{lookup_id}"
                                 delete m
                                 set didDelete to true
                                 exit repeat
@@ -3940,9 +3975,7 @@ class AppleMailConnector:
         """
         if not rfc5322_message_id:
             return None
-        bare = rfc5322_message_id
-        if bare.startswith("<") and bare.endswith(">"):
-            bare = bare[1:-1]
+        bare = _bare_message_id(rfc5322_message_id)
         bracketed = f"<{bare}>"
         safe_bare = escape_applescript_string(sanitize_input(bare))
         safe_bracketed = escape_applescript_string(sanitize_input(bracketed))
@@ -4006,10 +4039,11 @@ class AppleMailConnector:
             MailDraftNotFoundError: no draft with that id exists.
         """
         _validate_draft_id(draft_id)
+        lookup_id = self._resolve_draft_lookup_id(draft_id)
 
         tell_body = f"""
         tell application "Mail"
-            set targetId to "{draft_id}"
+            set targetId to "{lookup_id}"
             set foundDraft to missing value
             repeat with acc in accounts
                 try
@@ -4245,7 +4279,7 @@ class AppleMailConnector:
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         imap.append_draft(raw)
         self._imap_clear_breaker(from_account)
-        return {"draft_id": message_id, "sent_message_id": ""}
+        return {"draft_id": _bare_message_id(message_id), "sent_message_id": ""}
 
     def _create_reply_forward_draft_via_imap(
         self,
@@ -4347,7 +4381,107 @@ class AppleMailConnector:
         )
         imap.append_draft(draft_raw)
         self._imap_clear_breaker(from_account)
-        return {"draft_id": message_id, "sent_message_id": ""}
+        return {"draft_id": _bare_message_id(message_id), "sent_message_id": ""}
+
+    def _try_imap_compose_draft(
+        self,
+        *,
+        seed: str,
+        send_now: bool,
+        from_account: str | None,
+        to: list[str] | None,
+        cc: list[str] | None,
+        bcc: list[str] | None,
+        subject: str | None,
+        body: str,
+        attachment_paths: list[Path] | None,
+    ) -> dict[str, str] | None:
+        """IMAP-APPEND path for a ``seed="new"`` save-as-draft (issue #245).
+
+        Returns the draft dict when it handles the request, or ``None`` to
+        signal ``create_draft`` to fall through to the AppleScript path.
+        Scoped to ``seed="new"`` save-as-draft with a known account; on the
+        usual IMAP-degradation signals (e.g. no Keychain opt-in) it logs
+        and returns ``None``, preserving prior behavior.
+        """
+        if not (
+            seed == "new"
+            and not send_now
+            and from_account is not None
+            and not self._imap_breaker_open(from_account)
+        ):
+            return None
+        try:
+            return self._create_draft_via_imap(
+                from_account=from_account,
+                to=to or [],
+                cc=cc,
+                bcc=bcc,
+                subject=subject or "",
+                body=body,
+                attachment_paths=attachment_paths,
+            )
+        except _IMAP_FALLBACK_EXCS as exc:
+            self._log_imap_fallback(from_account, exc)
+        return None
+
+    def _try_imap_reply_forward_draft(
+        self,
+        *,
+        seed: str,
+        seed_id: str | None,
+        seed_mailbox: str | None,
+        send_now: bool,
+        from_account: str | None,
+        to: list[str] | None,
+        cc: list[str] | None,
+        bcc: list[str] | None,
+        subject: str | None,
+        body: str,
+        reply_all: bool,
+        attachment_paths: list[Path] | None,
+    ) -> dict[str, str] | None:
+        """IMAP-APPEND path for a reply/forward save-as-draft (issue #245
+        follow-up).
+
+        Same cite-blockquote avoidance as compose, but rebuilds the quoted
+        original + threading from the original's raw RFC 822 (fetched by
+        Message-ID from ``seed_mailbox``). Requires an RFC Message-ID seed
+        (the form read tools emit) and a known account. Returns ``None`` to
+        fall through to AppleScript on IMAP degradation OR a folder-guess
+        miss (``MailMessageNotFoundError``) — AppleScript resolves the seed
+        across all folders.
+        """
+        if not (
+            seed in ("reply", "forward")
+            and not send_now
+            and seed_id is not None
+            and "@" in seed_id
+            and from_account is not None
+            and not self._imap_breaker_open(from_account)
+        ):
+            return None
+        try:
+            return self._create_reply_forward_draft_via_imap(
+                seed=seed,
+                seed_id=seed_id,
+                seed_mailbox=seed_mailbox or "INBOX",
+                from_account=from_account,
+                to=to,
+                cc=cc,
+                bcc=bcc,
+                subject=subject,
+                body=body,
+                reply_all=reply_all,
+                attachment_paths=attachment_paths,
+            )
+        except _IMAP_FALLBACK_EXCS as exc:
+            self._log_imap_fallback(from_account, exc)
+        except MailMessageNotFoundError as exc:
+            # Original not in seed_mailbox (or wrong folder hint) — the
+            # AppleScript path resolves the seed across all folders.
+            self._log_imap_fallback(from_account, exc)
+        return None
 
     def create_draft(
         self,
@@ -4426,70 +4560,37 @@ class AppleMailConnector:
         """
         self._validate_create_draft_args(seed, seed_id, to, subject)
 
-        # IMAP-APPEND path for compose drafts (issue #245): bypasses
-        # Mail.app's AppleScript `content` setter, which wraps the body in
-        # an Apple-Mail-URLShareWrapper <blockquote type="cite"> (Mail.app
-        # bug FB11734014) that renders as a quote on iOS. Scoped to
-        # seed="new" save-as-draft with a known account; on the usual
-        # IMAP-degradation signals (e.g. no Keychain opt-in) we fall back
-        # to the AppleScript path below, preserving prior behavior.
-        if (
-            seed == "new"
-            and not send_now
-            and from_account is not None
-            and not self._imap_breaker_open(from_account)
-        ):
-            try:
-                return self._create_draft_via_imap(
-                    from_account=from_account,
-                    to=to or [],
-                    cc=cc,
-                    bcc=bcc,
-                    subject=subject or "",
-                    body=body,
-                    attachment_paths=attachment_paths,
-                )
-            except _IMAP_FALLBACK_EXCS as exc:
-                self._log_imap_fallback(from_account, exc)
-            # fall through to the AppleScript path
-
-        # IMAP-APPEND path for REPLY / FORWARD save-as-draft (issue #245
-        # follow-up): same cite-blockquote avoidance as compose, but we
-        # rebuild the quoted original + threading ourselves from the
-        # original's raw RFC 822 (fetched by Message-ID from seed_mailbox).
-        # Requires an RFC Message-ID seed (the form read tools emit) and a
-        # known account. On IMAP degradation OR a folder-guess miss
-        # (MailMessageNotFoundError), fall back to the AppleScript path,
-        # which resolves the seed across all folders.
-        if (
-            seed in ("reply", "forward")
-            and not send_now
-            and seed_id is not None
-            and "@" in seed_id
-            and from_account is not None
-            and not self._imap_breaker_open(from_account)
-        ):
-            try:
-                return self._create_reply_forward_draft_via_imap(
-                    seed=seed,
-                    seed_id=seed_id,
-                    seed_mailbox=seed_mailbox or "INBOX",
-                    from_account=from_account,
-                    to=to,
-                    cc=cc,
-                    bcc=bcc,
-                    subject=subject,
-                    body=body,
-                    reply_all=reply_all,
-                    attachment_paths=attachment_paths,
-                )
-            except _IMAP_FALLBACK_EXCS as exc:
-                self._log_imap_fallback(from_account, exc)
-            except MailMessageNotFoundError as exc:
-                # Original not in seed_mailbox (or wrong folder hint) — the
-                # AppleScript path resolves the seed across all folders.
-                self._log_imap_fallback(from_account, exc)
-            # fall through to the AppleScript path
+        # Clean IMAP-APPEND paths (issue #245) — return a draft dict when
+        # they handle the request, or None to fall through to AppleScript.
+        # Both avoid Mail.app's cite-blockquote wrapper (bug FB11734014).
+        imap_result = self._try_imap_compose_draft(
+            seed=seed,
+            send_now=send_now,
+            from_account=from_account,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            subject=subject,
+            body=body,
+            attachment_paths=attachment_paths,
+        )
+        if imap_result is None:
+            imap_result = self._try_imap_reply_forward_draft(
+                seed=seed,
+                seed_id=seed_id,
+                seed_mailbox=seed_mailbox,
+                send_now=send_now,
+                from_account=from_account,
+                to=to,
+                cc=cc,
+                bcc=bcc,
+                subject=subject,
+                body=body,
+                reply_all=reply_all,
+                attachment_paths=attachment_paths,
+            )
+        if imap_result is not None:
+            return imap_result
 
         # If the caller handed us an RFC 5322 Message-ID (the form read
         # tools emit on the IMAP path per #148), resolve to Mail's

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -2581,6 +2581,7 @@ def _merge_draft_recipients(
 async def create_draft(
     reply_to: str | None = None,
     forward_of: str | None = None,
+    seed_mailbox: str | None = None,
     to: list[str] | None = None,
     cc: list[str] | None = None,
     bcc: list[str] | None = None,
@@ -2611,6 +2612,12 @@ async def create_draft(
         forward_of: Id of a message to forward. Accepts the same id forms
             as ``reply_to``. Mutually exclusive with ``reply_to``. ``to``
             is required (recipient of the forward).
+        seed_mailbox: Mailbox the reply_to/forward_of message lives in
+            (e.g. the ``mailbox`` field from its ``search_messages`` row).
+            Lets the clean save-as-draft path fetch the original directly
+            so reply/forward drafts render without the iOS quote bug —
+            supply it especially for replies to filed (non-INBOX) mail.
+            Defaults to INBOX; a miss falls back transparently.
         to/cc/bcc: Recipient lists. For reply/forward, ``None`` keeps the
             auto-derived recipients; ``[]`` explicitly clears that group;
             a populated list replaces.
@@ -2709,6 +2716,7 @@ async def create_draft(
         result = mail.create_draft(
             seed=seed_kind,
             seed_id=seed_id,
+            seed_mailbox=seed_mailbox,
             to=to,
             cc=cc,
             bcc=bcc,

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -1340,6 +1340,12 @@ class TestDraftsLifecycleIntegration:
             from_account=test_account,
         )
         draft_id = result["draft_id"]
+        # The IMAP-APPEND path (#245) returns a bare RFC Message-ID, not
+        # Mail's internal id; resolve it so the `id of d` lookup below
+        # matches (mirrors get_draft_state / delete_draft).
+        lookup_id = draft_id
+        if "@" in draft_id:
+            lookup_id = connector.find_message_by_message_id(draft_id) or draft_id
 
         try:
             # Read the draft's headers via osascript and confirm the
@@ -1352,7 +1358,7 @@ class TestDraftsLifecycleIntegration:
                         repeat with mb in mailboxes of acc
                             if name of mb contains "Drafts" then
                                 repeat with d in messages of mb
-                                    if (id of d as text) is "{draft_id}" then
+                                    if (id of d as text) is "{lookup_id}" then
                                         return sender of d
                                     end if
                                 end repeat

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -502,6 +502,60 @@ class TestDraftsLifecycleIntegration:
         finally:
             connector.delete_draft(draft_id)
 
+    def test_imap_append_message_id_round_trips_state_and_delete(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """Issue #245 / PR #293: the IMAP-APPEND draft path returns a bare
+        RFC Message-ID as draft_id (not Mail's internal numeric id).
+        get_draft_state and delete_draft must resolve that Message-ID back
+        to Mail's internal id (via find_message_by_message_id) for their
+        `whose id is` lookups — otherwise a freshly-created draft can be
+        neither read back nor deleted.
+
+        Skips if the test account has no Keychain entry (IMAP path can't be
+        exercised; the AppleScript fallback returns a numeric id which the
+        fresh/reply tests above already cover).
+        """
+        from apple_mail_mcp.exceptions import (
+            MailKeychainAccessDeniedError,
+            MailKeychainEntryNotFoundError,
+        )
+        from apple_mail_mcp.keychain import get_imap_password
+
+        try:
+            _, _, email = connector._resolve_imap_config(test_account)
+            get_imap_password(test_account, email)
+        except (
+            MailKeychainEntryNotFoundError,
+            MailKeychainAccessDeniedError,
+        ):
+            pytest.skip(
+                f"No Keychain entry for {test_account!r} — IMAP-APPEND path "
+                f"can't be exercised. Run `apple-mail-mcp setup-imap` first."
+            )
+
+        result = connector.create_draft(
+            seed="new",
+            from_account=test_account,
+            to=["test1@example.com"],
+            subject="ZZZ-AMM-INTEG-MSGID",
+            body="integration message-id round-trip body",
+        )
+        draft_id = result["draft_id"]
+        # IMAP path returns a BARE Message-ID (has @, no angle brackets).
+        assert "@" in draft_id, (
+            "expected IMAP-APPEND path (bare Message-ID draft_id); got "
+            f"{draft_id!r} — AppleScript fallback likely fired"
+        )
+        assert "<" not in draft_id and ">" not in draft_id
+
+        try:
+            state = connector.get_draft_state(draft_id)
+            assert state["subject"] == "ZZZ-AMM-INTEG-MSGID"
+            assert "integration message-id round-trip body" in state["body"]
+        finally:
+            assert connector.delete_draft(draft_id) is True
+
     def test_reply_save_preserves_threading_headers(
         self,
         connector: AppleMailConnector,

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -582,6 +582,208 @@ class TestDraftsLifecycleIntegration:
         finally:
             connector.delete_draft(draft_id)
 
+    def _append_via_imap(
+        self,
+        connector: AppleMailConnector,
+        test_account: str,
+        mailbox: str,
+        raw: bytes,
+    ) -> None:
+        """APPEND a raw RFC 822 message to ``mailbox`` over IMAP (helper for
+        the #293 reply/forward clean-path tests). Caller creates the
+        mailbox and handles cleanup."""
+        from imapclient import IMAPClient
+
+        from apple_mail_mcp.keychain import get_imap_password
+
+        host, port, email = connector._resolve_imap_config(test_account)
+        pw = get_imap_password(test_account, email)
+        client = IMAPClient(host, port=port, ssl=True, timeout=30)
+        client.login(email, pw)
+        try:
+            client.append(mailbox, raw, flags=[])
+        finally:
+            client.logout()
+
+    def _skip_without_keychain(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        from apple_mail_mcp.exceptions import (
+            MailKeychainAccessDeniedError,
+            MailKeychainEntryNotFoundError,
+        )
+        from apple_mail_mcp.keychain import get_imap_password
+
+        try:
+            _, _, email = connector._resolve_imap_config(test_account)
+            get_imap_password(test_account, email)
+        except (
+            MailKeychainEntryNotFoundError,
+            MailKeychainAccessDeniedError,
+        ):
+            pytest.skip(
+                f"No Keychain entry for {test_account!r} — IMAP path can't "
+                f"be exercised. Run `apple-mail-mcp setup-imap` first."
+            )
+
+    def test_fetch_raw_message_happy_and_folder_miss(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """#293: ImapConnector.fetch_raw_message returns a message's raw RFC
+        822 bytes when found in the given folder, and raises
+        MailMessageNotFoundError when the folder doesn't contain it (so the
+        reply/forward orchestrator can fall back to AppleScript). Exercises
+        the real IMAP SEARCH/FETCH boundary the unit tests mock out.
+        """
+        import uuid as _uuid
+        from datetime import datetime, timezone
+        from email.utils import format_datetime
+
+        from apple_mail_mcp.exceptions import MailMessageNotFoundError
+        from apple_mail_mcp.imap_connector import ImapConnector
+        from apple_mail_mcp.keychain import get_imap_password
+
+        self._skip_without_keychain(connector, test_account)
+
+        suffix = _uuid.uuid4().hex[:8]
+        src = f"ZZZ-AMM-FETCHRAW-{suffix}"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+        host, port, email = connector._resolve_imap_config(test_account)
+        pw = get_imap_password(test_account, email)
+
+        assert connector.create_mailbox(account=test_account, name=src)
+        try:
+            now = format_datetime(datetime.now(tz=timezone.utc))
+            raw = (
+                f"From: sender@apple-mail-mcp-test.invalid\r\n"
+                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"Subject: AMM #293 fetch-raw test\r\n"
+                f"Date: {now}\r\n"
+                f"Message-ID: <{msg_id_local}>\r\n"
+                f"\r\n"
+                f"raw fetch body\r\n"
+            ).encode()
+            self._append_via_imap(connector, test_account, src, raw)
+
+            imap = ImapConnector(host, port, email, pw)
+
+            # Happy path: present in src.
+            fetched = imap.fetch_raw_message(msg_id_local, src)
+            assert b"AMM #293 fetch-raw test" in fetched
+            assert msg_id_local.encode() in fetched
+
+            # Folder-miss: the same id is not in INBOX -> raises so the
+            # orchestrator can fall back to AppleScript.
+            with pytest.raises(MailMessageNotFoundError):
+                imap.fetch_raw_message(msg_id_local, "INBOX")
+        finally:
+            try:
+                connector.delete_mailbox(
+                    account=test_account, name=src, delete_messages=True
+                )
+            except Exception:
+                pass
+
+    def test_reply_via_imap_append_is_clean_and_threaded(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """#293 / #292: a reply save-as-draft with a seed_mailbox goes
+        through the clean IMAP-APPEND path (no iOS cite-blockquote): it
+        fetches the original over IMAP, rebuilds a text/plain reply with a
+        quoted original + threading headers, and APPENDs to Drafts. The
+        IMAP path returns a bare RFC Message-ID as draft_id (the AppleScript
+        fallback would return a numeric id), so that shape proves the clean
+        path fired. Verifies In-Reply-To, Re: subject, and the quoted body.
+        """
+        import time as _time
+        import uuid as _uuid
+        from datetime import datetime, timezone
+        from email.utils import format_datetime
+
+        self._skip_without_keychain(connector, test_account)
+
+        suffix = _uuid.uuid4().hex[:8]
+        src = f"ZZZ-AMM-REPLYSRC-{suffix}"
+        orig_id = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+
+        assert connector.create_mailbox(account=test_account, name=src)
+        draft_id = ""
+        try:
+            now = format_datetime(datetime.now(tz=timezone.utc))
+            raw = (
+                f"From: Ada Original <ada@apple-mail-mcp-test.invalid>\r\n"
+                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"Subject: AMM 293 original subject\r\n"
+                f"Date: {now}\r\n"
+                f"Message-ID: <{orig_id}>\r\n"
+                f"\r\n"
+                f"This is the original message body.\r\n"
+            ).encode()
+            self._append_via_imap(connector, test_account, src, raw)
+
+            result = connector.create_draft(
+                seed="reply",
+                seed_id=orig_id,
+                seed_mailbox=src,
+                from_account=test_account,
+                body="ZZZ-AMM-293-REPLY-BODY",
+            )
+            draft_id = result["draft_id"]
+
+            # Clean IMAP-APPEND path returns a BARE RFC Message-ID; the
+            # AppleScript fallback would have returned a numeric id.
+            assert "@" in draft_id and "<" not in draft_id, (
+                f"expected IMAP clean-path draft_id (bare Message-ID); got "
+                f"{draft_id!r} — AppleScript fallback likely fired"
+            )
+
+            # Mail.app may lag picking up the APPENDed draft; poll briefly.
+            state = None
+            for _ in range(10):
+                try:
+                    state = connector.get_draft_state(draft_id)
+                    break
+                except Exception:
+                    _time.sleep(3)
+            assert state is not None, "draft never became readable within 30s"
+
+            assert state["in_reply_to"], "reply must carry In-Reply-To"
+            assert orig_id in state["in_reply_to"], (
+                f"In-Reply-To should reference the original; got "
+                f"{state['in_reply_to']!r}"
+            )
+            assert state["subject"].startswith("Re:"), (
+                f"expected Re: prefix; got {state['subject']!r}"
+            )
+            # Clean reply rebuild: user's new text on top, an attribution
+            # line, then the original carried as a quoted reply (NOT a
+            # cite-blockquote). The literal "> " markers are normalised away
+            # by Mail.app's plain-text `content` read-back; the pure builder
+            # unit tests assert the "> " quoting directly. Here we verify the
+            # round-trip-stable structure.
+            body = state["body"]
+            assert "ZZZ-AMM-293-REPLY-BODY" in body
+            assert "wrote:" in body, "reply should carry an attribution line"
+            assert "This is the original message body." in body, (
+                f"original must be quoted into the reply; body was {body!r}"
+            )
+            assert (
+                body.index("ZZZ-AMM-293-REPLY-BODY")
+                < body.index("This is the original message body.")
+            ), "user's new text should sit above the quoted original"
+        finally:
+            if draft_id:
+                try:
+                    connector.delete_draft(draft_id)
+                except Exception:
+                    pass
+            try:
+                connector.delete_mailbox(
+                    account=test_account, name=src, delete_messages=True
+                )
+            except Exception:
+                pass
+
     def test_attachment_extraction_round_trip(
         self,
         connector: AppleMailConnector,

--- a/tests/unit/test_draft_builder.py
+++ b/tests/unit/test_draft_builder.py
@@ -88,3 +88,164 @@ def test_sanitizes_header_injection_chars():
     assert msg["From"] == "AliceSmith <me@x.com>"
     assert msg["Bcc"] is None
     assert msg["X-Injected"] is None
+
+
+# --- Reply/forward extensions (issue #245 follow-up) ---------------------
+
+from apple_mail_mcp.draft_builder import (  # noqa: E402
+    build_forward_body,
+    build_reply_body,
+    derive_reply_recipients,
+    forward_subject,
+    reply_subject,
+)
+
+
+def test_threading_headers_and_no_blockquote():
+    msgid, raw = build_draft_mime(
+        sender="email@fmasi.eu",
+        to=["lazar@hadleigh.co.uk"],
+        subject="Re: Flat 9 Constable House",
+        body="Hi Lazar,\n\n> quoted line",
+        in_reply_to="<orig@mail.example.com>",
+        references=["<root@x>", "<orig@mail.example.com>"],
+    )
+    text = raw.decode("utf-8")
+    assert "blockquote" not in text.lower()
+    msg = email.message_from_bytes(raw, policy=policy.default)
+    assert msg["In-Reply-To"] == "<orig@mail.example.com>"
+    assert msg["References"] == "<root@x> <orig@mail.example.com>"
+    assert msg.get_content_type() == "text/plain"
+    assert msgid != "<orig@mail.example.com>"
+
+
+def test_forwarded_attachments_travel_with_draft():
+    _msgid, raw = build_draft_mime(
+        sender="email@fmasi.eu",
+        to=["someone@example.com"],
+        subject="Fwd: Statement",
+        body="See attached.",
+        forwarded_attachments=[("statement.pdf", "application", "pdf", b"%PDF-1.4 fake")],
+    )
+    msg = email.message_from_bytes(raw, policy=policy.default)
+    names = [p.get_filename() for p in msg.iter_attachments()]
+    assert "statement.pdf" in names
+    att = next(p for p in msg.iter_attachments() if p.get_filename() == "statement.pdf")
+    assert att.get_content_type() == "application/pdf"
+    assert att.get_payload(decode=True) == b"%PDF-1.4 fake"
+
+
+def test_reply_subject_no_double_prefix():
+    assert reply_subject("Flat 9") == "Re: Flat 9"
+    assert reply_subject("Re: Flat 9") == "Re: Flat 9"
+    assert reply_subject("re: flat 9") == "re: flat 9"
+    assert reply_subject("") == "Re:"
+
+
+def test_forward_subject_no_double_prefix():
+    assert forward_subject("Flat 9") == "Fwd: Flat 9"
+    assert forward_subject("Fwd: Flat 9") == "Fwd: Flat 9"
+    assert forward_subject("FW: Flat 9") == "FW: Flat 9"
+
+
+def test_derive_reply_recipients_simple():
+    to, cc = derive_reply_recipients(
+        from_header="Lazar <lazar@hadleigh.co.uk>",
+        to_header="email@fmasi.eu, someone@else.com",
+        cc_header="cc@x.com",
+        self_addresses=["email@fmasi.eu"],
+        reply_all=False,
+    )
+    assert to == ["Lazar <lazar@hadleigh.co.uk>"]
+    assert cc == []
+
+
+def test_derive_reply_all_excludes_self_and_primary():
+    to, cc = derive_reply_recipients(
+        from_header="Lazar <lazar@hadleigh.co.uk>",
+        to_header="email@fmasi.eu, Bob <bob@x.com>",
+        cc_header="lazar@hadleigh.co.uk, carol@y.com",
+        self_addresses=["email@fmasi.eu"],
+        reply_all=True,
+    )
+    assert to == ["Lazar <lazar@hadleigh.co.uk>"]
+    cc_emails = cc
+    # self excluded, primary (lazar) excluded, the rest kept once
+    assert any("bob@x.com" in c for c in cc_emails)
+    assert any("carol@y.com" in c for c in cc_emails)
+    assert not any("email@fmasi.eu" in c for c in cc_emails)
+    assert not any("lazar@hadleigh.co.uk" in c for c in cc_emails)
+
+
+def test_reply_to_overrides_from():
+    to, _cc = derive_reply_recipients(
+        from_header="noreply@bot.com",
+        reply_to_header="Real Person <real@person.com>",
+    )
+    assert to == ["Real Person <real@person.com>"]
+
+
+def test_build_reply_body_quotes_original():
+    out = build_reply_body(
+        new_body="Thanks Lazar.",
+        original_from="Lazar <lazar@hadleigh.co.uk>",
+        original_date="29 May 2026 14:10",
+        original_text="Hi Frederic,\n\nConfirming the invoice.",
+    )
+    assert out.startswith("Thanks Lazar.")
+    assert "On 29 May 2026 14:10, Lazar <lazar@hadleigh.co.uk> wrote:" in out
+    assert "> Hi Frederic," in out
+    assert ">\n" in out  # blank original line quoted as bare ">"
+    assert "> Confirming the invoice." in out
+
+
+def test_build_forward_body_has_header_block():
+    out = build_forward_body(
+        new_body="FYI",
+        original_from="Lazar <lazar@hadleigh.co.uk>",
+        original_date="29 May 2026 14:10",
+        original_subject="Flat 9",
+        original_to="email@fmasi.eu",
+        original_text="Body here.",
+    )
+    assert out.startswith("FYI")
+    assert "---------- Forwarded message ----------" in out
+    assert "From: Lazar <lazar@hadleigh.co.uk>" in out
+    assert "Subject: Flat 9" in out
+    assert "Body here." in out
+
+
+def test_parse_original_message_extracts_fields_and_attachment():
+    from apple_mail_mcp.draft_builder import build_draft_mime, parse_original_message
+    # Build a representative original (with an attachment) and round-trip it.
+    _mid, raw = build_draft_mime(
+        sender="Lazar <lazar@hadleigh.co.uk>",
+        to=["email@fmasi.eu", "Bob <bob@x.com>"],
+        subject="Flat 9 Constable House",
+        body="Hi Frederic,\n\nConfirming the invoice.",
+        cc=["carol@y.com"],
+        in_reply_to="<prev@x>",
+        references=["<root@x>", "<prev@x>"],
+        forwarded_attachments=[("inv.pdf", "application", "pdf", b"%PDF data")],
+    )
+    orig = parse_original_message(raw)
+    assert "lazar@hadleigh.co.uk" in orig.from_header
+    assert "email@fmasi.eu" in orig.to_header
+    assert "carol@y.com" in orig.cc_header
+    assert orig.subject == "Flat 9 Constable House"
+    assert orig.references == ["<root@x>", "<prev@x>"]
+    assert "Confirming the invoice." in orig.text
+    assert any(a[0] == "inv.pdf" and a[3] == b"%PDF data" for a in orig.attachments)
+
+
+def test_parse_original_html_only_falls_back_to_text():
+    from email.message import EmailMessage
+
+    from apple_mail_mcp.draft_builder import parse_original_message
+    m = EmailMessage()
+    m["From"] = "x@y.com"
+    m["Subject"] = "HTML only"
+    m.set_content("<p>Hello <b>there</b></p>", subtype="html")
+    orig = parse_original_message(m.as_bytes())
+    assert "Hello" in orig.text and "there" in orig.text
+    assert "<p>" not in orig.text

--- a/tests/unit/test_drafts.py
+++ b/tests/unit/test_drafts.py
@@ -19,6 +19,19 @@ class TestValidateDraftId:
 
         _validate_draft_id("abc_123-xyz")
 
+    def test_accepts_bare_rfc_message_id(self):
+        from apple_mail_mcp.drafts import _validate_draft_id
+
+        # IMAP-APPEND drafts (#245) return the RFC 5322 Message-ID as the
+        # draft_id; the bare (bracket-stripped) form must validate.
+        _validate_draft_id("178031450722.27521.4532321693417753548@frederics-mbp.lan")
+
+    def test_accepts_message_id_with_plus_and_equals(self):
+        from apple_mail_mcp.drafts import _validate_draft_id
+
+        # atext allows + and = ; real-world Message-IDs use them.
+        _validate_draft_id("a+b=c.123@mail.example.com")
+
     def test_rejects_path_traversal(self):
         from apple_mail_mcp.drafts import _validate_draft_id
 
@@ -47,7 +60,22 @@ class TestValidateDraftId:
         from apple_mail_mcp.drafts import _validate_draft_id
 
         with pytest.raises(MailDraftInvalidIdError):
-            _validate_draft_id("a" * 129)
+            _validate_draft_id("a" * 256)
+
+    def test_rejects_backslash(self):
+        from apple_mail_mcp.drafts import _validate_draft_id
+
+        # No path separators, even after widening for Message-IDs.
+        with pytest.raises(MailDraftInvalidIdError):
+            _validate_draft_id("foo\\bar")
+
+    def test_rejects_angle_brackets(self):
+        from apple_mail_mcp.drafts import _validate_draft_id
+
+        # draft_id is the BARE Message-ID; the bracketed form is normalized
+        # away at the boundary and must not validate here.
+        with pytest.raises(MailDraftInvalidIdError):
+            _validate_draft_id("<abc@host>")
 
 
 class TestDefaultRoot:

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -6912,3 +6912,157 @@ class TestCreateDraftImapAppend:
         mock_imap_cls.return_value.append_draft.assert_called_once()
         mock_applescript.assert_called_once()
         assert result["draft_id"] == "123"
+
+
+class TestCreateReplyForwardDraftViaImap:
+    """Issue #245 follow-up: reply/forward save-as-draft via IMAP APPEND of
+    a hand-built clean RFC822 message (no Mail.app cite-blockquote), with
+    threading headers and (for forward) the original's attachments."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @staticmethod
+    def _original(*, with_attachment: bool = False) -> tuple[str, bytes]:
+        from apple_mail_mcp.draft_builder import build_draft_mime
+        fwd = (
+            [("invoice.pdf", "application", "pdf", b"%PDF data")]
+            if with_attachment
+            else None
+        )
+        mid, raw = build_draft_mime(
+            sender="Lazar <lazar@hadleigh.co.uk>",
+            to=["email@fmasi.eu", "Bob <bob@x.com>"],
+            subject="Flat 9 Constable House",
+            body="Hi Frederic,\n\nConfirming the invoice.",
+            cc=["carol@y.com"],
+            forwarded_attachments=fwd,
+        )
+        return mid, raw
+
+    def _patches(self, connector, mock_imap):
+        from unittest.mock import patch
+        return [
+            patch("apple_mail_mcp.mail_connector.ImapConnector",
+                  return_value=mock_imap),
+            patch.object(AppleMailConnector, "_get_imap_password_with_fallback",
+                         return_value="pw"),
+            patch.object(AppleMailConnector, "_resolve_imap_config",
+                         return_value=("h", 993, "email@fmasi.eu")),
+            patch.object(AppleMailConnector, "_resolve_account_to_sender",
+                         return_value="email@fmasi.eu"),
+        ]
+
+    def _run(self, connector, mock_imap, **kw):
+        import contextlib
+        captured: dict = {}
+        mock_imap.append_draft.side_effect = (
+            lambda raw: captured.setdefault("raw", raw)
+        )
+        with contextlib.ExitStack() as stack:
+            for p in self._patches(connector, mock_imap):
+                stack.enter_context(p)
+            result = connector.create_draft(**kw)
+        return result, captured.get("raw")
+
+    def test_reply_builds_clean_threaded_quoted_draft(self, connector):
+        import email as _email
+        from email import policy as _policy
+        orig_mid, orig_raw = self._original()
+        mock_imap = MagicMock()
+        mock_imap.fetch_raw_message.return_value = orig_raw
+
+        result, raw = self._run(
+            connector, mock_imap,
+            seed="reply", seed_id=orig_mid, from_account="iCloud",
+            body="Thanks Lazar.",
+        )
+        assert "blockquote" not in raw.decode().lower()
+        msg = _email.message_from_bytes(raw, policy=_policy.default)
+        assert msg["In-Reply-To"] == orig_mid
+        assert msg["Subject"] == "Re: Flat 9 Constable House"
+        assert msg["To"] == "Lazar <lazar@hadleigh.co.uk>"
+        body = msg.get_content()
+        assert body.startswith("Thanks Lazar.")
+        assert "> Hi Frederic," in body
+        assert result["draft_id"] and result["draft_id"] != orig_mid
+        mock_imap.fetch_raw_message.assert_called_once_with(orig_mid, "INBOX")
+
+    def test_reply_all_ccs_others_minus_self(self, connector):
+        import email as _email
+        from email import policy as _policy
+        orig_mid, orig_raw = self._original()
+        mock_imap = MagicMock()
+        mock_imap.fetch_raw_message.return_value = orig_raw
+        _result, raw = self._run(
+            connector, mock_imap,
+            seed="reply", seed_id=orig_mid, from_account="iCloud",
+            body="Thanks all.", reply_all=True,
+        )
+        msg = _email.message_from_bytes(raw, policy=_policy.default)
+        cc = msg["Cc"] or ""
+        assert "bob@x.com" in cc and "carol@y.com" in cc
+        assert "email@fmasi.eu" not in cc  # self excluded
+
+    def test_forward_carries_attachment_and_seed_mailbox(self, connector):
+        import email as _email
+        from email import policy as _policy
+        orig_mid, orig_raw = self._original(with_attachment=True)
+        mock_imap = MagicMock()
+        mock_imap.fetch_raw_message.return_value = orig_raw
+        _result, raw = self._run(
+            connector, mock_imap,
+            seed="forward", seed_id=orig_mid, seed_mailbox="Finance/Constable House",
+            from_account="iCloud", to=["colleague@firm.com"], body="FYI",
+        )
+        msg = _email.message_from_bytes(raw, policy=_policy.default)
+        assert msg["Subject"] == "Fwd: Flat 9 Constable House"
+        names = [p.get_filename() for p in msg.iter_attachments()]
+        assert "invoice.pdf" in names
+        body_part = msg.get_body(preferencelist=("plain",))
+        assert "---------- Forwarded message ----------" in body_part.get_content()
+        mock_imap.fetch_raw_message.assert_called_once_with(
+            orig_mid, "Finance/Constable House"
+        )
+
+    def test_numeric_seed_id_skips_imap_reply_path(self, connector):
+        from unittest.mock import patch
+
+        class _Stop(Exception):
+            pass
+
+        # A numeric seed_id must NOT take the IMAP reply path; it proceeds
+        # to the AppleScript path, whose first step is
+        # _maybe_resolve_rfc_seed_id (used here as a tripwire).
+        with (
+            patch.object(AppleMailConnector,
+                         "_create_reply_forward_draft_via_imap") as m,
+            patch.object(AppleMailConnector, "_maybe_resolve_rfc_seed_id",
+                         side_effect=_Stop),
+        ):
+            with pytest.raises(_Stop):
+                connector.create_draft(
+                    seed="reply", seed_id="12345", from_account="iCloud", body="x",
+                )
+            m.assert_not_called()
+
+    def test_missing_original_falls_back_to_applescript(self, connector):
+        from unittest.mock import patch
+        with (
+            patch.object(AppleMailConnector,
+                         "_create_reply_forward_draft_via_imap",
+                         side_effect=MailMessageNotFoundError("not here")),
+            patch.object(AppleMailConnector, "_maybe_resolve_rfc_seed_id",
+                         return_value="999"),
+            patch.object(AppleMailConnector, "_run_applescript",
+                         return_value="999"),
+            patch.object(AppleMailConnector, "_resolve_account_to_sender",
+                         return_value="email@fmasi.eu"),
+        ):
+            # Must NOT raise — falls through to the AppleScript path.
+            result = connector.create_draft(
+                seed="reply", seed_id="<x@y.com>", from_account="iCloud",
+                body="hi",
+            )
+            assert "draft_id" in result

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -5055,6 +5055,39 @@ class TestDeleteDraft:
         mock_run.return_value = "OK\n"
         assert connector.delete_draft("160991") is True
 
+    @patch.object(
+        AppleMailConnector, "find_message_by_message_id", return_value="160991"
+    )
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_delete_draft_resolves_rfc_message_id(
+        self,
+        mock_run: MagicMock,
+        mock_find: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        # IMAP-APPEND drafts (#245) are identified by a bare RFC Message-ID.
+        # delete_draft must resolve it to Mail's internal id first, then
+        # delete by that internal id (whose `id` property).
+        mock_run.return_value = "OK"
+        assert connector.delete_draft("abc.123@host") is True
+        mock_find.assert_called_once_with("abc.123@host")
+        script = mock_run.call_args[0][0]
+        assert 'whose id is "160991"' in script
+
+    @patch.object(
+        AppleMailConnector, "find_message_by_message_id", return_value=None
+    )
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_delete_draft_unresolved_rfc_message_id_raises(
+        self,
+        mock_run: MagicMock,
+        mock_find: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        with pytest.raises(MailDraftNotFoundError):
+            connector.delete_draft("missing@host")
+        mock_run.assert_not_called()
+
 
 class TestFindMessageByMessageId:
     """Tests for AppleMailConnector.find_message_by_message_id."""
@@ -5212,6 +5245,44 @@ class TestGetDraftState:
         mock_run.return_value = '{"found":false}'
         with pytest.raises(MailDraftNotFoundError):
             connector.get_draft_state("999999")
+
+    @patch.object(
+        AppleMailConnector, "find_message_by_message_id", return_value="160991"
+    )
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolves_rfc_message_id(
+        self,
+        mock_run: MagicMock,
+        mock_find: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        # IMAP-APPEND drafts (#245) are keyed by a bare RFC Message-ID;
+        # update_draft's get_draft_state must resolve it to Mail's internal
+        # id before the AppleScript scan (which matches on `id`, not
+        # `message id`).
+        mock_run.return_value = (
+            '{"found":true,"draft_id":"160991","to":[],"cc":[],"bcc":[],'
+            '"subject":"","body":"","in_reply_to":"","references":"",'
+            '"attachment_names":[]}'
+        )
+        connector.get_draft_state("abc.123@host")
+        mock_find.assert_called_once_with("abc.123@host")
+        script = mock_run.call_args[0][0]
+        assert 'set targetId to "160991"' in script
+
+    @patch.object(
+        AppleMailConnector, "find_message_by_message_id", return_value=None
+    )
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_unresolved_rfc_message_id_raises(
+        self,
+        mock_run: MagicMock,
+        mock_find: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        with pytest.raises(MailDraftNotFoundError):
+            connector.get_draft_state("missing@host")
+        mock_run.assert_not_called()
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_strips_internal_found_flag(
@@ -6877,6 +6948,40 @@ class TestCreateDraftImapAppend:
         assert b"Fred <email@fmasi.eu>" in raw
         # draft_id is the generated RFC Message-ID.
         assert "@" in result["draft_id"]
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password", return_value="pw")
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_imap_config",
+        return_value=("imap.host", 993, "appleid@fmasi.eu"),
+    )
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_account_to_sender",
+        return_value="Fred <email@fmasi.eu>",
+    )
+    def test_returned_draft_id_is_bare_and_valid(
+        self, _sender, _cfg, _pw, mock_imap_cls, mock_applescript
+    ):
+        # The returned draft_id must be the BARE Message-ID (no angle
+        # brackets) so it matches what read tools / Mail.app store and so
+        # it round-trips through delete_draft / update_draft validation.
+        from apple_mail_mcp.drafts import _validate_draft_id
+
+        conn = self._conn()
+        result = conn.create_draft(
+            seed="new",
+            to=["lazar@hadleigh.co.uk"],
+            subject="Re: Flat 9 Constable House",
+            body="Hi Lazar,",
+            from_account="iCloud",
+            send_now=False,
+        )
+        draft_id = result["draft_id"]
+        assert "<" not in draft_id and ">" not in draft_id
+        _validate_draft_id(draft_id)  # must not raise
 
     @patch.object(AppleMailConnector, "_run_applescript", return_value="123")
     @patch("apple_mail_mcp.mail_connector.ImapConnector")

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2965,6 +2965,35 @@ class TestCreateDraftTool:
         assert seed.reply_all is True
 
     @pytest.mark.asyncio
+    async def test_reply_via_imap_rfc_id_succeeds_and_persists_seed(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        # Regression (#245 / PR #293): the IMAP-APPEND reply path returns a
+        # bare RFC Message-ID as draft_id. Persisting the seed must NOT
+        # reject that id — previously _persist_draft_seed raised
+        # MailDraftInvalidIdError AFTER the draft was created, so the tool
+        # reported success:false despite a real draft on the server.
+        from apple_mail_mcp.drafts import DraftStateStore
+        from apple_mail_mcp.server import create_draft
+
+        rfc_id = "178031450722.27521.4532321693417753548@frederics-mbp.lan"
+        mock_mail.create_draft.return_value = {
+            "draft_id": rfc_id, "sent_message_id": ""
+        }
+        result = await create_draft(
+            reply_to="orig.abc@hadleigh.co.uk", body="thanks"
+        )
+        assert result["success"] is True
+        assert result["draft_id"] == rfc_id
+        seed = DraftStateStore().get_seed(rfc_id)
+        assert seed is not None
+        assert seed.seed_kind == "reply"
+        assert seed.seed_id == "orig.abc@hadleigh.co.uk"
+
+    @pytest.mark.asyncio
     async def test_draft_state_not_persisted_for_send_now(
         self,
         isolated_drafts: Any,


### PR DESCRIPTION
Fixes #292. Follow-up to #245 / #246.

## Problem

#246 made **compose** drafts (`seed="new"`) clean by IMAP-APPENDing a
hand-built RFC 822 message instead of Mail.app's AppleScript `content`
setter (which wraps the body in an `Apple-Mail-URLShareWrapper
<blockquote type="cite">`, rendered as a quote on iOS — FB11734014).
**Reply** and **forward** save-as-draft still went through AppleScript and
kept the bug.

## What this does

Extends the clean IMAP-APPEND path to `seed="reply"` and `seed="forward"`
save-as-draft. `send_now=True` still uses AppleScript (clean SMTP send is a
separate concern).

Because AppleScript normally auto-derives the quote/recipients/subject/
threading, the clean path rebuilds them:

- **Locate + fetch** the original's raw RFC 822 by Message-ID over IMAP
  (`ImapConnector.fetch_raw_message`) from a new optional **`seed_mailbox`**
  (default `INBOX`). The caller passes the message's folder (the `mailbox`
  field from its `search_messages` row) so replies to *filed* mail work too.
- **Parse** it (`draft_builder.parse_original_message`) — headers, plain
  body (HTML falls back to a crude text render), and attachment payloads.
- **Rebuild** a clean `text/plain` draft:
  - reply: new text, then `On <date>, <from> wrote:`, then the original
    `> `-quoted;
  - forward: new text, then a `---------- Forwarded message ----------`
    header block, then the original — carrying the original's attachments;
  - `Re:`/`Fwd:` subject without stacking a second prefix;
  - `In-Reply-To` = original Message-ID, `References` = original chain +
    original Message-ID;
  - reply-all Cc = original To+Cc minus self and the primary recipient.
- Explicit `to`/`cc`/`bcc`/`subject` still override the derived values.
- **Graceful fallback** to the AppleScript path on any IMAP-degradation
  signal *or* a folder-guess miss (`MailMessageNotFoundError`) — AppleScript
  resolves the seed across all folders, so non-INBOX replies without a
  `seed_mailbox` hint still work (just via the old path).

## Design notes

The hard logic — MIME building, recipient/subject derivation, plain-text
quoting, and raw-message parsing — lives as **pure functions** in
`draft_builder` (no Mail.app, no IMAP), unit-tested in isolation. The
connector method just orchestrates fetch → parse → build → APPEND.

## Testing

- `test_draft_builder.py`: threading headers, forwarded attachments,
  `Re:`/`Fwd:` no-double-prefix, reply/reply-all recipient derivation
  (self + primary excluded), `> ` quoting, forward header block, raw parse
  incl. HTML-only fallback.
- `test_mail_connector.py::TestCreateReplyForwardDraftViaImap`: reply builds
  a clean threaded quoted draft; reply-all Cc; forward carries the
  attachment and honors `seed_mailbox`; numeric seed id skips the IMAP path;
  missing original falls back to AppleScript.
- Full unit suite green; ruff clean.
- **Verified end-to-end on a live iCloud account**: a reply draft APPENDs to
  Drafts with no blockquote, correct `In-Reply-To`/`References`, a `Re:`
  subject, and a `> `-quoted original (test draft cleaned up afterward).

## Public surface

`create_draft` (tool + connector) gains an optional `seed_mailbox`; no
behavior change for existing callers.
