### PR TITLE
fix(#253): make /merge-and-status catch-net resilient to transient empties

### DIFF
--- a/.claude/commands/merge-and-status.md
+++ b/.claude/commands/merge-and-status.md
@@ -22,11 +22,19 @@ Merge the current PR, pull main, surface any open contributor PRs and untriaged 
    git checkout main && git pull
    ```
 
-5. **Surface open contributor PRs** (any PR the current GitHub user did not author). This is the catch-net for external contributions that might otherwise sit unreviewed for weeks:
+5. **Surface open contributor PRs** (any PR the current GitHub user did not author). This is the catch-net for external contributions that might otherwise sit unreviewed for weeks. The block below is hardened against a transient empty response that once hid PR #246 across four runs (#253): it echoes the filter identity, retries once on an empty fetch, reports total-vs-filtered counts, and filters via `jq --arg` (so an empty identity over-surfaces rather than silently dropping everything):
    ```bash
    GIT_USER=$(gh api user --jq .login)
-   gh pr list --state open --json number,title,author,createdAt \
-     --jq "map(select(.author.login != \"$GIT_USER\")) | .[] | \"#\(.number)|\(.author.login)|\(.title)|\(.createdAt[:10])\""
+   [ -z "$GIT_USER" ] && echo "WARNING: gh api user returned empty — contributor filter unreliable."
+   echo "Identity for filter: ${GIT_USER:-<empty>}"
+   prs=$(gh pr list --state open --json number,title,author,createdAt)
+   if [ "$(printf '%s' "$prs" | jq 'length')" -eq 0 ]; then   # retry a transient empty (#253)
+     sleep 1; prs=$(gh pr list --state open --json number,title,author,createdAt)
+   fi
+   total=$(printf '%s' "$prs" | jq 'length')
+   contrib=$(printf '%s' "$prs" | jq --arg me "$GIT_USER" 'map(select(.author.login != $me))')
+   echo "Open PRs: $total total, $(printf '%s' "$contrib" | jq 'length') by contributors"
+   printf '%s' "$contrib" | jq -r '.[] | "#\(.number)|\(.author.login)|\(.title)|\(.createdAt[:10])"'
    ```
    Behavioral rules for displaying the result:
    - Render as a table with columns: PR #, author, title, opened-on date.
@@ -34,18 +42,28 @@ Merge the current PR, pull main, surface any open contributor PRs and untriaged 
    - If the same author appears multiple times, group them together in the table.
    - Dependabot PRs count as contributor PRs for visibility purposes (they need rebase nudges or merges too).
    - If zero rows, say "No open contributor PRs" so the user gets positive confirmation rather than ambiguity.
+   - **Report the count line.** A `total` > 0 with `0` contributor PRs is only expected when every open PR is the maintainer's; otherwise treat it as a possible dropped-filter miss and re-run before reporting "none." (#253)
 
 6. **Surface untriaged contributor issues** (open issues filed by anyone other than the current GitHub user that are NOT assigned to a milestone). The reasoning for the no-milestone filter: assigned issues have already been triaged and are visible elsewhere — the truly invisible ones are the unassigned ones.
    ```bash
    GIT_USER=$(gh api user --jq .login)
-   gh issue list --state open --limit 50 --json number,title,author,createdAt,milestone \
-     --jq "map(select(.author.login != \"$GIT_USER\")) | map(select(.milestone == null)) | .[] | \"#\(.number)|\(.author.login)|\(.title)|\(.createdAt[:10])\""
+   [ -z "$GIT_USER" ] && echo "WARNING: gh api user returned empty — contributor filter unreliable."
+   echo "Identity for filter: ${GIT_USER:-<empty>}"
+   issues=$(gh issue list --state open --limit 50 --json number,title,author,createdAt,milestone)
+   if [ "$(printf '%s' "$issues" | jq 'length')" -eq 0 ]; then   # retry a transient empty (#253)
+     sleep 1; issues=$(gh issue list --state open --limit 50 --json number,title,author,createdAt,milestone)
+   fi
+   total=$(printf '%s' "$issues" | jq 'length')
+   untriaged=$(printf '%s' "$issues" | jq --arg me "$GIT_USER" 'map(select(.author.login != $me)) | map(select(.milestone == null))')
+   echo "Open issues: $total total, $(printf '%s' "$untriaged" | jq 'length') untriaged contributor"
+   printf '%s' "$untriaged" | jq -r '.[] | "#\(.number)|\(.author.login)|\(.title)|\(.createdAt[:10])"'
    ```
    Behavioral rules (mirror the contributor-PR step):
    - Render as a table with columns: issue #, author, title, opened-on date.
    - If any rows appear, **call them out at the top of the final response** alongside (or below) the contributor-PR call-out — e.g., "⚠️ N untriaged contributor issue(s) need attention."
    - If the same author appears multiple times, group them together in the table.
    - If zero rows, say "No untriaged contributor issues" for positive confirmation.
+   - **Report the count line.** A `total` > 0 with `0` untriaged contributor issues is only expected when every open issue is the maintainer's or already milestoned; otherwise treat it as a possible dropped-filter miss and re-run. (#253)
 
 7. **Determine the current milestone.** Look at the most recent closed PR's milestone, or find the earliest open milestone **by semantic version**. Sort on the numeric version tuple, not the title string — a lexical sort puts `v0.10.0` before `v0.9.0` (`'1' < '9'` at the third character). The `test(...)` guard sorts any non-`vX.Y.Z` title last so a future named milestone doesn't crash `tonumber`:
    ```bash


### PR DESCRIPTION
Closes #253

## Problem
`/merge-and-status`'s contributor-PR catch-net reported **"No open contributor PRs"** across **four consecutive runs** while @fmasi's #246 was open; the *identical* query rerun manually returned it every time. A transient empty `gh pr list` (or empty `$GIT_USER`) that the silent one-liner couldn't distinguish from a genuine "none" — so #246 stayed invisible to triage for ~24h.

## Fix (steps 5 & 6 of the command)
Implements the issue's mitigations:
- **Echo the filter identity** (`$GIT_USER`) + warn if empty.
- **Retry once on an empty fetch** — the smallest-diff guard for the transient blip.
- **Echo total-vs-filtered counts** so "0 of 5" (dropped filter) ≠ "0 of 0" (genuinely none).
- **Filter via `jq --arg me "$GIT_USER"`** instead of interpolating into the jq string — an empty identity then *over*-surfaces rather than silently dropping everything.
- Behavioral rule: report the count line; re-run on a suspicious `total>0 / filtered=0`.

## Verification
Command-doc change (no app tests, like #268). Dry-run against the live repo:
- Step 5 → `Identity for filter: s-morgan-jeffries` / `Open PRs: 0 total, 0 by contributors`
- Step 6 → `Open issues: 17 total, 0 untriaged contributor` — the count proves the fetch succeeded and the 0 is legitimate, exactly the signal that was missing.

Doesn't fix the underlying `gh`/network transience (not fixable from here) — makes the step self-healing (retry) and observable (counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)