### PR TITLE
fix(#314): IMAP search/get_message survive a message vanishing mid-FETCH

### DIFF
--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -697,7 +697,14 @@ class ImapConnector:
 
             results: list[dict[str, Any]] = []
             for uid in uids:
-                entry = fetched[uid]
+                entry = fetched.get(uid)
+                # A message can vanish between SEARCH and FETCH (expunged or
+                # moved by a concurrent change — another client, a rule, or
+                # our own move/delete on this mailbox). The server then omits
+                # ENVELOPE for that UID. Skip it rather than crashing the
+                # whole search. (#314)
+                if entry is None or b"ENVELOPE" not in entry:
+                    continue
                 if has_attachment is not None:
                     has = _bodystructure_has_attachment(
                         entry.get(b"BODYSTRUCTURE")
@@ -707,7 +714,7 @@ class ImapConnector:
                     if has_attachment is False and has:
                         continue
                 row = _envelope_to_dict(
-                    entry[b"ENVELOPE"], tuple(entry[b"FLAGS"])
+                    entry[b"ENVELOPE"], tuple(entry.get(b"FLAGS", ()))
                 )
                 if include_attachments:
                     row["attachments"] = _bodystructure_extract_attachments(
@@ -790,10 +797,18 @@ class ImapConnector:
                 )
 
             fetched = client.fetch(uids[:1], fetch_keys)
-            entry = next(iter(fetched.values()))
+            entry = next(iter(fetched.values()), None)
+            # The message matched SEARCH but vanished before FETCH (expunged
+            # or moved by a concurrent change) — treat as not-found rather
+            # than crashing on the missing ENVELOPE. (#314)
+            if entry is None or b"ENVELOPE" not in entry:
+                raise MailMessageNotFoundError(
+                    f"Message-ID {message_id!r} vanished from mailbox "
+                    f"{mailbox!r} between SEARCH and FETCH."
+                )
 
             result = _envelope_to_dict(
-                entry[b"ENVELOPE"], tuple(entry[b"FLAGS"])
+                entry[b"ENVELOPE"], tuple(entry.get(b"FLAGS", ()))
             )
             if want_body:
                 body_bytes = entry.get(b"BODY[TEXT]") or b""

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -8,6 +8,7 @@ import pytest
 from imapclient.exceptions import IMAPClientError
 from imapclient.response_types import Address, Envelope
 
+from apple_mail_mcp.exceptions import MailMessageNotFoundError
 from apple_mail_mcp.imap_connector import (
     CONNECT_TIMEOUT_S,
     OPERATION_TIMEOUT_S,
@@ -3240,3 +3241,58 @@ class TestAppendDraft:
         conn.append_draft(b"raw-bytes")
 
         assert mock_client.append.call_args[0][0] == "Drafts"
+
+
+class TestEnvelopeVanishRobustness:
+    """#314: a message can be expunged/moved between SEARCH and FETCH (a
+    concurrent change), so the server's FETCH response omits ENVELOPE for
+    that UID. search_messages must skip it (return the rest), and get_message
+    must report not-found — neither may crash with KeyError: ENVELOPE."""
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_search_skips_uid_with_missing_envelope(
+        self, mock_cls: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.search.return_value = [1, 2, 3]
+        fetched = _fake_fetch_result([1, 3])
+        # uid 2 matched SEARCH but its FETCH entry lacks ENVELOPE (vanished).
+        fetched[2] = {b"FLAGS": ()}
+        mock_client.fetch.return_value = fetched
+
+        conn = ImapConnector("imap.example.com", 993, "u@e.com", "pw")
+        result = conn.search_messages()
+
+        assert [m["id"] for m in result] == [
+            "msg-1@example.com", "msg-3@example.com"
+        ]
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_search_skips_uid_absent_from_fetch(
+        self, mock_cls: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.search.return_value = [1, 2, 3]
+        # uid 2 is entirely absent from the FETCH dict.
+        mock_client.fetch.return_value = _fake_fetch_result([1, 3])
+
+        conn = ImapConnector("imap.example.com", 993, "u@e.com", "pw")
+        result = conn.search_messages()
+
+        assert len(result) == 2
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_get_message_vanished_raises_not_found(
+        self, mock_cls: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.search.return_value = [5]
+        # Matched by Message-ID search but the entry lacks ENVELOPE.
+        mock_client.fetch.return_value = {5: {b"FLAGS": ()}}
+
+        conn = ImapConnector("imap.example.com", 993, "u@e.com", "pw")
+        with pytest.raises(MailMessageNotFoundError):
+            conn.get_message("<gone@example.com>")


### PR DESCRIPTION
Closes #314

## Problem
`ImapConnector.search_messages` and `get_message` read the FETCH response with an **unguarded** `entry[b"ENVELOPE"]`. IMAP `SEARCH` returns UIDs, then a separate `FETCH` retrieves their envelopes — if a message is **expunged or moved between the two** (a concurrent change: another client, a rule firing, or our own move/delete on the same mailbox), the server omits `ENVELOPE` for that UID and the access raised `KeyError: ENVELOPE`, **crashing the entire search** (losing all results, not just the vanished one).

## Fix
Skip UIDs whose FETCH entry is missing or lacks `ENVELOPE`:
- `search_messages` returns the surviving rows.
- `get_message` raises `MailMessageNotFoundError` (the message is effectively gone).
- `FLAGS` defaulted to `()` defensively at both sites.

## How it surfaced
The #287 bulk-benchmark run: the bench mailbox is moved into/out of rapidly, so the teardown-drain search hit a vanished message every run and crashed — which cascaded and blocked capturing the headline IMAP-move benchmark. (That capture resumes once this lands.)

## Verification
- Unit regression tests (`TestEnvelopeVanishRobustness`): a searched UID whose entry lacks ENVELOPE — or is absent from the FETCH dict — is skipped, returning the rest; `get_message` on a vanished message raises not-found.
- `make check-all` green.

Real-world confirmation: the #287 re-capture (previously crashing at this exact teardown spot) now drains cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)