### PR TITLE
perf(#287): capture bulk-mutation benchmarks via a self-seeding source

### DIFF
--- a/docs/guides/BENCHMARKING.md
+++ b/docs/guides/BENCHMARKING.md
@@ -43,26 +43,41 @@ Benchmarks measure real Mail.app behavior, so they need real data:
 |-----------|----------|
 | `search_messages_*` | At least 1 message in INBOX, Archive, or Sent Messages |
 | `save_attachments_*` | At least 1 message with an attachment in those mailboxes |
-| `mark_as_read_50_msgs` | At least 50 messages across those mailboxes |
+| `mark_as_read_50_msgs`, `move_messages_50_msgs`, `update_message_move_50_msgs_imap` | Keychain IMAP credentials for `MAIL_TEST_ACCOUNT` — the source pool **self-seeds** synthetic messages (no real ≥50-msg mailbox needed; #287) |
 | `search_messages_*_gmail` | A Gmail account configured in Mail.app + Keychain IMAP credentials (#73 opt-in) |
 | `move_messages_50_msgs_gmail` | Same as above. Exercises the `gmail_mode=True` copy+delete path |
 
 If a precondition isn't met, the benchmark skips with a clear message rather than failing. This is by design — running a smaller bulk benchmark on 5 messages would defeat the point (the scaling signal is what matters).
 
-### Gmail-variant fixtures use synthetic data
+### Bulk fixtures use synthetic data (both account families)
 
-Unlike the iCloud benchmarks (which find a real mailbox with ≥50 messages and shuttle real messages), the Gmail variants populate two dedicated mailboxes via IMAP `APPEND`:
+The bulk benchmarks never touch your real mail. Both the generic
+(`MAIL_TEST_ACCOUNT`) and Gmail (`MAIL_TEST_ACCOUNT_GMAIL`) families seed a
+dedicated source mailbox with 50 synthetic RFC 5322 messages via IMAP `APPEND`
+(subject `ZZZ-AMM-BENCH Synthetic Message NNN`), idempotently (re-runs only
+append what's missing):
 
-- `[apple-mail-mcp-bench-gmail-source]` — holds 50 synthetic RFC 5322 messages (subject `ZZZ-AMM-BENCH Synthetic Message NNN`). Created and populated once per test session; idempotent (re-runs only append what's missing).
-- `[apple-mail-mcp-bench-gmail]` — the move-target. Populated per-test from the source via `move_messages(... gmail_mode=True)`; drained back on teardown.
+- Generic: `[apple-mail-mcp-bench-source]` → `[apple-mail-mcp-bench]` (#287).
+- Gmail: `[apple-mail-mcp-bench-gmail-source]` → `[apple-mail-mcp-bench-gmail]`, moved with `gmail_mode=True` (copy+delete).
 
-Your real Gmail INBOX is never touched. Both fixture mailboxes persist across runs (cheaper than re-creating per-run, and easy to spot from the prefix). Use `delete_mailbox` to clean them up if desired.
+The move-target is populated per-test from the source and drained back on
+teardown. All four fixture mailboxes persist across runs (cheaper than
+re-creating per-run, and easy to spot from the prefix). Use `delete_mailbox`
+to clean them up if desired.
 
-## Bulk benchmarks (mark_as_read, move_messages) currently skip
+## Bulk-move: IMAP fast path vs AppleScript (#287)
 
-The bulk-operation benchmarks rely on `move_messages` to populate the bench mailbox. `move_messages` in the connector currently scans every account × every mailbox to find each message ID — on a configuration with 4 accounts and ~115 total mailboxes (typical when Gmail is enabled, since it surfaces 90+ labels), that's 5,750 IMAP searches per call. The fixture setup times out and the bulk benchmarks skip with a clear message pointing at issue #103.
+The bulk benchmarks are captured against a self-seeding synthetic source (above), so they no longer depend on a real ≥50-message mailbox. Captured medians (50 messages, iCloud):
 
-Once #103 ships an optimized bulk path with a `source_mailbox` parameter, the fixture will succeed and bulk baselines can be captured via `make benchmark-baseline`. No code changes are needed in the benchmarks themselves — the suite is wired and ready.
+| Benchmark | Path | Median |
+|-----------|------|--------|
+| `mark_as_read_50_msgs` | flag toggle | ~0.8s |
+| `move_messages_50_msgs` | AppleScript bulk move (one direction ≈ half) | ~4.0s |
+| `update_message_move_50_msgs_imap` | `update_message` IMAP move-only fast path (#149) | ~23.6s |
+
+**Surprising result:** the IMAP "fast path" is **~6× *slower*** than the AppleScript move. The likely cause is that resolving 50 RFC 5322 Message-IDs to IMAP UIDs issues ~50 individual `SEARCH HEADER Message-ID` round-trips (unindexed on most servers), which dominates the move itself. This is tracked for investigation in a follow-up — the benchmark exists precisely to surface this kind of regression-vs-intuition.
+
+(Historical note: these benchmarks previously skipped because the fixture needed a real ≥50-message mailbox and the AppleScript `move_messages` setup was slow on many-mailbox accounts, #103. The self-seeding source + the IMAP-search robustness fix #314 unblocked capture.)
 
 ## How baselines are stored
 

--- a/tests/benchmarks/baseline.json
+++ b/tests/benchmarks/baseline.json
@@ -1,8 +1,8 @@
 {
   "imap_repeat_5_calls_no_pool": 12.078,
   "imap_repeat_5_calls_pooled": 11.87,
-  "mark_as_read_50_msgs": 3.65,
-  "move_messages_50_msgs": 17.167,
+  "mark_as_read_50_msgs": 0.8,
+  "move_messages_50_msgs": 3.953,
   "move_messages_50_msgs_gmail": 3.463,
   "save_attachments_one_file": 0.432,
   "search_messages_no_filter": 0.721,
@@ -10,5 +10,6 @@
   "search_messages_with_sender_filter": 0.756,
   "search_messages_with_sender_filter_gmail": 1.762,
   "search_messages_with_zero_matches": 0.52,
-  "search_messages_with_zero_matches_gmail": 1.571
+  "search_messages_with_zero_matches_gmail": 1.571,
+  "update_message_move_50_msgs_imap": 23.562
 }

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -35,6 +35,10 @@ DEFAULT_RUNS = 5
 BASELINE_PATH = Path(__file__).parent / "baseline.json"
 
 BENCH_MAILBOX_NAME = "[apple-mail-mcp-bench]"
+# Dedicated synthetic source for the generic bulk benchmarks (#287). Seeded
+# via IMAP APPEND like the Gmail variant, so the bulk benchmarks never touch
+# the user's real mail and don't depend on a real >=50-message mailbox.
+BENCH_SOURCE_NAME = "[apple-mail-mcp-bench-source]"
 BULK_SIZE = 50
 
 # Gmail variant fixtures (#101): benchmarks against a Gmail account use a
@@ -227,26 +231,55 @@ def test_account() -> str:
 def bench_source(
     connector: AppleMailConnector, test_account: str
 ) -> str:
-    """First mailbox in the test account that has at least BULK_SIZE
-    messages. Used as the source pool for bulk fixtures and as the
-    move-back destination during teardown.
+    """Dedicated synthetic source pool for the bulk fixtures, also the
+    move-back destination during teardown (#287).
 
-    Skips the entire benchmark session if no mailbox has enough
-    messages — see BENCHMARKING.md for setup."""
-    for mb in ("INBOX", "Archive", "Sent Messages"):
-        try:
-            results = connector.search_messages(
-                account=test_account, mailbox=mb, limit=BULK_SIZE
-            )
-        except Exception:
-            continue
-        if len(results) >= BULK_SIZE:
-            return mb
-    pytest.skip(
-        f"Need at least {BULK_SIZE} messages in account {test_account!r} "
-        f"(across INBOX/Archive/Sent Messages). See "
-        f"docs/guides/BENCHMARKING.md for setup."
+    Creates [apple-mail-mcp-bench-source] if missing and IMAP-APPENDs
+    BULK_SIZE synthetic messages into it (idempotent — only appends the
+    shortfall). Same approach as ``gmail_bench_source`` so the generic bulk
+    benchmarks never touch the user's real mail and don't depend on a real
+    >=50-message mailbox existing. Session-scoped; the populate cost is paid
+    once per run.
+
+    Skips cleanly if MAIL_TEST_ACCOUNT has no Keychain IMAP creds (the
+    synthetic seeding needs the IMAP path). Run `apple-mail-mcp setup-imap
+    --account <acct>` first."""
+    from imapclient import IMAPClient
+
+    from apple_mail_mcp.exceptions import (
+        MailKeychainAccessDeniedError,
+        MailKeychainEntryNotFoundError,
     )
+    from apple_mail_mcp.keychain import get_imap_password
+
+    mailboxes = connector.list_mailboxes(test_account)
+    names = {mb["name"] for mb in mailboxes}
+    if BENCH_SOURCE_NAME not in names:
+        connector.create_mailbox(account=test_account, name=BENCH_SOURCE_NAME)
+
+    host, port, email = connector._resolve_imap_config(test_account)
+    try:
+        pw = get_imap_password(test_account, email)
+    except (MailKeychainEntryNotFoundError, MailKeychainAccessDeniedError):
+        pytest.skip(
+            f"No Keychain IMAP creds for {test_account!r}; the synthetic "
+            f"bench source can't be seeded. Run `apple-mail-mcp setup-imap "
+            f"--account {test_account}`. See docs/guides/BENCHMARKING.md."
+        )
+
+    client = IMAPClient(host, port=port, ssl=True, timeout=60)
+    client.login(email, pw)
+    try:
+        info = client.select_folder(BENCH_SOURCE_NAME)
+        existing = int(info.get(b"EXISTS", 0))
+        if existing < BULK_SIZE:
+            client.unselect_folder()
+            for i in range(existing, BULK_SIZE):
+                client.append(BENCH_SOURCE_NAME, _make_synthetic_message(i))
+    finally:
+        client.logout()
+
+    return BENCH_SOURCE_NAME
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Closes #287

The bulk-mutation benchmarks never had real medians — they skipped because the generic source fixture needed a real ≥50-message mailbox (iCloud has none). This captures them.

## Changes
- **Self-seeding source** (`tests/benchmarks/conftest.py`): `bench_source` now creates `[apple-mail-mcp-bench-source]` and IMAP-APPENDs 50 synthetic messages (idempotent), mirroring the existing Gmail variant. The bulk benchmarks now run against iCloud **touching no real mail** and without depending on a real ≥50-msg mailbox.
- **Captured baselines** (50 msgs, iCloud) — incl. the headline IMAP path measured for the first time:

| Benchmark | Path | Old | New |
|-----------|------|-----|-----|
| `mark_as_read_50_msgs` | flag toggle | 3.65 | **~0.8s** |
| `move_messages_50_msgs` | AppleScript bulk move | 17.167 | **~4.0s** |
| `update_message_move_50_msgs_imap` | `update_message` IMAP move-only (#149) | *(never captured)* | **~23.6s** |

- **`BENCHMARKING.md`**: documents the self-seeding fixtures + the contrast below.

## ⚠️ Finding: the IMAP "fast path" is ~6× *slower* than AppleScript
`update_message_move_50_msgs_imap` (23.6s) vs `move_messages_50_msgs` (4.0s) — the opposite of #149's premise (low variance, CV 6.6%, so not noise). Likely cause: resolving 50 RFC Message-IDs → UIDs via ~50 individual `SEARCH HEADER Message-ID` round-trips dominating the move. **Filed #316** to investigate/batch the resolution. This is exactly the regression-vs-intuition the benchmark exists to surface.

## Verification
- Capture run clean (all 3 measured, CV 1–6.6%); `baseline.json` merged (other entries untouched).
- `make check-all` green (benchmarks skip in the unit suite).
- Capture was unblocked by #314 (the ENVELOPE-vanish fix stopped the teardown drains from crashing).
- Fixture mailboxes (`[apple-mail-mcp-bench-source]`, `[apple-mail-mcp-bench]`) are synthetic, prefixed, idempotent, and drained between runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)