### PR TITLE
feat(#321,#270): auto-resolve sole account for clean drafts + warn on AppleScript fallback

### DIFF
--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -850,7 +850,7 @@ Create a draft (fresh, reply, or forward). Optionally send immediately.
 | `reply_all` | boolean | No | False | For `reply_to` only — use `reply to all`. |
 | `template_name` | string | No | None | Optional template to render for `subject` + `body`. Caller-supplied `subject`/`body` override the rendered output. |
 | `template_vars` | object | No | None | Variables for the template renderer. Requires `template_name`. |
-| `from_account` | string | No | None | Mail.app account name or UUID. None = Mail's default. |
+| `from_account` | string | No | None | Mail.app account name or UUID. None = Mail's default. On a save-as-draft with exactly one enabled account, that account is adopted so the clean (no iOS quote bug) IMAP draft path can engage — it's Mail's default sender anyway, so the From is unchanged (#321). |
 | `send_now` | boolean | No | False | `False` saves as draft. `True` sends immediately and elicits confirmation. |
 
 **Returns:**
@@ -860,12 +860,21 @@ Create a draft (fresh, reply, or forward). Optionally send immediately.
   "success": true,
   "draft_id": "161055",
   "sent_message_id": "",
-  "details": {"seed_kind": "new", "send_now": false}
+  "details": {"seed_kind": "new", "send_now": false, "from_account": "iCloud"}
 }
 ```
 
 `draft_id` is empty when sent (`send_now=True`); `sent_message_id` is
-reserved for future use.
+reserved for future use. `details.from_account` is the account the draft
+was created under (including an auto-resolved one), or `""` when Mail's
+default was used.
+
+**Warnings:** when a save-as-draft falls back to the AppleScript path
+(IMAP not configured, unreachable, no `from_account` and >1 account), the
+response includes an optional `warnings: list[str]` field noting the body
+may render as a blockquote on iOS Mail (Mail.app bug FB11734014, #245).
+The field is **omitted** on the clean path. Configure IMAP for the account
+(`apple-mail-mcp setup-imap`) — or pass `from_account` — to avoid it.
 
 **Examples:**
 

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -49,7 +49,7 @@ it for later or send it now.
 - `reply_all` (boolean, optional) (default: False): For ``reply_to`` only — use ``reply to all``.
 - `template_name` (string, optional): Optional template to render for ``subject`` and ``body``. Caller-supplied ``subject``/``body`` override the rendered output. ``template_vars`` override auto-fills.
 - `template_vars` (object, optional): Variables to pass to the template renderer. Requires ``template_name``.
-- `from_account` (string, optional): Mail.app account name or UUID. ``None`` uses Mail's default.
+- `from_account` (string, optional): Mail.app account name or UUID. ``None`` uses Mail's default; on a save-as-draft with exactly one enabled account, that account is adopted so the clean (no iOS quote bug) IMAP draft path can engage.
 - `send_now` (boolean, optional) (default: False): ``False`` (default) saves as draft. ``True`` sends immediately and elicits user confirmation.
 
 ### create_mailbox

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -4531,6 +4531,7 @@ class AppleMailConnector:
         reply_all: bool = False,
         from_account: str | None = None,
         send_now: bool = False,
+        on_warning: Callable[[str], None] | None = None,
     ) -> dict[str, str]:
         """Create a draft (fresh, reply, or forward). Optionally send.
 
@@ -4575,7 +4576,15 @@ class AppleMailConnector:
             attachment_paths: List of file paths. Each must exist.
             reply_all: For ``seed="reply"`` only — use ``reply to all``.
             from_account: Mail.app account name or UUID; ``None`` uses
-                Mail's default sender for the seed message.
+                Mail's default sender for the seed message. When ``None``
+                on a save-as-draft and exactly one enabled account exists,
+                that account is adopted so the clean IMAP path can engage
+                (it is Mail's default sender anyway, so the From is
+                unchanged). (#321)
+            on_warning: Optional callback invoked with a human-readable
+                string when a save-as-draft falls back to the AppleScript
+                path (whose body carries Mail.app's cite-blockquote wrapper,
+                FB11734014) instead of the clean IMAP path. (#270)
             send_now: ``False`` saves as draft and returns
                 ``{"draft_id": ...}``. ``True`` sends and returns
                 ``{"draft_id": "", "sent_message_id": ""}`` (sent_message_id
@@ -4593,37 +4602,38 @@ class AppleMailConnector:
         """
         self._validate_create_draft_args(seed, seed_id, to, subject)
 
-        # Clean IMAP-APPEND paths (issue #245) — return a draft dict when
-        # they handle the request, or None to fall through to AppleScript.
-        # Both avoid Mail.app's cite-blockquote wrapper (bug FB11734014).
-        imap_result = self._try_imap_compose_draft(
+        # #321: with no explicit account the clean IMAP draft path can't
+        # engage (it must name the account for creds + From); adopt the
+        # sole enabled account when there is one (it's Mail's default
+        # sender anyway, so the From is unchanged).
+        effective_account = self._effective_from_account(from_account, send_now)
+
+        # Clean IMAP-APPEND paths (issue #245) avoid Mail.app's
+        # cite-blockquote wrapper (bug FB11734014); they return a draft
+        # dict, or None to fall through to AppleScript.
+        imap_result = self._try_imap_draft_paths(
             seed=seed,
+            seed_id=seed_id,
+            seed_mailbox=seed_mailbox,
             send_now=send_now,
-            from_account=from_account,
+            effective_account=effective_account,
             to=to,
             cc=cc,
             bcc=bcc,
             subject=subject,
             body=body,
+            reply_all=reply_all,
             attachment_paths=attachment_paths,
         )
-        if imap_result is None:
-            imap_result = self._try_imap_reply_forward_draft(
-                seed=seed,
-                seed_id=seed_id,
-                seed_mailbox=seed_mailbox,
-                send_now=send_now,
-                from_account=from_account,
-                to=to,
-                cc=cc,
-                bcc=bcc,
-                subject=subject,
-                body=body,
-                reply_all=reply_all,
-                attachment_paths=attachment_paths,
-            )
         if imap_result is not None:
+            imap_result.setdefault("from_account", effective_account or "")
             return imap_result
+
+        # Committed to the AppleScript path, which carries Mail.app's
+        # cite-blockquote wrapper (FB11734014). Warn save-as-draft callers
+        # so a silently-wrapped draft is visible and actionable. (#270)
+        if not send_now and on_warning is not None:
+            on_warning(self._draft_fallback_warning(effective_account))
 
         # If the caller handed us an RFC 5322 Message-ID (the form read
         # tools emit on the IMAP path per #148), resolve to Mail's
@@ -4650,8 +4660,8 @@ class AppleMailConnector:
         # and the Display-Name <email> form from #158 broadened what
         # characters can appear here. (#173)
         sender_clause = ""
-        if from_account is not None:
-            sender_email = self._resolve_account_to_sender(from_account)
+        if effective_account is not None:
+            sender_email = self._resolve_account_to_sender(effective_account)
             sender_safe = escape_applescript_string(sanitize_input(sender_email))
             sender_clause = f'set sender of theMessage to "{sender_safe}"'
 
@@ -4783,8 +4793,118 @@ class AppleMailConnector:
             raise
 
         if send_now:
-            return {"draft_id": "", "sent_message_id": ""}
-        return {"draft_id": result, "sent_message_id": ""}
+            return {"draft_id": "", "sent_message_id": "", "from_account": ""}
+        return {
+            "draft_id": result,
+            "sent_message_id": "",
+            "from_account": effective_account or "",
+        }
+
+    @staticmethod
+    def _draft_fallback_warning(effective_account: str | None) -> str:
+        """Build the #270 warning shown when a save-as-draft lands on the
+        AppleScript path (and thus the cite-blockquote wrapper, FB11734014)
+        instead of the clean IMAP path."""
+        tail = (
+            "Body may render as a blockquote on iOS Mail (Mail.app bug "
+            "FB11734014)."
+        )
+        if effective_account is None:
+            return (
+                "Draft created via AppleScript: no from_account was given "
+                "and there isn't exactly one enabled account, so the clean "
+                f"IMAP draft path couldn't be auto-selected. {tail} Pass "
+                "from_account, or set up IMAP with `apple-mail-mcp "
+                "setup-imap`."
+            )
+        return (
+            "Draft created via AppleScript fallback: the IMAP draft path is "
+            f"unavailable for {effective_account!r} (IMAP not configured, "
+            f"unreachable, or a non-RFC reply seed). {tail} Configure or "
+            "repair IMAP for the account with `apple-mail-mcp setup-imap`."
+        )
+
+    def _effective_from_account(
+        self, from_account: str | None, send_now: bool
+    ) -> str | None:
+        """Resolve the account create_draft should act under (#321).
+
+        Honors an explicit ``from_account``; otherwise, for a save-as-draft,
+        adopts the sole enabled account so the clean IMAP path can engage.
+        ``send_now`` stays on the AppleScript send path, so it isn't
+        auto-resolved.
+        """
+        if from_account is not None or send_now:
+            return from_account
+        return self._resolve_implicit_account()
+
+    def _try_imap_draft_paths(
+        self,
+        *,
+        seed: str,
+        seed_id: str | None,
+        seed_mailbox: str | None,
+        send_now: bool,
+        effective_account: str | None,
+        to: list[str] | None,
+        cc: list[str] | None,
+        bcc: list[str] | None,
+        subject: str | None,
+        body: str,
+        reply_all: bool,
+        attachment_paths: list[Path] | None,
+    ) -> dict[str, str] | None:
+        """Try the clean IMAP-APPEND draft paths (compose, then
+        reply/forward), returning a draft dict or ``None`` to fall through
+        to AppleScript. (#245)"""
+        result = self._try_imap_compose_draft(
+            seed=seed,
+            send_now=send_now,
+            from_account=effective_account,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            subject=subject,
+            body=body,
+            attachment_paths=attachment_paths,
+        )
+        if result is not None:
+            return result
+        return self._try_imap_reply_forward_draft(
+            seed=seed,
+            seed_id=seed_id,
+            seed_mailbox=seed_mailbox,
+            send_now=send_now,
+            from_account=effective_account,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            subject=subject,
+            body=body,
+            reply_all=reply_all,
+            attachment_paths=attachment_paths,
+        )
+
+    def _resolve_implicit_account(self) -> str | None:
+        """Return the sole enabled Mail account's name, or ``None`` (#321).
+
+        ``create_draft`` uses this when no ``from_account`` is supplied: the
+        clean IMAP-APPEND draft path needs to name the account (for creds
+        and the From header), so it can't engage on an anonymous call. With
+        exactly one enabled account, Mail's default sender already *is* that
+        account, so adopting it is behavior-preserving for the From header.
+        With zero or several enabled accounts we return ``None`` and the
+        caller keeps Mail's default (AppleScript) behavior.
+        """
+        try:
+            accounts = self.list_accounts()
+        except Exception:
+            return None
+        enabled = [a for a in accounts if a.get("enabled")]
+        if len(enabled) != 1:
+            return None
+        name = enabled[0].get("name")
+        return cast(str, name) if name else None
 
     def extract_draft_attachments(
         self,

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -2683,13 +2683,19 @@ async def create_draft(
         template_vars: Variables to pass to the template renderer.
             Requires ``template_name``.
         from_account: Mail.app account name or UUID. ``None`` uses Mail's
-            default.
+            default; on a save-as-draft with exactly one enabled account,
+            that account is adopted so the clean (no iOS quote bug) IMAP
+            draft path can engage.
         send_now: ``False`` (default) saves as draft. ``True`` sends
             immediately and elicits user confirmation.
 
     Returns:
-        ``{"success": True, "draft_id": "<id>", "sent_message_id": ""}``
-        when saved as draft. ``draft_id`` is empty when sent.
+        ``{"success": True, "draft_id": "<id>", "sent_message_id": "",
+        "details": {...}}`` when saved as draft. ``draft_id`` is empty when
+        sent. A ``warnings`` list is included when a save-as-draft fell back
+        to the AppleScript path (whose body may render as a quote on iOS
+        Mail — Mail.app bug FB11734014); configure IMAP for the account to
+        avoid it.
     """
     try:
         # ----------------------------------------------------------------
@@ -2762,6 +2768,7 @@ async def create_draft(
             if attachment_paths is not None
             else None
         )
+        warnings: list[str] = []
         result = mail.create_draft(
             seed=seed_kind,
             seed_id=seed_id,
@@ -2775,6 +2782,7 @@ async def create_draft(
             reply_all=reply_all,
             from_account=from_account,
             send_now=send_now,
+            on_warning=warnings.append,
         )
         draft_id = result.get("draft_id", "")
 
@@ -2792,12 +2800,19 @@ async def create_draft(
             },
             "success",
         )
-        return {
+        response: dict[str, Any] = {
             "success": True,
             "draft_id": draft_id,
             "sent_message_id": result.get("sent_message_id", ""),
-            "details": {"seed_kind": seed_kind, "send_now": send_now},
+            "details": {
+                "seed_kind": seed_kind,
+                "send_now": send_now,
+                "from_account": result.get("from_account", ""),
+            },
         }
+        if warnings:
+            response["warnings"] = warnings
+        return response
 
     except Exception as e:
         handled = _draft_action_error("create_draft", e)

--- a/tests/e2e/test_mcp_tools.py
+++ b/tests/e2e/test_mcp_tools.py
@@ -394,3 +394,44 @@ class TestPromptInjectionAnnotation:
         }
         result = await server.mcp.call_tool("get_messages", {"message_ids": ["1"]})
         assert "prompt_injection" not in result.structured_content["messages"][0]
+
+
+class TestCreateDraftFallbackWarning:
+    """#270: a save-as-draft that falls back to the AppleScript path
+    surfaces a warnings list through the full FastMCP dispatch layer."""
+
+    @pytest.fixture(autouse=True)
+    def _accept_elicitation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def _accept(*_a: object, **_k: object) -> None:
+            return None
+
+        monkeypatch.setattr(
+            "apple_mail_mcp.server._elicit_confirmation", _accept
+        )
+
+    async def test_warnings_surface_through_dispatch(
+        self, mock_mail: MagicMock
+    ) -> None:
+        def fake_create_draft(**kwargs: Any) -> dict[str, str]:
+            on_warning = kwargs.get("on_warning")
+            if on_warning is not None:
+                on_warning("Draft created via AppleScript (FB11734014).")
+            return {"draft_id": "d1", "sent_message_id": "", "from_account": ""}
+
+        mock_mail.create_draft.side_effect = fake_create_draft
+        result = await server.mcp.call_tool(
+            "create_draft", {"to": ["a@example.com"], "subject": "s", "body": "b"}
+        )
+        warnings = result.structured_content["warnings"]
+        assert any("FB11734014" in w for w in warnings)
+
+    async def test_no_warnings_field_on_clean_path(
+        self, mock_mail: MagicMock
+    ) -> None:
+        mock_mail.create_draft.return_value = {
+            "draft_id": "d1", "sent_message_id": "", "from_account": "iCloud"
+        }
+        result = await server.mcp.call_tool(
+            "create_draft", {"to": ["a@example.com"], "subject": "s", "body": "b"}
+        )
+        assert "warnings" not in result.structured_content

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -5520,7 +5520,9 @@ class TestCreateDraft:
             subject="hi",
             body="hello",
         )
-        assert result == {"draft_id": "161055", "sent_message_id": ""}
+        assert result == {
+            "draft_id": "161055", "sent_message_id": "", "from_account": ""
+        }
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_new_send_returns_empty_ids(
@@ -5534,7 +5536,9 @@ class TestCreateDraft:
             body="hello",
             send_now=True,
         )
-        assert result == {"draft_id": "", "sent_message_id": ""}
+        assert result == {
+            "draft_id": "", "sent_message_id": "", "from_account": ""
+        }
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_new_script_shape(
@@ -5923,12 +5927,19 @@ class TestCreateDraft:
         script = mock_run.call_args[0][0]
         assert 'whose id is "160989"' in script
 
+    # No from_account → create_draft would auto-resolve a sole account
+    # (#321) via list_accounts; stub it out so this test isolates the RFC
+    # seed-resolution path.
+    @patch.object(
+        AppleMailConnector, "_resolve_implicit_account", return_value=None
+    )
     @patch.object(AppleMailConnector, "find_message_by_message_id")
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_unresolvable_rfc_seed_raises_message_not_found(
         self,
         mock_run: MagicMock,
         mock_resolve: MagicMock,
+        _mock_implicit: MagicMock,
         connector: AppleMailConnector,
     ) -> None:
         """When the RFC id doesn't match any message, surface the same
@@ -7348,3 +7359,180 @@ class TestCreateReplyForwardDraftViaImap:
                 body="hi",
             )
             assert "draft_id" in result
+
+
+class TestResolveImplicitAccount:
+    """#321: _resolve_implicit_account returns the sole enabled account name,
+    else None, so create_draft can engage the clean IMAP path on an
+    anonymous (no from_account) save-as-draft."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    def test_single_enabled_account_returns_name(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with patch.object(
+            AppleMailConnector, "list_accounts",
+            return_value=[{"name": "iCloud", "enabled": True}],
+        ):
+            assert connector._resolve_implicit_account() == "iCloud"
+
+    def test_zero_accounts_returns_none(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with patch.object(AppleMailConnector, "list_accounts", return_value=[]):
+            assert connector._resolve_implicit_account() is None
+
+    def test_multiple_enabled_accounts_returns_none(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with patch.object(
+            AppleMailConnector, "list_accounts",
+            return_value=[
+                {"name": "iCloud", "enabled": True},
+                {"name": "Gmail", "enabled": True},
+            ],
+        ):
+            assert connector._resolve_implicit_account() is None
+
+    def test_one_enabled_one_disabled_returns_enabled(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with patch.object(
+            AppleMailConnector, "list_accounts",
+            return_value=[
+                {"name": "iCloud", "enabled": True},
+                {"name": "OldPOP", "enabled": False},
+            ],
+        ):
+            assert connector._resolve_implicit_account() == "iCloud"
+
+    def test_list_accounts_failure_returns_none(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with patch.object(
+            AppleMailConnector, "list_accounts",
+            side_effect=RuntimeError("osascript boom"),
+        ):
+            assert connector._resolve_implicit_account() is None
+
+
+class TestCreateDraftImplicitAccountAndWarning:
+    """#321 (auto-resolve sole account) + #270 (warn on AppleScript
+    fallback) for create_draft."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    def test_no_account_single_account_takes_imap_path(
+        self, connector: AppleMailConnector
+    ) -> None:
+        # from_account omitted + exactly one enabled account → the IMAP
+        # compose path engages, using the resolved account.
+        with (
+            patch.object(
+                AppleMailConnector, "_resolve_implicit_account",
+                return_value="iCloud",
+            ),
+            patch.object(
+                AppleMailConnector, "_create_draft_via_imap",
+                return_value={"draft_id": "<m@h>", "sent_message_id": ""},
+            ) as mock_imap,
+        ):
+            result = connector.create_draft(
+                seed="new", to=["x@example.com"], subject="Hi", body="x",
+            )
+        assert result["draft_id"] == "<m@h>"
+        assert result["from_account"] == "iCloud"
+        assert mock_imap.call_args.kwargs["from_account"] == "iCloud"
+
+    def test_no_account_multi_account_falls_back_and_warns(
+        self, connector: AppleMailConnector
+    ) -> None:
+        # from_account omitted + can't auto-resolve → AppleScript path +
+        # the "no account" warning.
+        seen: list[str] = []
+        with (
+            patch.object(
+                AppleMailConnector, "_resolve_implicit_account",
+                return_value=None,
+            ),
+            patch.object(
+                AppleMailConnector, "_run_applescript", return_value="999",
+            ),
+        ):
+            result = connector.create_draft(
+                seed="new", to=["x@example.com"], subject="Hi", body="x",
+                on_warning=seen.append,
+            )
+        assert result["draft_id"] == "999"
+        assert result["from_account"] == ""
+        assert len(seen) == 1
+        assert "no from_account" in seen[0]
+        assert "FB11734014" in seen[0]
+
+    def test_account_given_imap_unavailable_warns_with_account(
+        self, connector: AppleMailConnector
+    ) -> None:
+        # Explicit account but IMAP not configured → AppleScript fallback +
+        # the account-specific warning.
+        seen: list[str] = []
+        with (
+            patch.object(
+                AppleMailConnector, "_create_draft_via_imap",
+                side_effect=MailKeychainEntryNotFoundError("no entry"),
+            ),
+            patch.object(
+                AppleMailConnector, "_resolve_account_to_sender",
+                return_value="me@icloud.com",
+            ),
+            patch.object(
+                AppleMailConnector, "_run_applescript", return_value="999",
+            ),
+        ):
+            result = connector.create_draft(
+                seed="new", to=["x@example.com"], subject="Hi", body="x",
+                from_account="iCloud", on_warning=seen.append,
+            )
+        assert result["from_account"] == "iCloud"
+        assert len(seen) == 1
+        assert "iCloud" in seen[0]
+        assert "setup-imap" in seen[0]
+
+    def test_no_warning_when_imap_succeeds(
+        self, connector: AppleMailConnector
+    ) -> None:
+        seen: list[str] = []
+        with patch.object(
+            AppleMailConnector, "_create_draft_via_imap",
+            return_value={"draft_id": "<m@h>", "sent_message_id": ""},
+        ):
+            connector.create_draft(
+                seed="new", to=["x@example.com"], subject="Hi", body="x",
+                from_account="iCloud", on_warning=seen.append,
+            )
+        assert seen == []
+
+    def test_no_warning_and_no_autoresolve_when_send_now(
+        self, connector: AppleMailConnector
+    ) -> None:
+        # send_now never auto-resolves (no IMAP send path) and never warns
+        # (the wrapper-on-sent-mail case is #322/SMTP, not #270).
+        seen: list[str] = []
+        with (
+            patch.object(
+                AppleMailConnector, "_resolve_implicit_account",
+            ) as mock_resolve,
+            patch.object(
+                AppleMailConnector, "_run_applescript", return_value="SENT",
+            ),
+        ):
+            connector.create_draft(
+                seed="new", to=["x@example.com"], subject="Hi", body="x",
+                send_now=True, on_warning=seen.append,
+            )
+        mock_resolve.assert_not_called()
+        assert seen == []

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -3053,6 +3053,79 @@ class TestCreateDraftTool:
         # Sanity: nothing in state dir.
         assert list(store.root.iterdir()) == [] if store.root.is_dir() else True
 
