### PR TITLE
fix(#269): sync account after IMAP-APPEND so drafts surface in Mail.app

### DIFF
--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -869,6 +869,10 @@ reserved for future use. `details.from_account` is the account the draft
 was created under (including an auto-resolved one), or `""` when Mail's
 default was used.
 
+A draft created via the clean IMAP path triggers an account sync so it
+appears in Mail.app's Drafts promptly; a brief lag can still remain since
+Mail controls the final UI refresh (#269).
+
 **Warnings:** when a save-as-draft falls back to the AppleScript path
 (IMAP not configured, unreachable, no `from_account` and >1 account), the
 response includes an optional `warnings: list[str]` field noting the body

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -4552,6 +4552,11 @@ class AppleMailConnector:
         original isn't in ``seed_mailbox``. ``send_now=True`` still uses
         AppleScript.
 
+        After an IMAP-path APPEND the account is synchronized so the draft
+        appears in Mail.app's local Drafts pane promptly rather than after
+        Mail's background poll (#269); a brief lag can still remain since
+        Mail controls the final UI refresh.
+
         Args:
             seed: ``"new"``, ``"reply"``, or ``"forward"``.
             seed_id: Identifier of the message to reply/forward. Accepts
@@ -4627,6 +4632,10 @@ class AppleMailConnector:
         )
         if imap_result is not None:
             imap_result.setdefault("from_account", effective_account or "")
+            # The draft is now on the server, but Mail.app doesn't poll
+            # Drafts on its own — nudge it to sync so the draft surfaces in
+            # the local UI promptly. (#269)
+            self._sync_account_drafts(effective_account)
             return imap_result
 
         # Committed to the AppleScript path, which carries Mail.app's
@@ -4799,6 +4808,27 @@ class AppleMailConnector:
             "sent_message_id": "",
             "from_account": effective_account or "",
         }
