### PR TITLE
fix(#325): enforce the forbidden set in name/draft_id validators

### DIFF
--- a/src/apple_mail_mcp/drafts.py
+++ b/src/apple_mail_mcp/drafts.py
@@ -40,7 +40,10 @@ from .exceptions import MailDraftInvalidIdError
 # separator no input can escape the drafts directory. Bracketed
 # Message-IDs are normalized to bare form at the boundary before reaching
 # here. The 255-char cap is generous for any real Message-ID.
-_DRAFT_ID_RE = re.compile(r"^[A-Za-z0-9._@+=-]{1,255}$")
+# `.` is allowed (RFC Message-IDs use it) but a `..` run is a path-traversal
+# sequence (draft_id becomes a filename stem) — the negative lookahead forbids
+# it so the regex stays the single source of truth for what's accepted. (#325)
+_DRAFT_ID_RE = re.compile(r"^(?!.*\.\.)[A-Za-z0-9._@+=-]{1,255}$")
 _EXT = ".json"
 
 SeedKind = Literal["reply", "forward"]
@@ -56,7 +59,7 @@ class SeedRecord:
 
 
 def _validate_draft_id(draft_id: str) -> None:
-    if not isinstance(draft_id, str) or not _DRAFT_ID_RE.match(draft_id):
+    if not isinstance(draft_id, str) or not _DRAFT_ID_RE.fullmatch(draft_id):
         raise MailDraftInvalidIdError(
             f"draft_id {draft_id!r} must match {_DRAFT_ID_RE.pattern}"
         )

--- a/src/apple_mail_mcp/templates.py
+++ b/src/apple_mail_mcp/templates.py
@@ -178,7 +178,7 @@ def serialize_template(t: Template) -> str:
 
 
 def _validate_name(name: str) -> None:
-    if not isinstance(name, str) or not _NAME_RE.match(name):
+    if not isinstance(name, str) or not _NAME_RE.fullmatch(name):
         raise MailTemplateInvalidNameError(
             f"template name {name!r} must match {_NAME_RE.pattern}"
         )
@@ -213,7 +213,7 @@ class TemplateStore:
             if entry.suffix != _EXT or not entry.is_file():
                 continue
             name = entry.stem
-            if not _NAME_RE.match(name):
+            if not _NAME_RE.fullmatch(name):
                 continue
             try:
                 out.append(self.get(name))

--- a/tests/unit/test_drafts.py
+++ b/tests/unit/test_drafts.py
@@ -50,6 +50,30 @@ class TestValidateDraftId:
         with pytest.raises(MailDraftInvalidIdError):
             _validate_draft_id("")
 
+    def test_rejects_trailing_newline(self):
+        from apple_mail_mcp.drafts import _validate_draft_id
+
+        # #325: `$` + re.match let a trailing newline slip past an
+        # otherwise-valid id; fullmatch rejects it.
+        with pytest.raises(MailDraftInvalidIdError):
+            _validate_draft_id("160991\n")
+
+    def test_rejects_embedded_newline(self):
+        from apple_mail_mcp.drafts import _validate_draft_id
+
+        with pytest.raises(MailDraftInvalidIdError):
+            _validate_draft_id("160\n991")
+
+    def test_rejects_double_dot(self):
+        from apple_mail_mcp.drafts import _validate_draft_id
+
+        # #325: `.` is in the charset, so `..` matches the regex; it's a
+        # path-traversal sequence and must be rejected explicitly.
+        with pytest.raises(MailDraftInvalidIdError):
+            _validate_draft_id("..")
+        with pytest.raises(MailDraftInvalidIdError):
+            _validate_draft_id("a..b@host")
+
     def test_rejects_non_string(self):
         from apple_mail_mcp.drafts import _validate_draft_id
 

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -299,6 +299,8 @@ class TestTemplateStore:
             "a" * 65,  # too long
             "with.dot",
             "with$",
+            "trailing\n",  # #325: `$` + re.match let a trailing newline pass
+            "embed\nded",
         ],
     )
     def test_save_rejects_invalid_names(self, tmp_path: Path, bad_name: str):


### PR DESCRIPTION
The #214 property tests surfaced two **pre-existing** holes (both fail on `main`) where the name validators accepted inputs they document as forbidden. Discovered while implementing #269; split out as its own fix.

## Holes closed
1. **Trailing newline.** `_NAME_RE` (`templates.py:41`) and `_DRAFT_ID_RE` (`drafts.py:43`) anchor with `$` and were checked via `re.match`, so `$` matched *before* a trailing `\n` and the newline slipped past — even though `\n` is forbidden. → switch all three call sites (`templates.py:181`, `:216`, `drafts.py:59`) to `re.fullmatch`.
2. **Path traversal (`..`).** `_DRAFT_ID_RE` allows `.` (RFC Message-IDs use it), so a `..` run matched. → forbid it in the regex via a negative lookahead `(?!.*\.\.)`, keeping the pattern the single source of truth (preserves the *accepted ⟺ matches-regex* property the tests assert). The name validator's charset has no `.`, so it's unaffected.

These matter because names become **filename stems** and draft_ids are **AppleScript-interpolated / used as path stems** — exactly the path-traversal/injection surface the validators exist to guard.

## Tests
- The #214 property tests (`test_reject_or_safe_charset`, `test_reject_or_path_contained`, `test_valid_ids_always_accepted`) now pass — verified stable across repeated runs (Hypothesis is randomized).
- Added concrete regression tests: trailing/embedded newline + `..` rejection (`test_drafts.py`), newline names (`test_templates.py`).

## Validation
unit (1268) · lint · typecheck · complexity — all green. No AppleScript touched (pure validators), so no integration test required.

Closes #325