+    @pytest.mark.asyncio
+    async def test_on_warning_callback_passed_to_connector(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        # #270: the tool hands the connector a callback so fallback
+        # warnings can be surfaced.
+        from apple_mail_mcp.server import create_draft
+
+        mock_mail.create_draft.return_value = {
+            "draft_id": "1", "sent_message_id": ""
+        }
+        await create_draft(to=["a@example.com"], subject="hi", body="x")
+        kwargs = mock_mail.create_draft.call_args.kwargs
+        assert callable(kwargs.get("on_warning"))
+
+    @pytest.mark.asyncio
+    async def test_warnings_field_present_when_callback_fires(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        # #270: a connector that emits via on_warning surfaces a warnings
+        # list on the response.
+        from apple_mail_mcp.server import create_draft
+
+        def fake_create_draft(**kwargs: Any) -> dict[str, str]:
+            on_warning = kwargs.get("on_warning")
+            if on_warning is not None:
+                on_warning("Draft created via AppleScript (FB11734014).")
+            return {"draft_id": "1", "sent_message_id": "", "from_account": ""}
+
+        mock_mail.create_draft.side_effect = fake_create_draft
+        result = await create_draft(to=["a@example.com"], subject="hi", body="x")
+        assert "warnings" in result
+        assert any("FB11734014" in w for w in result["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_warnings_field_omitted_when_no_callback_fires(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        # No warning emitted → no warnings key (don't pollute the happy path).
+        from apple_mail_mcp.server import create_draft
+
+        mock_mail.create_draft.return_value = {
+            "draft_id": "1", "sent_message_id": "", "from_account": "iCloud"
+        }
+        result = await create_draft(to=["a@example.com"], subject="hi", body="x")
+        assert "warnings" not in result
+
+    @pytest.mark.asyncio
+    async def test_details_reports_from_account_used(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        # #321 transparency: the account the draft was created under (incl.
+        # an auto-resolved one) is surfaced in details.
+        from apple_mail_mcp.server import create_draft
+
+        mock_mail.create_draft.return_value = {
+            "draft_id": "1", "sent_message_id": "", "from_account": "iCloud"
+        }
+        result = await create_draft(to=["a@example.com"], subject="hi", body="x")
+        assert result["details"]["from_account"] == "iCloud"
+
 
 class TestUpdateDraftTool:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Children of the #245 cite-blockquote umbrella. `create_draft`'s clean IMAP-APPEND path (which avoids Mail.app bug FB11734014 — bodies rendering as a quote on iOS) previously only engaged with an explicit `from_account`, so the common no-account call silently fell back to the AppleScript path and got the wrapper, with no signal.

## #321 — auto-resolve the sole account
When `from_account` is omitted on a save-as-draft, `_resolve_implicit_account()` adopts the **sole enabled** Mail account so the clean IMAP path can engage. With exactly one account, Mail's default sender already *is* that account, so the From header is **unchanged** (no surprise). With 0 or >1 accounts, prior AppleScript behavior is preserved. `send_now` is never auto-resolved (no IMAP send path yet — that's #322).

## #270 — warn on AppleScript fallback
Adds `on_warning` to the connector `create_draft` (mirroring `search_messages`). Whenever a `send_now=False` draft lands on the AppleScript path (IMAP not configured, unreachable, non-RFC reply seed, or no resolvable account), it emits a tailored warning, surfaced via the server's `warnings: list[str]` field (omitted on the clean path). The connector now also returns the effective account, exposed as `details.from_account` for transparency.

## Tests
- Connector: `_resolve_implicit_account` (0/1/2/disabled/error); auto-resolve takes IMAP path; warning fires on multi-account & IMAP-unavailable; no warning on IMAP success or `send_now=True`.
- Server: `warnings` present/omitted, callback passed through, `details.from_account`.
- E2E: `warnings` surfaces through full FastMCP dispatch; omitted on clean path.

## Validation
unit (1263) · e2e (29) · lint · typecheck · complexity (extracted two helpers to keep `create_draft` ≤20) · doc-drift (regenerated eval descriptions) · parity — all green. TOOLS.md updated.

## Scope
Closes #321
Closes #270

#245 stays open until #269 (draft sync visibility) also lands. `send_now`/SMTP wrapper is #322 (future).

🤖 Generated with [Claude Code](https://claude.com/claude-code)