### PR TITLE
fix(#294): harden draft_id interpolation + resolve RFC ids in extract_draft_attachments

### DIFF
--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -3940,6 +3940,11 @@ class AppleMailConnector:
         """
         _validate_draft_id(draft_id)
         lookup_id = self._resolve_draft_lookup_id(draft_id)
+        # Defense-in-depth: _validate_draft_id's charset already excludes
+        # AppleScript-breaking chars, but apply the SECURITY_CHECKLIST
+        # two-step at the interpolation site so safety doesn't hinge on the
+        # regex staying narrow. (#294)
+        lookup_id_safe = escape_applescript_string(sanitize_input(lookup_id))
 
         script = _wrap_with_timeout(
             f"""tell application "Mail"
@@ -3949,7 +3954,7 @@ class AppleMailConnector:
                     repeat with mb in mailboxes of acc
                         if name of mb contains "Drafts" then
                             try
-                                set m to first message of mb whose id is "{lookup_id}"
+                                set m to first message of mb whose id is "{lookup_id_safe}"
                                 delete m
                                 set didDelete to true
                                 exit repeat
@@ -4067,10 +4072,11 @@ class AppleMailConnector:
         """
         _validate_draft_id(draft_id)
         lookup_id = self._resolve_draft_lookup_id(draft_id)
+        lookup_id_safe = escape_applescript_string(sanitize_input(lookup_id))
 
         tell_body = f"""
         tell application "Mail"
-            set targetId to "{lookup_id}"
+            set targetId to "{lookup_id_safe}"
             set foundDraft to missing value
             repeat with acc in accounts
                 try
@@ -4817,6 +4823,12 @@ class AppleMailConnector:
             FileNotFoundError: ``dest_dir`` does not exist.
         """
         _validate_draft_id(draft_id)
+        # Resolve RFC Message-ID draft ids (IMAP-APPEND drafts, #245) to
+        # Mail's internal numeric id, matching delete_draft/get_draft_state.
+        # Without this, update_draft loses attachments on IMAP-created drafts
+        # (their `id` is numeric, never equal to the RFC-id targetId). (#294)
+        lookup_id = self._resolve_draft_lookup_id(draft_id)
+        lookup_id_safe = escape_applescript_string(sanitize_input(lookup_id))
         dest_dir = Path(dest_dir)
         if not dest_dir.is_dir():
             raise FileNotFoundError(f"dest_dir does not exist: {dest_dir}")
@@ -4838,7 +4850,7 @@ class AppleMailConnector:
 
         script = _wrap_with_timeout(
             f"""tell application "Mail"
-            set targetId to "{draft_id}"
+            set targetId to "{lookup_id_safe}"
             set foundDraft to missing value
             repeat with acc in accounts
                 try

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -845,6 +845,70 @@ class TestDraftsLifecycleIntegration:
         finally:
             connector.delete_draft(draft_id)
 
+    def test_extract_attachments_on_imap_draft_resolves_rfc_id(
+        self,
+        connector: AppleMailConnector,
+        test_account: str,
+        tmp_path: Path,
+    ) -> None:
+        """#294: extract_draft_attachments must resolve an RFC Message-ID
+        draft_id (IMAP-APPEND drafts, #245) to Mail's internal id, like
+        delete_draft/get_draft_state. Pre-fix it interpolated the raw RFC id
+        as targetId, never matched Mail's numeric `id`, and update_draft
+        silently lost attachments on IMAP-created drafts. Skips unless the
+        account has Keychain creds — only then does create_draft take the
+        IMAP-APPEND path and return an RFC-id draft_id (the case under test).
+        """
+        self._skip_without_keychain(connector, test_account)
+
+        original = tmp_path / "src" / "report.pdf"
+        original.parent.mkdir(parents=True)
+        original.write_bytes(b"%PDF-294-INTEG")
+
+        import time as _time
+
+        from apple_mail_mcp.exceptions import MailDraftNotFoundError
+
+        result = connector.create_draft(
+            seed="new",
+            from_account=test_account,
+            to=["target@example.com"],
+            subject="ZZZ-AMM-294-ATTACH",
+            body="see attached",
+            attachment_paths=[original],
+        )
+        draft_id = result["draft_id"]
+        try:
+            # IMAP-APPEND path returns a bare RFC Message-ID (has @, no <>).
+            assert "@" in draft_id and "<" not in draft_id, (
+                f"expected IMAP-APPEND draft_id; got {draft_id!r}"
+            )
+            # Mail.app's IMAP sync may lag the APPEND; poll until the draft
+            # is resolvable by its Message-ID (also the case under test for
+            # extract — which now resolves the RFC id the same way).
+            state = None
+            for _ in range(10):
+                try:
+                    state = connector.get_draft_state(draft_id)
+                    break
+                except MailDraftNotFoundError:
+                    _time.sleep(3)
+            assert state is not None, "draft never synced into Mail.app in 30s"
+            assert "report.pdf" in state["attachment_names"]
+
+            extract_dir = tmp_path / "extract"
+            extract_dir.mkdir()
+            extracted = connector.extract_draft_attachments(
+                draft_id, state["attachment_names"], extract_dir
+            )
+            assert len(extracted) == 1 and extracted[0].is_file()
+            assert extracted[0].read_bytes() == b"%PDF-294-INTEG"
+        finally:
+            try:
+                connector.delete_draft(draft_id)
+            except Exception:
+                pass
+
     def test_delete_draft_removes_from_drafts_mailbox(
         self,
         connector: AppleMailConnector,

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -5165,6 +5165,31 @@ class TestDeleteDraft:
             connector.delete_draft("missing@host")
         mock_run.assert_not_called()
 
+    @patch.object(
+        AppleMailConnector, "_resolve_draft_lookup_id", return_value='1"x\\y'
+    )
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_delete_draft_escapes_resolved_id(
+        self,
+        mock_run: MagicMock,
+        mock_resolve: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """#294 defense-in-depth: the resolved id is escaped at the
+        interpolation site, so a (hypothetical) quote/backslash-bearing id
+        can't break out of the AppleScript string even if it ever got past
+        validation/resolution."""
+        from apple_mail_mcp.utils import (
+            escape_applescript_string,
+            sanitize_input,
+        )
+
+        mock_run.return_value = "OK"
+        connector.delete_draft("validid")
+        script = mock_run.call_args[0][0]
+        expected = escape_applescript_string(sanitize_input('1"x\\y'))
+        assert f'whose id is "{expected}"' in script
+
 
 class TestFindMessageByMessageId:
     """Tests for AppleMailConnector.find_message_by_message_id."""
@@ -5422,6 +5447,31 @@ class TestGetDraftState:
         script = mock_run.call_args[0][0]
         assert '"In-Reply-To"' in script
         assert '"References"' in script
+
+    @patch.object(
+        AppleMailConnector, "_resolve_draft_lookup_id", return_value='1"x\\y'
+    )
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_get_draft_state_escapes_resolved_id(
+        self,
+        mock_run: MagicMock,
+        mock_resolve: MagicMock,
+        connector: AppleMailConnector,
+    ) -> None:
+        """#294 defense-in-depth: the resolved id is escaped into targetId."""
+        from apple_mail_mcp.utils import (
+            escape_applescript_string,
+            sanitize_input,
+        )
+
+        mock_run.return_value = '{"found":false}'
+        try:
+            connector.get_draft_state("validid")
+        except MailDraftNotFoundError:
+            pass
+        script = mock_run.call_args[0][0]
+        expected = escape_applescript_string(sanitize_input('1"x\\y'))
+        assert f'set targetId to "{expected}"' in script
 
 
 class TestCreateDraft:
@@ -5989,6 +6039,51 @@ class TestExtractDraftAttachments:
         script = mock_run.call_args[0][0]
         assert "save a in (POSIX file tp)" in script
         assert "mail attachments of foundDraft" in script
+
+    @patch.object(
+        AppleMailConnector, "find_message_by_message_id", return_value="160991"
+    )
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_extract_resolves_rfc_message_id(
+        self,
+        mock_run: MagicMock,
+        mock_find: MagicMock,
+        connector: AppleMailConnector,
+        tmp_path: Any,
+    ) -> None:
+        """#294: extract_draft_attachments resolves an RFC Message-ID
+        draft_id to Mail's internal id (like delete_draft/get_draft_state),
+        so update_draft preserves attachments on IMAP-APPEND drafts (#245)."""
+        mock_run.return_value = "0"
+        connector.extract_draft_attachments(
+            "abc.123@host", ["a.pdf"], tmp_path
+        )
+        mock_find.assert_called_once_with("abc.123@host")
+        script = mock_run.call_args[0][0]
+        assert 'set targetId to "160991"' in script
+
+    @patch.object(
+        AppleMailConnector, "_resolve_draft_lookup_id", return_value='1"x\\y'
+    )
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_extract_escapes_resolved_id(
+        self,
+        mock_run: MagicMock,
+        mock_resolve: MagicMock,
+        connector: AppleMailConnector,
+        tmp_path: Any,
+    ) -> None:
+        """#294 defense-in-depth: the resolved id is escaped into targetId."""
+        from apple_mail_mcp.utils import (
+            escape_applescript_string,
+            sanitize_input,
+        )
+
+        mock_run.return_value = "0"
+        connector.extract_draft_attachments("validid", ["a.pdf"], tmp_path)
+        script = mock_run.call_args[0][0]
+        expected = escape_applescript_string(sanitize_input('1"x\\y'))
+        assert f'set targetId to "{expected}"' in script
 
 
 class TestUpdateMailbox:


### PR DESCRIPTION
Closes #294

Two-part follow-up from the v0.9.0 release review. #293 had already widened `_validate_draft_id` (now `^[A-Za-z0-9._@+=-]{1,255}$`) and added `_resolve_draft_lookup_id` for `delete_draft`/`get_draft_state`, so this finishes the remaining pieces.

## 1. Correctness — `extract_draft_attachments` lost attachments on IMAP drafts
It interpolated the **raw `draft_id`** into `set targetId to …` and matched `(id of d as text) is targetId` **without** `_resolve_draft_lookup_id`. For an IMAP-APPEND draft (#245) the `draft_id` is an RFC Message-ID while Mail's `id` is numeric — so `targetId` never matched, and `update_draft` (which uses `extract_draft_attachments` to preserve attachments through delete-and-recreate) **silently lost attachments**. Now resolves the same way as the sibling methods.

## 2. Defense-in-depth — escape at all three interpolation sites
`delete_draft`, `get_draft_state`, and `extract_draft_attachments` now wrap the interpolated id in `escape_applescript_string(sanitize_input(...))` per the SECURITY_CHECKLIST two-step. No live injection today (the regex excludes `"`/`\`, and `@`-ids resolve to a numeric id), but safety no longer hinges on the regex staying narrow — exactly the ratchet-risk #294 flagged now that it accepts `@`.

## Verification
- **Unit**: each method escapes the resolved id (mocked quote/backslash value asserted escaped in the generated script); `extract_draft_attachments` resolves an `@`-id to the numeric id via `find_message_by_message_id`. Existing draft tests pass (escape is a no-op for clean ids).
- **Integration (vs iCloud)**: create an IMAP-APPEND draft **with an attachment**, then `extract_draft_attachments(<bare RFC id>, …)` returns the file byte-for-byte — pre-fix the draft wasn't found. ✅
- `make check-all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)