### PR TITLE
fix(#309): coerce stringified array/dict tool params (Cowork interop)

### DIFF
--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -9,10 +9,11 @@ import sys
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Annotated, Any, TypeVar, cast
 
 from fastmcp import Context, FastMCP
 from fastmcp.server.elicitation import AcceptedElicitation
+from pydantic import BeforeValidator
 
 from .drafts import DraftStateStore, SeedRecord
 from .exceptions import (
@@ -44,6 +45,7 @@ from .security import (
     validate_send_operation,
 )
 from .templates import Template, TemplateStore
+from .utils import coerce_json_dict, coerce_json_list
 
 # Configure logging
 logging.basicConfig(
@@ -70,6 +72,17 @@ _READ_ONLY = _pre_parse_read_only()
 
 # Create FastMCP server
 mcp = FastMCP("apple-mail")
+
+# Param-coercion aliases for MCP hosts that stringify array/dict arguments
+# (e.g. Cowork — #309). BeforeValidator runs ahead of type validation, so a
+# JSON-encoded list/dict string is parsed back before Pydantic checks it. The
+# advertised JSON schema stays array/object, so well-behaved clients that send
+# real lists/dicts are unaffected (coercion is a no-op for non-strings).
+StrList = Annotated[list[str], BeforeValidator(coerce_json_list)]
+IntList = Annotated[list[int], BeforeValidator(coerce_json_list)]
+DictList = Annotated[list[dict[str, Any]], BeforeValidator(coerce_json_list)]
+StrDict = Annotated[dict[str, str], BeforeValidator(coerce_json_dict)]
+AnyDict = Annotated[dict[str, Any], BeforeValidator(coerce_json_dict)]
 
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -411,8 +424,8 @@ async def delete_rule(
 )
 async def create_rule(
     name: str,
-    conditions: list[dict[str, Any]],
-    actions: dict[str, Any],
+    conditions: DictList,
+    actions: AnyDict,
     match_logic: str = "all",
     enabled: bool = True,
     ctx: Context | None = None,
@@ -522,8 +535,8 @@ async def update_rule(
     rule_index: int,
     name: str | None = None,
     enabled: bool | None = None,
-    conditions: list[dict[str, Any]] | None = None,
-    actions: dict[str, Any] | None = None,
+    conditions: DictList | None = None,
+    actions: AnyDict | None = None,
     match_logic: str | None = None,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
@@ -835,7 +848,7 @@ def search_messages(
     received_within_hours: int | None = None,
     has_attachment: bool | None = None,
     limit: int = 50,
-    source: list[str] | None = None,
+    source: StrList | None = None,
     include_attachments: bool = False,
     body_contains: str | None = None,
     text_contains: str | None = None,
@@ -1072,7 +1085,7 @@ def search_messages(
     {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
 )
 def get_messages(
-    message_ids: list[str],
+    message_ids: StrList,
     include_content: bool = True,
     headers_only: bool = False,
     account: str | None = None,
@@ -1163,7 +1176,7 @@ def get_messages(
     mutating=True,
 )
 def update_message(
-    message_ids: list[str],
+    message_ids: StrList,
     read_status: bool | None = None,
     flagged: bool | None = None,
     flag_color: str | None = None,
@@ -1399,7 +1412,7 @@ def get_thread(message_id: str) -> dict[str, Any]:
 def save_attachments(
     message_id: str,
     save_directory: str,
-    attachment_indices: list[int] | None = None,
+    attachment_indices: IntList | None = None,
 ) -> dict[str, Any]:
     """
     Save attachments from a message to a directory.
@@ -1875,7 +1888,7 @@ async def delete_mailbox(
     mutating=True,
 )
 async def delete_messages(
-    message_ids: list[str],
+    message_ids: StrList,
     permanent: bool = False,
     account: str | None = None,
     source_mailbox: str | None = None,
@@ -2200,7 +2213,7 @@ async def delete_template(
 def render_template(
     name: str,
     message_id: str | None = None,
-    vars: dict[str, str] | None = None,
+    vars: StrDict | None = None,
 ) -> dict[str, Any]:
     """Render a template into ready-to-send subject and body text.
 
@@ -2582,15 +2595,15 @@ async def create_draft(
     reply_to: str | None = None,
     forward_of: str | None = None,
     seed_mailbox: str | None = None,
-    to: list[str] | None = None,
-    cc: list[str] | None = None,
-    bcc: list[str] | None = None,
+    to: StrList | None = None,
+    cc: StrList | None = None,
+    bcc: StrList | None = None,
     subject: str | None = None,
     body: str = "",
-    attachment_paths: list[str] | None = None,
+    attachment_paths: StrList | None = None,
     reply_all: bool = False,
     template_name: str | None = None,
-    template_vars: dict[str, str] | None = None,
+    template_vars: StrDict | None = None,
     from_account: str | None = None,
     send_now: bool = False,
     ctx: Context | None = None,
@@ -2764,14 +2777,14 @@ async def create_draft(
 )
 async def update_draft(
     draft_id: str,
-    to: list[str] | None = None,
-    cc: list[str] | None = None,
-    bcc: list[str] | None = None,
+    to: StrList | None = None,
+    cc: StrList | None = None,
+    bcc: StrList | None = None,
     subject: str | None = None,
     body: str | None = None,
-    attachment_paths: list[str] | None = None,
+    attachment_paths: StrList | None = None,
     template_name: str | None = None,
-    template_vars: dict[str, str] | None = None,
+    template_vars: StrDict | None = None,
     from_account: str | None = None,
     send_now: bool = False,
     ctx: Context | None = None,

--- a/src/apple_mail_mcp/utils.py
+++ b/src/apple_mail_mcp/utils.py
@@ -444,6 +444,47 @@ def walk_thread_graph(
     return accepted
 
 
+def coerce_json_list(v: Any) -> Any:
+    """Coerce a stringified array back to a list (#309).
+
+    Some MCP hosts (e.g. Cowork) serialize every tool argument as a string,
+    so a ``list[...]`` param arrives as ``'["a@b.com"]'`` and Pydantic
+    rejects it with a ``list_type`` error. Used as a Pydantic
+    ``BeforeValidator`` on list-typed tool params: a JSON-array string
+    becomes the list, a bare non-JSON string becomes a single-element list,
+    an empty string becomes ``[]``. Real lists and ``None`` pass through
+    untouched, so well-behaved clients are unaffected. Element types are
+    still validated by Pydantic afterwards.
+    """
+    if isinstance(v, str):
+        s = v.strip()
+        if not s:
+            return []
+        try:
+            parsed = json.loads(s)
+        except (ValueError, TypeError):
+            return [v]
+        return parsed if isinstance(parsed, list) else [v]
+    return v
+
+
+def coerce_json_dict(v: Any) -> Any:
+    """Coerce a stringified object back to a dict (#309).
+
+    Companion to :func:`coerce_json_list` for ``dict``-typed tool params
+    (e.g. rule ``actions``, template ``vars``). A JSON-object string becomes
+    the dict; anything else (real dict, ``None``, non-object JSON, garbage)
+    passes through to be validated/rejected normally.
+    """
+    if isinstance(v, str):
+        try:
+            parsed = json.loads(v)
+        except (ValueError, TypeError):
+            return v
+        return parsed if isinstance(parsed, dict) else v
+    return v
+
+
 def is_apple_hosted_address(address: str) -> bool:
     """True if ``address`` is on an Apple-hosted iCloud Mail domain.
 

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -263,3 +263,107 @@ class TestToolInvocation:
         assert result.structured_content["success"] is True
         assert "error" not in result.structured_content
         getattr(mock_mail, connector_method).assert_called_once()
+
+
+class TestStringifiedParamCoercion:
+    """#309: some MCP hosts (e.g. Cowork) serialize every tool argument as a
+    string, so array/dict params arrive as JSON strings. The tool layer
+    coerces them back before validation — these calls must succeed (pre-fix
+    they failed with a Pydantic ``list_type`` error) and the connector must
+    receive the parsed list/dict.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _accept_elicitation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def _accept(*_a: object, **_k: object) -> None:
+            return None
+
+        monkeypatch.setattr(
+            "apple_mail_mcp.server._elicit_confirmation", _accept
+        )
+
+    @staticmethod
+    def _call_values(call_args: Any) -> list[Any]:
+        args, kwargs = call_args
+        return list(args) + list(kwargs.values())
+
+    async def test_delete_messages_stringified_message_ids(
+        self, mock_mail: MagicMock
+    ) -> None:
+        mock_mail.delete_messages.return_value = 1
+        result = await server.mcp.call_tool(
+            "delete_messages", {"message_ids": '["msg-1", "msg-2"]'}
+        )
+        assert result.structured_content["success"] is True
+        mock_mail.delete_messages.assert_called_once()
+        assert ["msg-1", "msg-2"] in self._call_values(
+            mock_mail.delete_messages.call_args
+        )
+
+    async def test_create_draft_stringified_recipients(
+        self, mock_mail: MagicMock
+    ) -> None:
+        # The exact reported case (#309): to/cc arrive as JSON strings.
+        mock_mail.create_draft.return_value = {
+            "draft_id": "d1", "sent_message_id": ""
+        }
+        result = await server.mcp.call_tool(
+            "create_draft",
+            {"to": '["a@example.com"]', "cc": '["c@d.com"]',
+             "subject": "s", "body": "b"},
+        )
+        assert result.structured_content["success"] is True
+        flat = self._call_values(mock_mail.create_draft.call_args)
+        assert ["a@example.com"] in flat
+        assert ["c@d.com"] in flat
+
+    async def test_save_attachments_stringified_int_indices(
+        self, mock_mail: MagicMock, tmp_path: Path
+    ) -> None:
+        mock_mail.save_attachments.return_value = {"saved": 0, "rejected": []}
+        result = await server.mcp.call_tool(
+            "save_attachments",
+            {"message_id": "m1", "save_directory": str(tmp_path),
+             "attachment_indices": "[0, 2]"},
+        )
+        assert result.structured_content["success"] is True
+        assert [0, 2] in self._call_values(
+            mock_mail.save_attachments.call_args
+        )
+
+    async def test_create_rule_stringified_conditions_and_actions(
+        self, mock_mail: MagicMock
+    ) -> None:
+        mock_mail.create_rule.return_value = 1
+        result = await server.mcp.call_tool(
+            "create_rule",
+            {"name": "R",
+             "conditions":
+                 '[{"field": "from", "operator": "contains", "value": "x"}]',
+             "actions": '{"mark_as_read": true}'},
+        )
+        assert result.structured_content["success"] is True
+        flat = self._call_values(mock_mail.create_rule.call_args)
+        assert [
+            {"field": "from", "operator": "contains", "value": "x"}
+        ] in flat
+        assert {"mark_as_read": True} in flat
+
+    async def test_real_list_still_works(self, mock_mail: MagicMock) -> None:
+        # Well-behaved clients send real lists — coercion is a no-op.
+        mock_mail.delete_messages.return_value = 1
+        result = await server.mcp.call_tool(
+            "delete_messages", {"message_ids": ["msg-1"]}
+        )
+        assert result.structured_content["success"] is True
+        assert ["msg-1"] in self._call_values(
+            mock_mail.delete_messages.call_args
+        )
+
+    async def test_advertised_schema_stays_array(self) -> None:
+        # BeforeValidator coercion must not change the published schema, so
+        # well-behaved clients still see `array`.
+        tool = await server.mcp.get_tool("delete_messages")
+        assert (
+            tool.parameters["properties"]["message_ids"]["type"] == "array"
+        )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,6 +7,8 @@ import pytest
 from apple_mail_mcp.exceptions import MailAppleScriptError
 from apple_mail_mcp.utils import (
     applescript_account_clause,
+    coerce_json_dict,
+    coerce_json_list,
     escape_applescript_string,
     format_applescript_list,
     get_flag_index,
@@ -457,5 +459,54 @@ class TestIsIcloudImapHost:
 
     def test_substring_spoof_not_matched(self) -> None:
         assert is_icloud_imap_host("mail.me.com.evil.com") is False
+
+
+class TestCoerceJsonList:
+    """#309: coerce stringified arrays (MCP hosts that serialize params)."""
+
+    def test_json_array_string_becomes_list(self) -> None:
+        assert coerce_json_list('["a@b.com", "c@d.com"]') == ["a@b.com", "c@d.com"]
+
+    def test_json_int_array_string_becomes_list(self) -> None:
+        assert coerce_json_list("[0, 2]") == [0, 2]
+
+    def test_bare_string_becomes_single_element(self) -> None:
+        assert coerce_json_list("john@example.com") == ["john@example.com"]
+
+    def test_empty_string_becomes_empty_list(self) -> None:
+        assert coerce_json_list("") == []
+        assert coerce_json_list("   ") == []
+
+    def test_non_list_json_string_wraps_as_single_element(self) -> None:
+        # A JSON scalar string isn't a list → treat the original as one elem.
+        assert coerce_json_list("5") == ["5"]
+
+    def test_real_list_passes_through(self) -> None:
+        v = ["x@y.com"]
+        assert coerce_json_list(v) is v
+
+    def test_none_passes_through(self) -> None:
+        assert coerce_json_list(None) is None
+
+
+class TestCoerceJsonDict:
+    """#309: coerce stringified objects."""
+
+    def test_json_object_string_becomes_dict(self) -> None:
+        assert coerce_json_dict('{"name": "Bob"}') == {"name": "Bob"}
+
+    def test_real_dict_passes_through(self) -> None:
+        v = {"k": "v"}
+        assert coerce_json_dict(v) is v
+
+    def test_none_passes_through(self) -> None:
+        assert coerce_json_dict(None) is None
+
+    def test_non_object_json_passes_through_to_fail_validation(self) -> None:
+        # A JSON array/scalar isn't a dict → leave as-is for Pydantic to reject.
+        assert coerce_json_dict("[1, 2]") == "[1, 2]"
+
+    def test_garbage_string_passes_through(self) -> None:
+        assert coerce_json_dict("not json") == "not json"
         assert get_flag_index("Red") == 0
         assert get_flag_index("oRaNgE") == 1


### PR DESCRIPTION
Closes #309

## Problem
Some MCP hosts — Cowork, per @Errabundo66 — serialize **every** tool argument as a string. FastMCP's tools are signature-typed, and Pydantic leniently coerces scalar strings (`"10"`→int) but **not** lists/dicts, so an array param arriving as `'["a@b.com"]'` fails with a `list_type` validation error. Reported for `create_draft.to/cc/bcc`, but it's **systemic** — every list/dict param across ~10 tools (~20 params): `message_ids`, `to/cc/bcc`, `attachment_paths`, `attachment_indices`, `source`, `conditions`, `actions`, `template_vars`/`vars`.

## Fix
- **`utils.py`**: two pure coercers — `coerce_json_list` (JSON-array string → list; bare string → `[v]`; `""` → `[]`) and `coerce_json_dict` (JSON-object string → dict). No-ops for real lists/dicts and `None`.
- **`server.py`**: five reusable `Annotated[..., BeforeValidator(...)]` aliases (`StrList`/`IntList`/`DictList`/`StrDict`/`AnyDict`); swapped onto every list/dict tool param.

`BeforeValidator` runs **ahead** of type validation, so a JSON string is parsed back before Pydantic checks it. The advertised JSON schema stays `array`/`object` (probe-confirmed on FastMCP 3.3.1), so **well-behaved clients are unaffected** — coercion is a no-op for non-strings. Element/value types are still validated afterward.

## Verification
- **Unit** (`test_utils.py`): both coercers across JSON-string / bare-string / empty / real-value+`None` passthrough / non-matching-JSON.
- **E2E** (`test_mcp_tools.py`, through FastMCP dispatch): stringified `message_ids`, `to`+`cc`, `attachment_indices` (ints), and `conditions`+`actions` all **succeed** and reach the connector as **parsed** list/dict; a real list still works; the published `message_ids` schema is still `array`.
- `make check-all` green; `make test-e2e` 25 passed (19 + 6).

No real-Mail integration test needed — this is request-validation, above the connector.

Thanks to @Errabundo66 for the clear report and diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)