### PR TITLE
ci(#288): automated doc/artifact drift gate + release refresh hooks

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -42,6 +42,21 @@ Update ALL files (pyproject.toml is authoritative):
 
 ## Phase 8: Documentation Review
 - README, CLAUDE.md, CHANGELOG, docs/**, tool docstrings, skills
+- The content-drift gate (`check_docs.sh`, Phase 9) automates the tool-set /
+  removed-name / cross-ref / eval-description-sync parts; this phase is the
+  human read for things it can't check (accuracy, tone, completeness).
+
+## Phase 8.5: Refresh derived artifacts (mandatory, #288)
+Derived artifacts rot silently between releases — refresh them against the
+release commit so a stale snapshot can't ship:
+1. `make eval-descriptions` — regenerate the blind-eval tool descriptions;
+   commit if changed. (`check_docs.sh` also fails on drift here.)
+2. Re-capture the benchmark baseline (#216): `MAIL_TEST_MODE=true
+   MAIL_TEST_ACCOUNT=<acct> uv run pytest tests/benchmarks/ --run-benchmark
+   --capture-baseline` (needs real Mail.app); commit the refreshed
+   `baseline.json`.
+3. Re-run the blind agent eval (#219) and refresh its scored snapshot (needs
+   `OPENROUTER_API_KEY`); commit.
 
 ## Phase 9: Validation
 Run ALL checks (stop on failure):
@@ -52,6 +67,7 @@ Run ALL checks (stop on failure):
 5. `make test-e2e` — **mandatory** (requires `MAIL_TEST_MODE=true` + a test Mail.app account). CI excludes e2e, so this is the only gate that catches a stale e2e failure. A pre-existing failure on `main` is a **release-blocker**, not a known issue to ship around (#257).
 6. `./scripts/check_dependencies.sh`
 7. `./scripts/check_applescript_safety.sh`
+8. `./scripts/check_docs.sh` — doc/artifact drift gate (tool-set coverage, removed-name, cross-refs, eval-description sync) (#288)
 
 ## Phase 10: Commit, Push, PR
 - Commit: `"release: vX.Y.Z"`

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Client-server parity check
         run: ./scripts/check_client_server_parity.sh
 
+      - name: Docs drift check
+        run: ./scripts/check_docs.sh
+
   test-summary:
     runs-on: ubuntu-latest
     needs: [unit-tests]

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ coverage:
 check-all: lint typecheck test complexity
 	@./scripts/check_version_sync.sh
 	@./scripts/check_client_server_parity.sh
+	@./scripts/check_docs.sh
 	@echo ""
 	@echo "All checks passed."
 

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -39,6 +39,7 @@ it for later or send it now.
 
 - `reply_to` (string, optional): Id of a message to reply to. Accepts either Mail.app's internal numeric id or an RFC 5322 Message-ID — pass the ``id`` field from any ``search_messages`` / ``get_messages`` row verbatim. Mutually exclusive with ``forward_of``. When set, ``to``/``cc`` recipients and ``subject`` are auto-derived from the original (override by passing them explicitly).
 - `forward_of` (string, optional): Id of a message to forward. Accepts the same id forms as ``reply_to``. Mutually exclusive with ``reply_to``. ``to`` is required (recipient of the forward).
+- `seed_mailbox` (string, optional): Mailbox the reply_to/forward_of message lives in (e.g. the ``mailbox`` field from its ``search_messages`` row). Lets the clean save-as-draft path fetch the original directly so reply/forward drafts render without the iOS quote bug — supply it especially for replies to filed (non-INBOX) mail. Defaults to INBOX; a miss falls back transparently.
 - `to` (list[string], optional)
 - `cc` (list[string], optional)
 - `bcc` (list[string], optional)

--- a/scripts/check_docs.sh
+++ b/scripts/check_docs.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Doc/artifact drift checks (#288). Catches content drift that the numeric
+# gates (check_version_sync / check_readme_claims) miss:
+#   (a) tool-set coverage — TOOLS.md documents exactly the live tool set
+#   (b) no removed-tool names presented as current tools in user-facing docs
+#   (c) every relative doc cross-reference resolves
+#   (d) the generated eval tool_descriptions.md is in sync with the live server
+# Runnable standalone, in `make check-all`, and in CI.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+uv run python - <<'PYEOF'
+import asyncio
+import re
+import sys
+from pathlib import Path
+
+import apple_mail_mcp.server as server
+
+ROOT = Path.cwd()
+errors: list[str] = []
+
+
+def err(msg: str) -> None:
+    errors.append(msg)
+
+
+# Live tool set (authoritative).
+tools = asyncio.run(server.mcp.list_tools())
+live = {t.name for t in tools}
+
+readme = ROOT / "README.md"
+tools_md = ROOT / "docs/reference/TOOLS.md"
+readme_text = readme.read_text()
+tools_text = tools_md.read_text()
+
+# --- (a) tool-set coverage -------------------------------------------------
+# Every live tool has a `### <name>` section in TOOLS.md and is named in README.
+documented_headers = set(re.findall(r"(?m)^###\s+([a-z][a-z0-9_]+)\s*$", tools_text))
+for name in sorted(live):
+    if not re.search(rf"(?m)^###\s+{re.escape(name)}\s*$", tools_text):
+        err(f"(a) TOOLS.md has no `### {name}` section (tool documented?)")
+    if not re.search(rf"\b{re.escape(name)}\b", readme_text):
+        err(f"(a) README.md never mentions tool `{name}`")
+# A snake_case `### header` that isn't a live tool is a removed-but-documented tool.
+for header in sorted(documented_headers - live):
+    err(f"(a) TOOLS.md documents `### {header}` but it is not a live tool")
+
+# --- (b) removed-tool names presented as current tools ---------------------
+# Scope: user-facing docs only (exclude CHANGELOG + historical plans/research).
+REMOVED = [
+    "send_email", "send_email_with_attachments",
+    "reply_to_message", "forward_message", "get_message",
+]
+SKIP = re.compile(r"removed|replaced|renamed|docs-allow", re.IGNORECASE)
+current_docs = [readme, tools_md, *sorted((ROOT / "docs/guides").glob("*.md"))]
+for f in current_docs:
+    for i, line in enumerate(f.read_text().splitlines(), 1):
+        if SKIP.search(line):
+            continue
+        for name in REMOVED:
+            # Flag only when presented AS a tool: a call `name(` or a header.
+            if re.search(rf"\b{re.escape(name)}\s*\(", line) or re.search(
+                rf"^###\s+{re.escape(name)}\b", line
+            ):
+                rel = f.relative_to(ROOT)
+                err(f"(b) {rel}:{i} references removed tool `{name}`: {line.strip()[:80]}")
+
+# --- (c) cross-reference resolution ----------------------------------------
+# Maintained docs only — docs/plans + docs/research are historical (per #220)
+# and their as-authored links aren't kept current.
+LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+SCHEME = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
+maintained = [
+    p for p in sorted((ROOT / "docs").rglob("*.md"))
+    if "plans" not in p.relative_to(ROOT).parts
+    and "research" not in p.relative_to(ROOT).parts
+]
+for f in [readme, *maintained]:
+    base = f.parent
+    for i, line in enumerate(f.read_text().splitlines(), 1):
+        for target in LINK.findall(line):
+            if SCHEME.match(target) or target.startswith(("mailto:", "#")):
+                continue
+            path_part = target.split("#", 1)[0]
+            if not path_part:
+                continue
+            if not (base / path_part).resolve().exists():
+                rel = f.relative_to(ROOT)
+                err(f"(c) {rel}:{i} broken link -> {target}")
+
+# --- (d) generated eval descriptions in sync -------------------------------
+desc = ROOT / "evals/agent_tool_usability/tool_descriptions.md"
+gen = ROOT / "evals/agent_tool_usability/generate_descriptions.py"
+if desc.exists() and gen.exists():
+    before = desc.read_text()
+    import subprocess
+    subprocess.run([sys.executable, str(gen)], check=True, cwd=ROOT,
+                   capture_output=True)
+    after = desc.read_text()
+    if before != after:
+        desc.write_text(before)  # non-destructive: restore committed version
+        err("(d) evals tool_descriptions.md is stale — run `make eval-descriptions`")
+
+# --- report ----------------------------------------------------------------
+if errors:
+    print(f"Doc drift check FAILED ({len(errors)} issue(s)):")
+    for e in errors:
+        print(f"  - {e}")
+    sys.exit(1)
+print(f"Doc drift check passed ({len(live)} tools; coverage, removed-name, "
+      f"cross-ref, and eval-description sync all OK).")
+PYEOF


### PR DESCRIPTION
Closes #288

Docs and derived artifacts keep silently rotting between releases — this milestone alone: stale eval descriptions (#219), scenarios graded against removed tools (#284), wrong ARCHITECTURE/TOOLS (#220), stale benchmark baseline (#216). We had **numeric** gates (version-sync, readme-claims, changelog-date) and a **manual** release doc review, but nothing for *content* drift. This adds the automated gate.

## `scripts/check_docs.sh` — in `make check-all` + CI
1. **Tool-set coverage** — every live `mcp.list_tools()` tool has a `### <name>` section in `TOOLS.md` and is named in README; a snake_case `### header` that isn't a live tool flags a removed-but-documented tool.
2. **Removed-tool names** — `send_email`/`send_email_with_attachments`/`reply_to_message`/`forward_message`/`get_message` presented *as a call or header* in user-facing docs (README, TOOLS.md, docs/guides) fail. Historical `docs/plans` + `docs/research` and lines marked `removed`/`replaced`/`renamed` or `<!-- docs-allow -->` are skipped (the false-positive control).
3. **Cross-references** — every relative `[](path)` link in the maintained docs resolves (plans/research excluded; `scheme://` + `mailto:` + `#anchor` skipped; anchors not validated in v1).
4. **Generated-artifact sync** — regenerates the eval `tool_descriptions.md` and fails (non-destructively) if it drifts.

**It caught real drift on first run:** `tool_descriptions.md` was stale after the #225 docstring changes — refreshed here via `make eval-descriptions`.

## Release skill
- New **Phase 8.5** makes derived-artifact refresh mandatory (eval descriptions + benchmark baseline #216 + blind eval #219) so a stale snapshot can't ship.
- **Phase 9** now runs `check_docs.sh`.

## Note (deferred, pre-existing)
Did **not** wire `check_readme_claims.sh` into the gate: its tool-count grep looks for `@mcp.tool` but the tools use the `@_tool(...)` wrapper, so it miscounts `0` and fails spuriously (which is why it was never in CI). Its tool-set concern is now covered more authoritatively by check (a). Left as-is; worth a separate one-line fix.

## Verification
- `./scripts/check_docs.sh` passes; **adversarially confirmed** it fails on a broken link + a removed-tool call (and passes after cleanup).
- `make check-all` green (now includes the gate).
- No production code; scripts/CI/docs/skill + the refreshed eval snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)