+
+    def _sync_account_drafts(self, account: str | None) -> None:
+        """Best-effort: poke Mail.app to synchronize ``account`` so a
+        just-APPENDed draft surfaces in the local Drafts pane without
+        waiting for Mail's background poll (#269).
+
+        Never raises: the draft already exists on the server, so a sync
+        failure is a UI-latency nuisance, not a draft failure. Mail still
+        controls the final UI refresh, so a brief lag can remain.
+        """
+        if not account:
+            return
+        script = _wrap_with_timeout(
+            f'tell application "Mail" to synchronize with '
+            f"{applescript_account_clause(account)}",
+            timeout=self.timeout,
+        )
+        try:
+            self._run_applescript(script)
+        except Exception as exc:  # noqa: BLE001 — UI nicety, never fail draft
+            logger.debug("post-APPEND Drafts sync failed for %r: %s", account, exc)
 
     @staticmethod
     def _draft_fallback_warning(effective_account: str | None) -> str:

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -2689,6 +2689,10 @@ async def create_draft(
         send_now: ``False`` (default) saves as draft. ``True`` sends
             immediately and elicits user confirmation.
 
+    A draft created via the clean IMAP path triggers an account sync so it
+    shows up in Mail.app's Drafts promptly; a brief lag can still remain
+    since Mail controls the final UI refresh (#269).
+
     Returns:
         ``{"success": True, "draft_id": "<id>", "sent_message_id": "",
         "details": {...}}`` when saved as draft. ``draft_id`` is empty when

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -556,6 +556,70 @@ class TestDraftsLifecycleIntegration:
         finally:
             assert connector.delete_draft(draft_id) is True
 
+    def test_sync_account_drafts_runs_against_real_account(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """#269: the post-APPEND `synchronize with account` AppleScript is
+        accepted by the real Mail.app for the test account and does not
+        raise. (Unit tests mock _run_applescript and can't catch an
+        AppleScript syntax/dictionary error — this is the required real
+        coverage for the new script.)
+        """
+        # Best-effort by contract — assert it completes without raising.
+        connector._sync_account_drafts(test_account)
+
+    def test_imap_append_draft_becomes_visible_after_sync(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """#269: a draft created via the IMAP path (which now syncs the
+        account afterward) is readable from Mail.app's local state. Timing
+        isn't asserted — Mail controls the final UI refresh — so we poll
+        briefly for the functional outcome.
+        """
+        import time as _time
+
+        from apple_mail_mcp.exceptions import (
+            MailKeychainAccessDeniedError,
+            MailKeychainEntryNotFoundError,
+        )
+        from apple_mail_mcp.keychain import get_imap_password
+
+        try:
+            _, _, email = connector._resolve_imap_config(test_account)
+            get_imap_password(test_account, email)
+        except (
+            MailKeychainEntryNotFoundError,
+            MailKeychainAccessDeniedError,
+        ):
+            pytest.skip(
+                f"No Keychain entry for {test_account!r} — IMAP-APPEND path "
+                f"can't be exercised. Run `apple-mail-mcp setup-imap` first."
+            )
+
+        result = connector.create_draft(
+            seed="new",
+            from_account=test_account,
+            to=["test1@example.com"],
+            subject="ZZZ-AMM-INTEG-SYNC269",
+            body="post-append sync visibility body",
+        )
+        draft_id = result["draft_id"]
+        assert "@" in draft_id, (
+            f"expected IMAP-APPEND path (bare Message-ID); got {draft_id!r}"
+        )
+        try:
+            state = None
+            for _ in range(10):
+                try:
+                    state = connector.get_draft_state(draft_id)
+                    break
+                except Exception:
+                    _time.sleep(3)
+            assert state is not None, "draft never became readable within 30s"
+            assert state["subject"] == "ZZZ-AMM-INTEG-SYNC269"
+        finally:
+            assert connector.delete_draft(draft_id) is True
+
     def test_reply_save_preserves_threading_headers(
         self,
         connector: AppleMailConnector,

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -7125,8 +7125,11 @@ class TestCreateDraftImapAppend:
             send_now=False,
         )
 
-        # IMAP path used, AppleScript NOT touched.
-        mock_applescript.assert_not_called()
+        # IMAP path used for creation; the only AppleScript is the
+        # post-APPEND account sync (#269), never a draft-build script.
+        scripts = [c[0][0] for c in mock_applescript.call_args_list]
+        assert all("synchronize with" in s for s in scripts)
+        assert not any("make new outgoing message" in s for s in scripts)
         append = mock_imap_cls.return_value.append_draft
         append.assert_called_once()
         raw = append.call_args[0][0]
@@ -7245,6 +7248,11 @@ class TestCreateReplyForwardDraftViaImap:
                          return_value=("h", 993, "email@fmasi.eu")),
             patch.object(AppleMailConnector, "_resolve_account_to_sender",
                          return_value="email@fmasi.eu"),
+            # The IMAP path now fires a post-APPEND account sync (#269);
+            # stub _run_applescript so it doesn't shell out to real
+            # osascript in unit tests (#298).
+            patch.object(AppleMailConnector, "_run_applescript",
+                         return_value=""),
         ]
 
     def _run(self, connector, mock_imap, **kw):
@@ -7536,3 +7544,119 @@ class TestCreateDraftImplicitAccountAndWarning:
             )
         mock_resolve.assert_not_called()
         assert seen == []
+
+
+class TestSyncAccountDrafts:
+    """#269: after an IMAP-APPEND draft, create_draft pokes Mail.app to
+    synchronize the account so the draft surfaces in the local Drafts pane
+    promptly. Best-effort — a sync failure must never fail the draft."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=42)
+
+    def test_emits_synchronize_script_for_account(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with patch.object(
+            AppleMailConnector, "_run_applescript", return_value=""
+        ) as mock_run:
+            connector._sync_account_drafts("iCloud")
+        script = mock_run.call_args[0][0]
+        assert 'synchronize with account "iCloud"' in script
+        assert "with timeout of 42 seconds" in script
+
+    def test_uuid_account_uses_account_id_clause(
+        self, connector: AppleMailConnector
+    ) -> None:
+        uuid = "D73C0000-1111-2222-3333-444455556666"
+        with patch.object(
+            AppleMailConnector, "_run_applescript", return_value=""
+        ) as mock_run:
+            connector._sync_account_drafts(uuid)
+        script = mock_run.call_args[0][0]
+        assert f'synchronize with account id "{uuid}"' in script
+
+    def test_noop_when_account_falsy(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with patch.object(
+            AppleMailConnector, "_run_applescript"
+        ) as mock_run:
+            connector._sync_account_drafts(None)
+            connector._sync_account_drafts("")
+        mock_run.assert_not_called()
+
+    def test_swallows_applescript_failure(
+        self, connector: AppleMailConnector
+    ) -> None:
+        with patch.object(
+            AppleMailConnector, "_run_applescript",
+            side_effect=MailAppleScriptError("boom"),
+        ):
+            # Must not raise — the draft already exists server-side.
+            connector._sync_account_drafts("iCloud")
+
+    @pytest.mark.parametrize("seed", ["new", "reply"])
+    def test_create_draft_imap_success_triggers_sync(
+        self, connector: AppleMailConnector, seed: str
+    ) -> None:
+        imap_ret = {"draft_id": "<m@h>", "sent_message_id": ""}
+        method = (
+            "_create_draft_via_imap" if seed == "new"
+            else "_create_reply_forward_draft_via_imap"
+        )
+        with (
+            patch.object(AppleMailConnector, method, return_value=imap_ret),
+            patch.object(AppleMailConnector, "_sync_account_drafts") as mock_sync,
+        ):
+            kwargs: dict[str, Any] = {
+                "seed": seed, "from_account": "iCloud", "body": "x",
+            }
+            if seed == "new":
+                kwargs.update(to=["x@example.com"], subject="Hi")
+            else:
+                kwargs.update(seed_id="orig@host")
+            connector.create_draft(**kwargs)
+        mock_sync.assert_called_once_with("iCloud")
+
+    def test_create_draft_applescript_fallback_no_sync(
+        self, connector: AppleMailConnector
+    ) -> None:
+        # No from_account, can't auto-resolve → AppleScript path; sync is
+        # only for a real IMAP APPEND.
+        with (
+            patch.object(
+                AppleMailConnector, "_resolve_implicit_account",
+                return_value=None,
+            ),
+            patch.object(
+                AppleMailConnector, "_run_applescript", return_value="999",
+            ),
+            patch.object(AppleMailConnector, "_sync_account_drafts") as mock_sync,
+        ):
+            connector.create_draft(
+                seed="new", to=["x@example.com"], subject="Hi", body="x",
+            )
+        mock_sync.assert_not_called()
+
+    def test_create_draft_survives_sync_failure(
+        self, connector: AppleMailConnector
+    ) -> None:
+        # Sync going through the real helper and failing must not break a
+        # successful IMAP draft.
+        with (
+            patch.object(
+                AppleMailConnector, "_create_draft_via_imap",
+                return_value={"draft_id": "<m@h>", "sent_message_id": ""},
+            ),
+            patch.object(
+                AppleMailConnector, "_run_applescript",
+                side_effect=MailAppleScriptError("sync boom"),
+            ),
+        ):
+            result = connector.create_draft(
+                seed="new", to=["x@example.com"], subject="Hi", body="x",
+                from_account="iCloud",
+            )
+        assert result["draft_id"] == "<m@h>"


### PR DESCRIPTION
The final open child of the #245 cite-blockquote umbrella.

## Problem
The clean IMAP-APPEND draft path (#246/#292) writes straight to the server's `\Drafts` folder, but Mail.app doesn't poll Drafts on its own — a just-created draft could take **minutes** to appear in the local UI (or until the user opens Drafts). That's a regression vs the AppleScript path, where new drafts show immediately.

## Fix
After a successful IMAP-path APPEND, `create_draft` triggers `synchronize with <account>` (verified in `Mail.sdef`) via a new `_sync_account_drafts` helper. It's **best-effort** — swallows all failures, since the draft already exists server-side, so a sync hiccup is a UI-latency nuisance, not a draft failure. A single call site in `create_draft` covers both compose and reply/forward (no new branch, complexity stays under ceiling). Documented in the connector + tool docstrings and TOOLS.md (a brief lag can remain — Mail controls the final refresh).

## Tests
- **Unit:** script shape (`synchronize with account "X"`, name + UUID forms), no-op on falsy account, failure-swallow, called-on-IMAP / not-on-AppleScript-fallback, draft survives a sync failure.
- **Integration (the AppleScript hard-rule gate):** `_sync_account_drafts` runs against the real account without raising, and an IMAP-path draft is readable afterward. **Both ran and passed against a live Gmail account** (3 passed).

## Validation
unit (1276) · e2e (29) · integration (3, real Mail.app) · lint · typecheck · complexity · doc-drift · parity — all green.

Closes #269
Closes #245

With this, every actionable child of #245 is done (#246, #292, #294, #270, #321, #269). The wrapper-on-sent-mail case remains tracked separately as future work in #322 (SMTP), which was never a #245 blocker.