### PR TITLE
fix(#268): version-aware milestone sort in /merge-and-status

### DIFF
--- a/.claude/commands/merge-and-status.md
+++ b/.claude/commands/merge-and-status.md
@@ -47,9 +47,15 @@ Merge the current PR, pull main, surface any open contributor PRs and untriaged 
    - If the same author appears multiple times, group them together in the table.
    - If zero rows, say "No untriaged contributor issues" for positive confirmation.
 
-7. **Determine the current milestone.** Look at the most recent closed PR's milestone, or find the earliest open milestone:
+7. **Determine the current milestone.** Look at the most recent closed PR's milestone, or find the earliest open milestone **by semantic version**. Sort on the numeric version tuple, not the title string — a lexical sort puts `v0.10.0` before `v0.9.0` (`'1' < '9'` at the third character). The `test(...)` guard sorts any non-`vX.Y.Z` title last so a future named milestone doesn't crash `tonumber`:
    ```bash
-   gh api repos/:owner/:repo/milestones --jq 'sort_by(.due_on // .title) | map(select(.state == "open")) | .[0].title'
+   gh api repos/:owner/:repo/milestones \
+     --jq 'map(select(.state == "open"))
+           | sort_by(.title
+                     | if test("^v?[0-9]+(\\.[0-9]+)*$")
+                       then (ltrimstr("v") | split(".") | map(tonumber))
+                       else [999999] end)
+           | .[0].title'
    ```
 
 8. **List open issues** on that milestone:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,11 @@ jobs:
 
       - name: Unit tests
         run: uv run pytest tests/ -m "not integration and not e2e and not benchmark" -v --cov=apple_mail_mcp --cov-report=term-missing --cov-fail-under=90
-        timeout-minutes: 5
+        # Suite is ~10s locally but ~5min in CI: a few IMAP error-path unit
+        # tests stall ~30s each on a real socket timeout that's instant
+        # locally. Bumped 5->10 to stop borderline flakes; the real fix
+        # (mock the socket) is tracked in #298.
+        timeout-minutes: 10
 
       - name: Complexity check
         run: ./scripts/check_complexity.sh


### PR DESCRIPTION
Closes #268

## Problem
`/merge-and-status` step 7 determined the current milestone with `sort_by(.due_on // .title)`. Our milestones never set `due_on`, so it fell back to a **lexical title** sort — which orders `v0.10.0` before `v0.9.0` (`'1' < '9'` at the third character). The command reported the wrong milestone as current (observed live: it surfaced v0.10.0 while v0.9.x was the active line).

## Fix
Sort on the numeric version tuple instead:

```bash
gh api repos/:owner/:repo/milestones \
  --jq 'map(select(.state == "open"))
        | sort_by(.title
                  | if test("^v?[0-9]+(\\.[0-9]+)*$")
                    then (ltrimstr("v") | split(".") | map(tonumber))
                    else [999999] end)
        | .[0].title'
```

- **Version-only ordering** (no `due_on` tiebreaker) — matches our `vX.Y.Z`-only convention.
- **Crash-proof**: a non-`vX.Y.Z` title gets a high sentinel key (`[999999]`) so it sorts last and never reaches `tonumber` (which otherwise errors with `tonumber cannot be applied to "v0"`).
- Filters to open milestones **before** sorting (old snippet sorted first, then filtered).

Also tightened the step-7 prose to say "earliest open milestone **by semantic version**".

## Verification
```
# live API → v0.9.1 (correct), NOT v0.10.0
# synthetic edge case with a "Backlog" title → v0.9.1, no crash
```
Both confirmed. (`.claude/skills/release/SKILL.md` was checked — its Phase 1 has no auto-pick sort snippet, so it doesn't carry this bug.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)