### PR TITLE
release: v0.9.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Mail via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.8.2 | **Tests:** 1027 unit / 19 e2e / 37 integration | **Coverage:** 92%
+**Version:** v0.9.0 | **Tests:** 1210 unit / 19 e2e / 37 integration | **Coverage:** 92%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-06-01
+
+Minor release. The theme is **hardening the destructive-operation surface and the IMAP fast path**: explicit user-confirmation gates now front the remaining unguarded deletes and rule mutations, `save_attachments` is bounded against disk-fill, a contributor-reported IMAP CRLF command-injection vector is closed, and a STRIDE threat model now documents the trust boundaries those defenses sit on. Alongside the security work: an opt-in read-only server mode, a new recency search filter, several IMAP correctness fixes (three of them contributor-authored), and a full documentation reconciliation to the current 23-tool surface.
+
+Thanks to external contributors [@fmasi](https://github.com/fmasi), [@allenpan05](https://github.com/allenpan05), and [@jason21wc](https://github.com/jason21wc) for the fixes credited below.
+
+### Added
+
+**Read-only server mode + MCP tool annotations (#217):** Tools now carry MCP annotations (`readOnlyHint` / `destructiveHint` / `idempotentHint`) so clients can reason about each tool's effect before calling it. A new `--read-only` flag starts a split server that exposes only the non-mutating tools — a least-privilege deployment for "let the model read my mail but never change it."
+
+**`received_within_hours` search filter (#230):** `search_messages` gains a relative-recency filter (e.g. "messages in the last 6 hours") that compiles to an AppleScript date comparison server-side, avoiding a fetch-all-then-filter pass.
+
+### Changed
+
+**Destructive operations now require confirmation (#239, #222):** `delete_messages` and `create_rule` (when the rule carries a dangerous action — `delete` / `forward_to` / `move_to` / `copy_to`) now route through the `_elicit_confirmation` gate, joining the deletes and rule/draft mutations already gated. As with the existing gates, the flow fails closed: an MCP client that can't elicit gets a typed `confirmation_required` error rather than a silent execution.
+
+**`save_attachments` byte caps (#236):** Attachment saves are now bounded by per-file and total byte caps (a pre-write check plus a post-write net), defending against a malicious/oversized-attachment disk-fill DoS. The tool return now includes a `rejected` list naming any attachments skipped for exceeding a cap. Caps are configurable via `APPLE_MAIL_MCP_MAX_ATTACHMENT_BYTES` / `APPLE_MAIL_MCP_MAX_TOTAL_ATTACHMENT_BYTES`.
+
+**Complexity and type-check CI gates are now blocking (#274):** The cyclomatic-complexity gate (CC ≤ 20) and `mypy --strict` step in PR CI lost their `continue-on-error` — a complexity or type regression now fails the build instead of being advisory. (A CC-25 regression had previously merged undetected because the gate was non-blocking.)
+
+### Fixed
+
+**IMAP multipart attachment enumeration drops attachments (#266, by @jason21wc):** The IMAP BODYSTRUCTURE walk failed to enumerate attachments on some multipart message shapes, so `save_attachments` / attachment listing could under-report. Fixed alongside an `rfc822`-consistency cleanup.
+
+**`_resolve_imap_config` raises `KeyError` on accounts with no IMAP server (#267, by @jason21wc):** Accounts lacking an IMAP server property (e.g. some local/POP setups) raised `KeyError` instead of degrading gracefully; the resolver now coerces the missing value and falls back cleanly.
+
+**Compose drafts created via IMAP APPEND (#245, fix #246 by @fmasi):** Creating a compose draft through Mail.app introduced an unwanted cite-blockquote wrapper. Drafts are now written via IMAP APPEND, bypassing Mail.app's compose-window mangling.
+
+**Connector timeout threaded into non-JSON AppleScript paths (#233):** The `with timeout` protection added in v0.8.2 covered only `_wrap_as_json_script` call sites; the direct-AppleScript mutation paths (`mark_as_read`, `move_messages`, `update_message`, …) now also honor the configured connector timeout, closing the gap that entry tracked.
+
+**AppleScript mailbox resolver — nested paths + Gmail custom labels (#247):** The mailbox-name resolver mishandled nested mailbox paths and Gmail custom labels; resolution now walks the hierarchy correctly.
+
+**`search_messages` iteration order + date-literal bug (#242):** AppleScript message iteration is now reversed to return newest-first as documented, and a date-literal construction bug in the filter path is fixed.
+
+**IMAP Keychain lookup tries both name and UUID forms (#243):** `setup-imap` may key the Keychain entry under either the account display name or its UUID; runtime lookup now tries both forms before falling back to AppleScript.
+
+**Stale e2e elicitation harness repaired (#257):** The `delete_mailbox` / `delete_messages` e2e tests had drifted out of sync with the elicitation gates and were silently failing; repaired, and the manual-e2e policy (CI excludes e2e; `make test-e2e` is a mandatory pre-release gate) is now documented.
+
+### Security
+
+**IMAP CRLF command injection + attachment path traversal (#254, by @allenpan05):** Closed a CRLF-injection vector where crafted input could smuggle additional IMAP protocol commands across a line boundary, plus attachment-path traversal cases. Reported and fixed by an external contributor.
+
+**Removed latent AppleScript-injection vector (#258):** Deleted the unused `parse_date_filter` helper, which built AppleScript from input without the standard escape path — dead code, but a live injection vector if ever wired up.
+
+**Threat model documented (#213):** Added `docs/guides/THREAT_MODEL.md` — a STRIDE pass across the five trust boundaries (MCP client, server process, AppleScript bridge, IMAP, on-disk user data) — and cross-linked it from the per-feature security checklist.
+
+**Release-review hardening:** The release-gate code review surfaced three pre-existing gaps (none regressions), two fixed here: (1) `create_draft`'s recipient lists now pass through the mandated `sanitize_input` → `escape_applescript_string` two-step before AppleScript interpolation, matching every other interpolation site (previously only `escape_applescript_string` was applied, so a null byte in a recipient address would reach the generated script); (2) `delete_messages` is now an account-gated operation and calls `check_test_mode_safety` when an `account` is supplied — in `MAIL_TEST_MODE` a delete aimed at a non-test account is now rejected before the connector is touched — and its success path now records to the audit trail like every other mutating tool. The third (defense-in-depth escaping of `draft_id`, which `_validate_draft_id`'s regex already makes injection-safe) is tracked as #294.
+
+### Dependencies
+
+Bumped three transitive dependencies to clear newly-disclosed advisories (the pins were unchanged since v0.8.2; only the advisories are new): `idna` 3.11 → 3.17, `starlette` 1.0.0 → 1.2.1, `urllib3` 2.6.3 → 2.7.0.
+
+### Docs
+
+**Documentation reconciled to the current surface (#220):** Major refresh of README, `ARCHITECTURE.md` (now documents the AppleScript-default + IMAP-fast-path dispatch model, dual-emit IDs, drafts lifecycle, and thread tiers), `TOOLS.md` (corrected to 23 tools, stale `get_message` examples fixed), `DEVELOPMENT.md` (rewritten as a dev-workflow guide), `APPLESCRIPT_GOTCHAS.md` (JSON-via-ASObjC patterns), `TESTING.md`, and `SECURITY.md` (reconciled with the threat model). Refreshed the blind-agent-eval baseline (#219) and the performance benchmark baseline (#216), and added the claim-by-comment convention to `CONTRIBUTING.md` (#259).
+
 ## [0.8.2] - 2026-05-20
 
 Patch release. Three substantive bug fixes — one security regression in our own gate chain, one regression introduced at v0.8.1, and one long-latent AppleEvent timeout bug surfaced by use on slow Exchange/EWS accounts. Two of the three are contributor-authored: [@fmasi](https://github.com/fmasi) reported and fixed the v0.8.1 regression they noticed within hours of release; [@allenpan05](https://github.com/allenpan05) reported and fixed the AppleEvent timeout bug. Thanks to both.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server that provides programmatic access to Apple Mail, enabling AI assistants like Claude to read, send, search, and manage emails on macOS.
 
-> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.8.2`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
+> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.9.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
 
 ## Tools (23)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-mail-mcp"
-version = "0.8.2"
+version = "0.9.0"
 description = "MCP server for Apple Mail integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_mail_mcp/__init__.py
+++ b/src/apple_mail_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Mail MCP Server
 A Model Context Protocol server for Apple Mail integration.
 """
 
-__version__ = "0.8.2"
+__version__ = "0.9.0"

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -4316,7 +4316,8 @@ class AppleMailConnector:
             if addrs is None:
                 return ""  # keep auto-derived
             list_str = ", ".join(
-                f'"{escape_applescript_string(a)}"' for a in addrs
+                f'"{escape_applescript_string(sanitize_input(a))}"'
+                for a in addrs
             )
             return f"""
                 delete (every {kind} recipient of theMessage)

--- a/src/apple_mail_mcp/security.py
+++ b/src/apple_mail_mcp/security.py
@@ -264,6 +264,7 @@ ACCOUNT_GATED_OPERATIONS = {
     "search_messages",
     "update_message",
     "create_mailbox",
+    "delete_messages",
 }
 
 SEND_OPERATIONS = {

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -1922,6 +1922,16 @@ async def delete_messages(
                 "message": "No messages to delete",
             }
 
+        # Test-mode safety: when account is provided, gate the delete
+        # against MAIL_TEST_ACCOUNT so an integration run can't delete
+        # from a real account (delete_messages is account-gated).
+        if account is not None:
+            safety_err = check_test_mode_safety(
+                "delete_messages", account=account
+            )
+            if safety_err:
+                return safety_err
+
         rate_err = check_rate_limit("delete_messages", {"count": len(message_ids)})
         if rate_err:
             return rate_err
@@ -1964,6 +1974,13 @@ async def delete_messages(
             skip_bulk_check=False,  # Enforce limit
             account=account,
             source_mailbox=source_mailbox,
+        )
+
+        operation_logger.log_operation(
+            "delete_messages",
+            {"count": count, "account": account,
+             "source_mailbox": source_mailbox, "permanent": permanent},
+            "success",
         )
 
         return {

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -5305,6 +5305,28 @@ class TestCreateDraft:
         assert "set beforeIds to" in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
+    def test_new_sanitizes_recipient_addresses(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """Recipient lists must go through the SECURITY_CHECKLIST two-step
+        (sanitize_input then escape_applescript_string) like every other
+        AppleScript interpolation — escape alone doesn't strip null bytes.
+        A null byte in an address must be stripped, not interpolated raw
+        into the generated script."""
+        mock_run.return_value = "1"
+        connector.create_draft(
+            seed="new",
+            to=["evil\x00@example.com"],
+            cc=["c\x00c@example.com"],
+            subject="hi",
+            body="x",
+        )
+        script = mock_run.call_args[0][0]
+        assert "\x00" not in script
+        assert "evil@example.com" in script
+        assert "cc@example.com" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
     def test_new_send_uses_send_block(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -324,6 +324,23 @@ class TestCheckTestModeSafety:
         assert "Gmail" in result["error"]
         assert "TestAccount" in result["error"]
 
+    def test_delete_messages_is_account_gated(self, monkeypatch: Any) -> None:
+        """delete_messages is destructive — in test mode a delete aimed at
+        a non-test account must be rejected, same as the other
+        account-gated operations."""
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+        monkeypatch.setenv("MAIL_TEST_ACCOUNT", "TestAccount")
+
+        result = check_test_mode_safety("delete_messages", account="Gmail")
+        assert result is not None
+        assert result["error_type"] == "safety_violation"
+
+        # ...and the matching account is allowed through.
+        assert (
+            check_test_mode_safety("delete_messages", account="TestAccount")
+            is None
+        )
+
     @patch("apple_mail_mcp.security.subprocess.run")
     def test_uuid_matching_test_account_returns_none(
         self, mock_run: Any, monkeypatch: Any

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2353,6 +2353,49 @@ class TestDeleteMessages:
         )
 
     @pytest.mark.asyncio
+    async def test_success_logs_audit_trail(
+        self, mock_mail: MagicMock, mock_logger: MagicMock,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        """Every mutating tool records its success on the audit trail —
+        useful for confirming a destructive op was actually invoked."""
+        mock_mail.delete_messages.return_value = 2
+        await delete_messages(
+            ["1", "2"], account="Gmail", source_mailbox="INBOX",
+            ctx=mock_ctx_accept,
+        )
+        mock_logger.log_operation.assert_called_once_with(
+            "delete_messages",
+            {"count": 2, "account": "Gmail",
+             "source_mailbox": "INBOX", "permanent": False},
+            "success",
+        )
+
+    @pytest.mark.asyncio
+    async def test_test_mode_account_gate_blocks_non_test_account(
+        self, mock_mail: MagicMock, monkeypatch: Any,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        """delete_messages is account-gated: in MAIL_TEST_MODE a delete
+        targeting an account that isn't MAIL_TEST_ACCOUNT must be blocked
+        before the connector is touched (and before the user is even
+        prompted)."""
+        monkeypatch.setattr(
+            "apple_mail_mcp.server.check_test_mode_safety",
+            lambda *a, **kw: {
+                "success": False, "error": "blocked",
+                "error_type": "safety_violation",
+            },
+        )
+        result = await delete_messages(
+            ["1"], account="RealAccount", source_mailbox="INBOX",
+            ctx=mock_ctx_accept,
+        )
+        assert result["error_type"] == "safety_violation"
+        mock_mail.delete_messages.assert_not_called()
+        mock_ctx_accept.elicit.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_empty_list_early_exit(
         self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-mcp"
-version = "0.8.2"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -803,11 +803,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]
@@ -2053,15 +2053,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]
@@ -2159,11 +2159,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## v0.9.0 — security-hardening release

Cuts the **v0.9.0** milestone (25 issues, 0 open). Theme: hardening the destructive-operation surface and the IMAP fast path. Full notes in [CHANGELOG.md](CHANGELOG.md).

### Highlights
- **Added:** opt-in `--read-only` split server + MCP tool annotations (#217); `received_within_hours` search filter (#230).
- **Changed:** confirmation gates on `delete_messages` (#239) and dangerous `create_rule` actions (#222); `save_attachments` byte caps (#236); blocking complexity/mypy CI gates (#274).
- **Fixed:** IMAP multipart attachment enumeration (#266, @jason21wc); `_resolve_imap_config` KeyError (#267, @jason21wc); compose drafts via IMAP APPEND (#246, @fmasi); connector timeout on non-JSON AppleScript paths (#233); mailbox resolver nested paths/Gmail labels (#247); search iteration + date-literal (#242); Keychain name/UUID lookup (#243); stale e2e harness (#257).
- **Security:** IMAP CRLF injection + path traversal (#254, @allenpan05); removed latent AS-injection dead code (#258); STRIDE threat model (#213).
- **Docs:** full reconciliation to the 23-tool surface (#220) + refreshed eval/benchmark baselines (#219/#216).

### Release-gate work (this branch)
The Phase 7 cumulative-diff review surfaced three pre-existing gaps (no regressions); two fixed here under TDD, one deferred:
- **F1** — `create_draft` recipients now go through `sanitize_input` + `escape_applescript_string` (was escape-only).
- **F2** — `delete_messages` is now account-gated (`check_test_mode_safety`) and logs to the audit trail on success.
- **F3** — defense-in-depth `draft_id` escaping → deferred to #294 (no live path; regex already injection-safe).

Plus three transitive-dep bumps to clear newly-disclosed CVEs (`idna`, `starlette`, `urllib3`).

### Validation
All Phase 9 gates green: version-sync ✅, parity ✅, complexity ✅, applescript-safety ✅, `make test` (1161 unit / 92% cov) ✅, **`make test-e2e` (19) ✅**, dependency scan ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)