### PR TITLE
fix(#299): resolve iCloud IMAP login to the @icloud.com address

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -48,6 +48,8 @@ from .utils import (
     applescript_account_clause,
     escape_applescript_string,
     get_flag_index,
+    is_apple_hosted_address,
+    is_icloud_imap_host,
     parse_applescript_json,
     sanitize_filename,
     sanitize_input,
@@ -1578,6 +1580,16 @@ class AppleMailConnector:
             matches Mail.app's own behavior in every configuration we've
             seen. (#201)
 
+            Inverse case (#299): an iCloud account whose Apple ID is a
+            *third-party* email (e.g. a gmail-based Apple ID). There
+            `user name` is the gmail address, which iCloud's IMAP server
+            (*.mail.me.com) rejects — it wants the account's own
+            @icloud.com/@me.com address. So for iCloud IMAP hosts, when
+            `user name` is not itself Apple-hosted, we prefer an
+            Apple-hosted entry from `email addresses` (falling back to
+            `user name` when none exists, which keeps the #201 custom-domain
+            case correct).
+
         Raises:
             MailAccountNotFoundError: If the account doesn't exist.
         """
@@ -1605,8 +1617,23 @@ class AppleMailConnector:
         # as `missing value`, which drops those keys from the serialized
         # record. An empty host then fails the later connect with OSError
         # (the graceful-fallback path) rather than KeyError-ing here.
+        host = cast(str, parsed.get("host") or "")
+        # (#299) iCloud IMAP (*.mail.me.com) authenticates the account's own
+        # Apple-hosted address, not a third-party Apple ID. When `user name`
+        # is a non-Apple email (e.g. a gmail-based Apple ID), prefer an
+        # @icloud.com/@me.com/@mac.com entry from `email addresses`. Falls
+        # back to `user name` when none exists — preserving the #201
+        # custom-domain case (no Apple-hosted alias present → the Apple ID
+        # itself is the login).
+        if is_icloud_imap_host(host) and not is_apple_hosted_address(email):
+            apple_alias = next(
+                (a for a in email_addresses if is_apple_hosted_address(a)),
+                None,
+            )
+            if apple_alias:
+                email = apple_alias
         return (
-            cast(str, parsed.get("host") or ""),
+            host,
             cast(int, parsed.get("port") or 0),
             email,
         )

--- a/src/apple_mail_mcp/utils.py
+++ b/src/apple_mail_mcp/utils.py
@@ -442,3 +442,25 @@ def walk_thread_graph(
             break
 
     return accepted
+
+
+def is_apple_hosted_address(address: str) -> bool:
+    """True if ``address`` is on an Apple-hosted iCloud Mail domain.
+
+    iCloud Mail's IMAP server authenticates one of the account's own
+    Apple-hosted addresses (``@icloud.com`` / ``@me.com`` / legacy
+    ``@mac.com``). Used by ``_resolve_imap_config`` to pick the right IMAP
+    login when an iCloud account's Apple ID is a third-party email (#299).
+    """
+    return address.strip().lower().endswith(
+        ("@icloud.com", "@me.com", "@mac.com")
+    )
+
+
+def is_icloud_imap_host(host: str) -> bool:
+    """True if ``host`` is an iCloud Mail IMAP server (``*.mail.me.com``).
+
+    Covers the per-partition hostnames Mail.app reports (e.g.
+    ``p42-imap.mail.me.com``) as well as ``imap.mail.me.com``.
+    """
+    return host.strip().lower().endswith(".mail.me.com")

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -916,6 +916,83 @@ class TestAppleMailConnector:
         assert result == ("imap.gmail.com", 993, "me@gmail.com")
 
     @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_icloud_third_party_apple_id_uses_icloud_alias(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """#299: iCloud account whose Apple ID (`user name`) is a third-party
+        email (gmail) — the *.mail.me.com server rejects that, so resolve the
+        login to the account's @icloud.com address instead."""
+        mock_run.return_value = (
+            '{"host":"p42-imap.mail.me.com",'
+            '"port":993,'
+            '"user_name":"someone@gmail.com",'
+            '"email_addresses":["someone@icloud.com","someone@me.com"]}'
+        )
+        result = connector._resolve_imap_config("iCloud")
+        assert result == ("p42-imap.mail.me.com", 993, "someone@icloud.com")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_icloud_falls_back_to_me_com_alias(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """#299: when only an @me.com Apple-hosted alias is present, use it."""
+        mock_run.return_value = (
+            '{"host":"p42-imap.mail.me.com",'
+            '"port":993,'
+            '"user_name":"someone@gmail.com",'
+            '"email_addresses":["someone@me.com"]}'
+        )
+        result = connector._resolve_imap_config("iCloud")
+        assert result == ("p42-imap.mail.me.com", 993, "someone@me.com")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_icloud_apple_user_name_unchanged(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """#299: when `user name` is already Apple-hosted, keep it (the
+        normal iCloud case) — don't second-guess it."""
+        mock_run.return_value = (
+            '{"host":"imap.mail.me.com",'
+            '"port":993,'
+            '"user_name":"primary@icloud.com",'
+            '"email_addresses":["alias@icloud.com","primary@icloud.com"]}'
+        )
+        result = connector._resolve_imap_config("iCloud")
+        assert result == ("imap.mail.me.com", 993, "primary@icloud.com")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_icloud_no_apple_alias_keeps_user_name(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """#299/#201: me.com host + non-Apple `user name` + NO Apple-hosted
+        alias (the pure custom-domain shape) → fall back to `user name`,
+        preserving #201."""
+        mock_run.return_value = (
+            '{"host":"imap.mail.me.com",'
+            '"port":993,'
+            '"user_name":"apple-id@example.com",'
+            '"email_addresses":["from-alias@example.com","apple-id@example.com"]}'
+        )
+        result = connector._resolve_imap_config("iCloud")
+        assert result == ("imap.mail.me.com", 993, "apple-id@example.com")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_non_icloud_host_not_overridden(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """#299: the Apple-alias preference is scoped to iCloud IMAP hosts.
+        A non-me.com host keeps `user name` even if an icloud address happens
+        to be in the From list."""
+        mock_run.return_value = (
+            '{"host":"imap.gmail.com",'
+            '"port":993,'
+            '"user_name":"me@gmail.com",'
+            '"email_addresses":["me@gmail.com","old@icloud.com"]}'
+        )
+        result = connector._resolve_imap_config("Gmail")
+        assert result == ("imap.gmail.com", 993, "me@gmail.com")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
     def test_resolve_imap_config_propagates_account_not_found(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -11,7 +11,9 @@ from apple_mail_mcp.utils import (
     format_applescript_list,
     get_flag_index,
     is_account_uuid,
+    is_apple_hosted_address,
     is_gmail_system_label,
+    is_icloud_imap_host,
     normalize_subject,
     parse_applescript_json,
     parse_applescript_list,
@@ -415,5 +417,45 @@ class TestGetFlagIndex:
 
     def test_case_insensitive(self) -> None:
         assert get_flag_index("RED") == 0
+
+
+class TestIsAppleHostedAddress:
+    """#299: detect the account's own Apple-hosted iCloud Mail addresses."""
+
+    def test_icloud_me_mac_are_apple_hosted(self) -> None:
+        assert is_apple_hosted_address("a@icloud.com") is True
+        assert is_apple_hosted_address("a@me.com") is True
+        assert is_apple_hosted_address("a@mac.com") is True
+
+    def test_case_and_whitespace_insensitive(self) -> None:
+        assert is_apple_hosted_address("  A@ICloud.Com ") is True
+
+    def test_third_party_and_custom_domains_not_apple_hosted(self) -> None:
+        assert is_apple_hosted_address("a@gmail.com") is False
+        assert is_apple_hosted_address("a@example.com") is False
+        assert is_apple_hosted_address("") is False
+
+    def test_substring_spoof_not_apple_hosted(self) -> None:
+        # The Apple domain must be the actual host, not a prefix of a
+        # look-alike domain.
+        assert is_apple_hosted_address("a@icloud.com.evil.com") is False
+        assert is_apple_hosted_address("icloud.com@evil.com") is False
+
+
+class TestIsIcloudImapHost:
+    """#299: detect iCloud Mail IMAP servers (*.mail.me.com)."""
+
+    def test_partition_and_canonical_hosts(self) -> None:
+        assert is_icloud_imap_host("p42-imap.mail.me.com") is True
+        assert is_icloud_imap_host("imap.mail.me.com") is True
+        assert is_icloud_imap_host("P66-IMAP.MAIL.ME.COM") is True
+
+    def test_non_icloud_hosts(self) -> None:
+        assert is_icloud_imap_host("imap.gmail.com") is False
+        assert is_icloud_imap_host("imap.mail.yahoo.com") is False
+        assert is_icloud_imap_host("") is False
+
+    def test_substring_spoof_not_matched(self) -> None:
+        assert is_icloud_imap_host("mail.me.com.evil.com") is False
         assert get_flag_index("Red") == 0
         assert get_flag_index("oRaNgE") == 1


### PR DESCRIPTION
Closes #299

## Problem
`_resolve_imap_config` resolves the IMAP login as `user_name or email_addresses[0]`, always preferring Mail.app's `user name` (the #201 fix). That breaks the **inverse** case: an iCloud account whose Apple ID is a *third-party* email (e.g. a gmail-based Apple ID). There `user name` is the gmail address, which iCloud's IMAP server (`*.mail.me.com`) **rejects** — it wants the account's own `@icloud.com`/`@me.com` address. Result: every IMAP fast path fails auth and silently degrades to AppleScript, and `setup-imap` can't fix it (live-verify fails + rolls back). `--email` can't help either — runtime always re-derives the login from `user name`.

## Fix
For iCloud IMAP hosts (`*.mail.me.com`), when `user name` isn't itself Apple-hosted, prefer an `@icloud.com`/`@me.com`/`@mac.com` entry from `email addresses`; fall back to `user name` when none exists.

Two pure predicates added to `utils.py`: `is_apple_hosted_address`, `is_icloud_imap_host`.

**Doesn't regress #201:** the locked `test_resolve_imap_config_prefers_user_name_for_login` uses a me.com host whose `email_addresses` has **no** Apple-hosted address, so the new branch finds no alias and keeps `user name`. The fix only changes resolution when an Apple-hosted alias is actually present (the #299 shape). That test passes unchanged.

## Verification
- `make check-all` green — full unit suite incl. the existing #201 + empty-user_name resolver tests.
- New unit coverage: 5 resolver branches (third-party Apple ID → @icloud.com; @me.com-only fallback; already-Apple `user name` unchanged; no-Apple-alias keeps `user name` (the #201 shape); non-me.com host never overridden) + 7 predicate tests (incl. case-insensitivity and look-alike-domain spoofs).
- **Read-only check on the real account:** `_resolve_imap_config("iCloud")` now returns the `@icloud.com` login (was the gmail address); Gmail unchanged.
- AppleScript body unchanged (pure Python post-processing), so no new integration test required by the touched-AppleScript rule.

## Upgrade note (post-merge, user action)
Affected iCloud users should re-run `apple-mail-mcp setup-imap --account <name>` once: it now resolves to the `@icloud.com` address, so its live-verify will authenticate with an app-specific password, and the Keychain entry gets rekeyed (the old third-party-keyed entry is orphaned). Same pattern as the #201 upgrade note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)