### PR TITLE
fix(#249): split IMAP connect (3s) vs operation (30s) timeouts

### DIFF
--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -56,7 +56,23 @@ _ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 CONNECT_TIMEOUT_S: float = 3.0
 """Per invariant 4 in imap-auth-options-decision.md: ≤3s so offline
 fallback happens inside the graceful-degradation window without
-waiting for TCP's default timeout."""
+waiting for TCP's default timeout. Bounds connect + login only — once
+logged in the socket timeout is raised to OPERATION_TIMEOUT_S (#249)."""
+
+OPERATION_TIMEOUT_S: float = 30.0
+"""Socket read timeout for SEARCH/FETCH after login. imapclient's
+``timeout=`` applies to every socket read, so the short CONNECT_TIMEOUT_S
+would otherwise kill a legitimate server-side SEARCH (10–20s on a large
+iCloud mailbox) mid-operation, silently dropping the IMAP fast path to the
+slower AppleScript fallback. We connect fast (offline detection) then raise
+the timeout for real work. (#249)"""
+
+
+def _apply_operation_timeout(client: IMAPClient) -> None:
+    """Raise the socket read timeout from the connect window to
+    OPERATION_TIMEOUT_S, post-login. Call immediately after
+    ``client.login(...)`` at every connection-open site. (#249)"""
+    client.socket().settimeout(OPERATION_TIMEOUT_S)
 
 POOL_IDLE_TIMEOUT_S: float = 270.0
 """Default pool idle threshold. iCloud and most providers drop IMAP
@@ -155,6 +171,7 @@ class ImapConnectionPool:
                     host, port=port, ssl=True, timeout=connect_timeout
                 )
                 client.login(email, password)
+                _apply_operation_timeout(client)
                 entry = _PooledClient(client=client)
                 self._cache[key] = entry
 
@@ -623,6 +640,7 @@ class ImapConnector:
         )
         try:
             client.login(self._email, self._password)
+            _apply_operation_timeout(client)
             yield client
         finally:
             client.logout()

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -784,6 +784,31 @@ class TestDraftsLifecycleIntegration:
             except Exception:
                 pass
 
+    def test_imap_operation_timeout_applied_on_live_socket(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """#249: post-login, the live IMAP socket carries OPERATION_TIMEOUT_S
+        (not the short connect timeout), so a slow server-side SEARCH/FETCH
+        isn't killed mid-operation. Drives the real production `_session`
+        path and inspects the actual socket timeout, then runs a real
+        operation under it.
+        """
+        from apple_mail_mcp.imap_connector import (
+            OPERATION_TIMEOUT_S,
+            ImapConnector,
+        )
+        from apple_mail_mcp.keychain import get_imap_password
+
+        self._skip_without_keychain(connector, test_account)
+
+        host, port, email = connector._resolve_imap_config(test_account)
+        pw = get_imap_password(test_account, email)
+        imap = ImapConnector(host, port, email, pw)
+        with imap._session() as client:
+            assert client.socket().gettimeout() == OPERATION_TIMEOUT_S
+            # A real operation completes under the raised timeout.
+            client.select_folder("INBOX", readonly=True)
+
     def test_attachment_extraction_round_trip(
         self,
         connector: AppleMailConnector,

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -8,7 +8,11 @@ import pytest
 from imapclient.exceptions import IMAPClientError
 from imapclient.response_types import Address, Envelope
 
-from apple_mail_mcp.imap_connector import CONNECT_TIMEOUT_S, ImapConnector
+from apple_mail_mcp.imap_connector import (
+    CONNECT_TIMEOUT_S,
+    OPERATION_TIMEOUT_S,
+    ImapConnector,
+)
 
 
 def _fake_envelope(
@@ -54,6 +58,11 @@ def _fake_fetch_result(uids: list[int]) -> dict[int, dict[bytes, Any]]:
 class TestConstructor:
     def test_timeout_is_three_seconds_by_default(self):
         assert CONNECT_TIMEOUT_S == 3.0
+
+    def test_operation_timeout_is_thirty_seconds(self):
+        # #249: connect fast (3s), operate slow (30s).
+        assert OPERATION_TIMEOUT_S == 30.0
+        assert OPERATION_TIMEOUT_S > CONNECT_TIMEOUT_S
 
     def test_default_timeout(self):
         conn = ImapConnector("host", 993, "u@i.com", "pw")
@@ -102,6 +111,14 @@ class TestSearchHappyPath:
         mock_client.logout.assert_called_once()
 
         assert len(result) == 3
+
+        # #249: connect uses the short timeout (asserted above), then the
+        # socket is raised to the operation timeout after login.
+        mock_client.socket().settimeout.assert_called_once_with(
+            OPERATION_TIMEOUT_S
+        )
+        names = [c[0] for c in mock_client.mock_calls]
+        assert names.index("login") < names.index("socket().settimeout")
 
     @patch("apple_mail_mcp.imap_connector.IMAPClient")
     def test_empty_search_result_skips_fetch(self, mock_cls):

--- a/tests/unit/test_imap_pool.py
+++ b/tests/unit/test_imap_pool.py
@@ -26,6 +26,8 @@ import pytest
 from imapclient.exceptions import IMAPClientError, LoginError
 
 from apple_mail_mcp.imap_connector import (
+    CONNECT_TIMEOUT_S,
+    OPERATION_TIMEOUT_S,
     POOL_IDLE_TIMEOUT_S,
     ImapConnectionPool,
     ImapConnector,
@@ -72,6 +74,50 @@ class TestSessionReuse:
         client.login.assert_called_once_with("u@e.com", "pw")
         # No logout between calls — connection stays alive.
         client.logout.assert_not_called()
+
+
+class TestOperationTimeout:
+    """#249: connect/login bounded by the short connect timeout, then the
+    socket read timeout is raised to OPERATION_TIMEOUT_S for SEARCH/FETCH so
+    a slow server-side search isn't killed mid-operation."""
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_connect_short_then_operation_timeout_raised_post_login(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+
+        with pool.session("h", 993, "u@e.com", "pw", CONNECT_TIMEOUT_S):
+            pass
+
+        # Connect uses the short timeout...
+        mock_cls.assert_called_once_with(
+            "h", port=993, ssl=True, timeout=CONNECT_TIMEOUT_S
+        )
+        # ...and after login the socket is raised to the operation timeout.
+        client.login.assert_called_once_with("u@e.com", "pw")
+        client.socket().settimeout.assert_called_once_with(OPERATION_TIMEOUT_S)
+        # Ordering: settimeout happens after login, not before.
+        names = [c[0] for c in client.mock_calls]
+        assert names.index("login") < names.index("socket().settimeout")
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_reused_session_keeps_single_timeout_application(
+        self, mock_cls: MagicMock, pool: ImapConnectionPool
+    ) -> None:
+        """A pooled connection sets the operation timeout once at creation;
+        reuse neither re-logs-in nor re-applies it."""
+        client = MagicMock()
+        mock_cls.return_value = client
+
+        with pool.session("h", 993, "u@e.com", "pw", CONNECT_TIMEOUT_S):
+            pass
+        with pool.session("h", 993, "u@e.com", "pw", CONNECT_TIMEOUT_S):
+            pass
+
+        client.login.assert_called_once()
+        client.socket().settimeout.assert_called_once_with(OPERATION_TIMEOUT_S)
 
     @patch("apple_mail_mcp.imap_connector.IMAPClient")
     def test_different_accounts_get_independent_clients(


### PR DESCRIPTION
Closes #249

## Problem
`imapclient`'s `IMAPClient(timeout=…)` applies to **every socket read**, not just connect. The connector opened with `CONNECT_TIMEOUT_S = 3.0` (for fast offline detection), but that 3s then killed a legitimate server-side SEARCH/FETCH (10–20s on a large iCloud mailbox) mid-operation — the IMAP fast path bailed and silently fell back to the much slower AppleScript path. Symptom: large-mailbox queries that should take ~1s via IMAP take tens of seconds.

## Fix
Connect + login stay bounded by `CONNECT_TIMEOUT_S` (3s); once logged in, raise the socket read timeout to a new `OPERATION_TIMEOUT_S` (30s). A `_apply_operation_timeout(client)` helper is called immediately after `client.login(...)` at both — and only — IMAPClient creation sites: the pool's `session()` and the no-pool `_session()`. No signature changes; the operation timeout is a constant (per-call configurability is out of scope per the issue).

## Verification
- **Unit** — pool + no-pool: connect uses `CONNECT_TIMEOUT_S` (3.0); `socket().settimeout(30.0)` is applied **after** `login` (ordering asserted via `mock_calls`); a reused pooled connection applies it once. Plus a constant guard (`OPERATION_TIMEOUT_S == 30.0 > CONNECT_TIMEOUT_S`).
- **Integration** — drives the real production `_session` against the test account and asserts the **live socket** `gettimeout() == OPERATION_TIMEOUT_S` post-login, then runs a real `INBOX` select. ✅ Verified green against **iCloud** (also confirms the #299 resolver fix end-to-end).
- `make check-all` green.

Note: the issue's "a 5s SEARCH now succeeds" scenario isn't deterministically reproducible in CI, so the live-socket-timeout assertion + unit coverage are the rigorous substitute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)