### PR TITLE
fix(#298): stop unit suite leaking to real osascript (~5min CI → seconds)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Unit tests
         run: uv run pytest tests/ -m "not integration and not e2e and not benchmark" -v --cov=apple_mail_mcp --cov-report=term-missing --cov-fail-under=90
-        # Suite is ~10s locally but ~5min in CI: a few IMAP error-path unit
-        # tests stall ~30s each on a real socket timeout that's instant
-        # locally. Bumped 5->10 to stop borderline flakes; the real fix
-        # (mock the socket) is tracked in #298.
-        timeout-minutes: 10
+        # The unit suite runs in seconds. A tight cap catches any future
+        # leak of a real osascript/socket call (which stalls ~30s in CI) —
+        # the #298 keychain-fallback leak that once made this ~5min is fixed
+        # in tests/unit/conftest.py.
+        timeout-minutes: 5
 
       - name: Complexity check
         run: ./scripts/check_complexity.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ markers = [
     "e2e: mark test as end-to-end test (full MCP stack)",
     "benchmark: mark test as performance benchmark",
     "slow: mark test as slow-running",
+    "real_account_fallback: opt out of the conftest stub of _alternative_account_identifier (for tests that exercise the real name<->UUID Keychain fallback)",
 ]
 
 [tool.coverage.run]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from apple_mail_mcp.mail_connector import AppleMailConnector
 from apple_mail_mcp.security import rate_limiter
 
 
@@ -9,3 +10,32 @@ from apple_mail_mcp.security import rate_limiter
 def _reset_rate_limiter() -> None:
     """Reset rate limiter state between tests to prevent cross-contamination."""
     rate_limiter.reset()
+
+
+@pytest.fixture(autouse=True)
+def _no_applescript_keychain_fallback(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keep the unit suite off real AppleScript.
+
+    On a Keychain miss, ``_get_imap_password_with_fallback`` calls
+    ``_alternative_account_identifier`` → ``list_accounts()`` → real
+    ``osascript`` (the #243 name↔UUID fallback). The ~14 keychain-miss
+    unit tests mock ``get_imap_password``/``_resolve_imap_config`` but not
+    that fallback, so each fired a live osascript call — ~0.85s locally but
+    ~30s in CI (Mail.app unresponsive), ballooning the suite to ~5 min
+    (#298). Stub it to ``None`` so the fallback re-raises the original
+    ``MailKeychainEntryNotFoundError`` (what those tests already assert)
+    without touching AppleScript.
+
+    Tests that exercise the real fallback (``TestKeychainDualFormLookup``)
+    mock ``list_accounts`` on the instance and opt out via the
+    ``real_account_fallback`` marker.
+    """
+    if request.node.get_closest_marker("real_account_fallback"):
+        return
+    monkeypatch.setattr(
+        AppleMailConnector,
+        "_alternative_account_identifier",
+        lambda self, account: None,
+    )

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -6654,11 +6654,16 @@ class TestReceivedWithinHours:
 # =============================================================================
 
 
+@pytest.mark.real_account_fallback
 class TestKeychainDualFormLookup:
     """Keychain entries are written under whatever string the user typed at
     setup-imap time (typically the account NAME). Callers may legitimately
     pass either the name or the UUID (per the docstring's stability claim).
     The wrapper retries with the alternative form on initial NotFound.
+
+    Opts out of the conftest ``_alternative_account_identifier`` stub via the
+    ``real_account_fallback`` marker — these tests exercise the real fallback
+    against an instance-mocked ``list_accounts`` (no AppleScript).
     """
 
     def test_primary_lookup_succeeds_no_fallback(


### PR DESCRIPTION
Closes #298

## Problem
The unit suite ran ~10s locally but **~5 minutes in CI** — it sat on the `timeout-minutes` limit (bumped 5→10 as a stopgap in #297).

**Root cause:** on a Keychain miss, `_get_imap_password_with_fallback` → `_alternative_account_identifier` → `list_accounts()` runs **real AppleScript** (the #243 name↔UUID fallback). ~14 keychain-miss unit tests mock `get_imap_password`/`_resolve_imap_config` but not that fallback, so each fired a live `osascript` call: ~0.85s locally (the 8 slowest tests by `--durations`) but **~30s each in CI** where Mail.app isn't responsive. ~14 × stall ≈ the missing ~290s.

## Fix
- **`tests/unit/conftest.py`**: autouse fixture stubbing `_alternative_account_identifier` → `None`, so the keychain-miss path re-raises the original `MailKeychainEntryNotFoundError` (exactly what those tests assert) with **zero AppleScript**.
- **`TestKeychainDualFormLookup`** exercises the *real* fallback against an instance-mocked `list_accounts`, so it opts out via a new registered `real_account_fallback` marker.
- **`.github/workflows/test.yml`**: with the leak gone, restore `timeout-minutes` 10→**5** — a tight cap catches any *future* osascript/socket leak fast instead of letting the suite silently creep.

Test-only change; the production fallback-to-`list_accounts` behavior is unchanged.

## Verification
- Local unit suite **9.9s → 3.2s**; keychain-miss tests drop from ~0.85s to ~instant.
- `make check-all` green; all 1189 unit tests pass.
- This PR's own `unit-tests` CI job should now finish in well under a minute (and comfortably under the restored 5-min cap) — the real measurement of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)