### PR TITLE
perf(#316): batch IMAP Message-ID→UID resolution via a chunked OR search

### DIFF
--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -289,6 +289,41 @@ def _bracket_message_id(message_id: str) -> str:
     return f"<{message_id}>"
 
 
+# Max Message-IDs folded into a single OR SEARCH. Keeps the command well
+# under server line-length limits while still collapsing the common
+# bulk-mutation case (≤50 ids) into one round-trip. (#316)
+_MSGID_SEARCH_CHUNK = 50
+
+
+def _validate_message_ids(message_ids: list[str]) -> None:
+    """Reject control characters in every Message-ID up front (the #254
+    CRLF-injection guard), before any SELECT/capability work — so a crafted
+    id is refused regardless of server capabilities or where resolution
+    happens. ``_resolve_uids_batch`` re-applies the guard when it brackets
+    ids, but the chokepoint must also fail closed early."""
+    for mid in message_ids:
+        _bracket_message_id(mid)
+
+
+def _or_message_id_criteria(message_ids: list[str]) -> list[Any]:
+    """Build an IMAP SEARCH criteria matching ANY of ``message_ids`` by
+    ``HEADER "Message-ID"``, so a batch resolves in one round-trip. (#316)
+
+    Each id is routed through :func:`_bracket_message_id` (the CRLF-injection
+    chokepoint, #254). One id yields a bare ``HEADER`` clause; N ids fold
+    into right-nested binary ``OR`` (IMAP's ``OR`` takes exactly two keys):
+    ``["OR", a, ["OR", b, c]]``. Assumes ``message_ids`` is non-empty.
+    """
+    clauses = [
+        ["HEADER", "Message-ID", _bracket_message_id(mid)]
+        for mid in message_ids
+    ]
+    criteria: list[Any] = clauses[-1]
+    for clause in reversed(clauses[:-1]):
+        criteria = ["OR", clause, criteria]
+    return criteria
+
+
 def _build_search_criteria(
     sender_contains: str | None,
     subject_contains: str | None,
@@ -1078,6 +1113,30 @@ class ImapConnector:
         with self._session() as client:
             client.rename_folder(old_name, new_name)
 
+    def _resolve_uids_batch(
+        self,
+        client: IMAPClient,
+        message_ids: list[str],
+    ) -> list[int]:
+        """Resolve RFC 5322 Message-IDs to UIDs in the selected mailbox,
+        batching the lookups into one ``OR HEADER "Message-ID"`` SEARCH per
+        ``_MSGID_SEARCH_CHUNK`` ids instead of one SEARCH per id. (#316)
+
+        Returns the matched UIDs (first-seen order, de-duplicated). Ids that
+        don't resolve are silently skipped — callers act on the whole set,
+        matching the AppleScript path's best-effort partial-success. Each id
+        is validated via :func:`_bracket_message_id` (the #254 guard).
+        """
+        uids: list[int] = []
+        seen: set[int] = set()
+        for i in range(0, len(message_ids), _MSGID_SEARCH_CHUNK):
+            chunk = message_ids[i:i + _MSGID_SEARCH_CHUNK]
+            for uid in client.search(_or_message_id_criteria(chunk)):
+                if uid not in seen:
+                    seen.add(uid)
+                    uids.append(uid)
+        return uids
+
     def move_messages(
         self,
         message_ids: list[str],
@@ -1118,7 +1177,7 @@ class ImapConnector:
             IMAPClientError: SELECT / SEARCH / MOVE / COPY / STORE /
                 EXPUNGE failed at the protocol level.
         """
-        bracketed_ids = [_bracket_message_id(mid) for mid in message_ids]
+        _validate_message_ids(message_ids)
         _reject_control_chars(source_mailbox, "source_mailbox")
         _reject_control_chars(destination_mailbox, "destination_mailbox")
 
@@ -1134,10 +1193,7 @@ class ImapConnector:
                     f"safe scoped move"
                 )
 
-            uids: list[int] = []
-            for bracketed in bracketed_ids:
-                found = client.search(["HEADER", "Message-ID", bracketed])
-                uids.extend(found)
+            uids = self._resolve_uids_batch(client, message_ids)
             if not uids:
                 return 0
 
@@ -1252,7 +1308,7 @@ class ImapConnector:
                 SPECIAL-USE or conventional names.
             IMAPClientError: Protocol-level failure.
         """
-        bracketed_ids = [_bracket_message_id(mid) for mid in message_ids]
+        _validate_message_ids(message_ids)
         _reject_control_chars(source_mailbox, "source_mailbox")
 
         with self._session() as client:
@@ -1284,10 +1340,7 @@ class ImapConnector:
 
             client.select_folder(source_mailbox, readonly=False)
 
-            uids: list[int] = []
-            for bracketed in bracketed_ids:
-                found = client.search(["HEADER", "Message-ID", bracketed])
-                uids.extend(found)
+            uids = self._resolve_uids_batch(client, message_ids)
             if not uids:
                 return 0
 
@@ -1329,16 +1382,13 @@ class ImapConnector:
             IMAPClientError: SELECT / SEARCH / STORE failed at the
                 protocol level.
         """
-        bracketed_ids = [_bracket_message_id(mid) for mid in message_ids]
+        _validate_message_ids(message_ids)
         _reject_control_chars(source_mailbox, "source_mailbox")
 
         with self._session() as client:
             client.select_folder(source_mailbox, readonly=False)
 
-            uids: list[int] = []
-            for bracketed in bracketed_ids:
-                found = client.search(["HEADER", "Message-ID", bracketed])
-                uids.extend(found)
+            uids = self._resolve_uids_batch(client, message_ids)
             if not uids:
                 return 0
 
@@ -1386,16 +1436,13 @@ class ImapConnector:
             IMAPClientError: SELECT / SEARCH / STORE failed at the
                 protocol level.
         """
-        bracketed_ids = [_bracket_message_id(mid) for mid in message_ids]
+        _validate_message_ids(message_ids)
         _reject_control_chars(source_mailbox, "source_mailbox")
 
         with self._session() as client:
             client.select_folder(source_mailbox, readonly=False)
 
-            uids: list[int] = []
-            for bracketed in bracketed_ids:
-                found = client.search(["HEADER", "Message-ID", bracketed])
-                uids.extend(found)
+            uids = self._resolve_uids_batch(client, message_ids)
             if not uids:
                 return 0
 

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -1445,6 +1445,77 @@ class TestDraftsLifecycleIntegration:
             except Exception:
                 pass
 
+    def test_flag_two_ids_resolves_via_single_or_search(
+        self,
+        connector: AppleMailConnector,
+        test_account: str,
+    ) -> None:
+        """#316: two Message-IDs flagged in one update_message call resolve
+        through a single OR-of-HEADER SEARCH. Proves imapclient's nested-OR
+        criteria actually serializes and matches on the live server (the
+        thing unit tests with a mocked client can't verify), and that both
+        ids are found in one round-trip."""
+        import uuid as _uuid
+        from datetime import datetime, timezone
+        from email.utils import format_datetime
+
+        from imapclient import IMAPClient
+
+        from apple_mail_mcp.keychain import get_imap_password
+
+        suffix = _uuid.uuid4().hex[:8]
+        src = f"ZZZ-AMM-OR316-{suffix}"
+        ids_local = [
+            f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid" for _ in range(2)
+        ]
+
+        host, port, email = connector._resolve_imap_config(test_account)
+        pw = get_imap_password(test_account, email)
+
+        assert connector.create_mailbox(account=test_account, name=src)
+        try:
+            now = format_datetime(datetime.now(tz=timezone.utc))
+            append_client = IMAPClient(host, port=port, ssl=True, timeout=30)
+            append_client.login(email, pw)
+            try:
+                for mid in ids_local:
+                    raw = (
+                        f"From: s@apple-mail-mcp-test.invalid\r\n"
+                        f"To: r@apple-mail-mcp-test.invalid\r\n"
+                        f"Subject: AMM #316 OR-search test\r\n"
+                        f"Date: {now}\r\n"
+                        f"Message-ID: <{mid}>\r\n"
+                        f"\r\nbody\r\n"
+                    ).encode()
+                    append_client.append(src, raw, flags=[])
+            finally:
+                append_client.logout()
+
+            # Both ids in one call → one OR search resolves both.
+            marked = connector.update_message(
+                ids_local, flagged=True, account=test_account,
+                source_mailbox=src,
+            )
+            assert marked == 2
+
+            verify = IMAPClient(host, port=port, ssl=True, timeout=30)
+            verify.login(email, pw)
+            try:
+                verify.select_folder(src, readonly=True)
+                for mid in ids_local:
+                    uids = verify.search(["HEADER", "Message-ID", f"<{mid}>"])
+                    assert len(uids) == 1
+                    assert b"\\Flagged" in verify.get_flags(uids)[uids[0]]
+            finally:
+                verify.logout()
+        finally:
+            try:
+                connector.delete_mailbox(
+                    account=test_account, name=src, delete_messages=True
+                )
+            except Exception:
+                pass
+
     def test_search_messages_returns_rfc_message_id_via_applescript(
         self,
         connector: AppleMailConnector,

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -10,9 +10,11 @@ from imapclient.response_types import Address, Envelope
 
 from apple_mail_mcp.exceptions import MailMessageNotFoundError
 from apple_mail_mcp.imap_connector import (
+    _MSGID_SEARCH_CHUNK,
     CONNECT_TIMEOUT_S,
     OPERATION_TIMEOUT_S,
     ImapConnector,
+    _or_message_id_criteria,
 )
 
 
@@ -1396,7 +1398,7 @@ class TestImapMoveMessages:
         client = MagicMock()
         mock_cls.return_value = client
         client.capabilities.return_value = {b"IMAP4REV1", b"MOVE", b"UIDPLUS"}
-        client.search.side_effect = [[101], [102]]
+        client.search.return_value = [101, 102]
 
         moved = ImapConnector("h", 993, "u@e.com", "pw").move_messages(
             ["msg-a@example.com", "<msg-b@example.com>"],
@@ -1420,7 +1422,7 @@ class TestImapMoveMessages:
         client = MagicMock()
         mock_cls.return_value = client
         client.capabilities.return_value = {b"IMAP4REV1", b"UIDPLUS"}
-        client.search.side_effect = [[201], [202]]
+        client.search.return_value = [201, 202]
 
         moved = ImapConnector("h", 993, "u@e.com", "pw").move_messages(
             ["a@example.com", "b@example.com"],
@@ -1488,7 +1490,7 @@ class TestImapMoveMessages:
         client = MagicMock()
         mock_cls.return_value = client
         client.capabilities.return_value = {b"MOVE"}
-        client.search.side_effect = [[1], [2]]
+        client.search.return_value = [1, 2]
 
         ImapConnector("h", 993, "u@e.com", "pw").move_messages(
             ["bare@example.com", "<wrapped@example.com>"],
@@ -1497,9 +1499,12 @@ class TestImapMoveMessages:
         )
 
         searches = [c[0][0] for c in client.search.call_args_list]
+        # One batched OR search instead of one per id (#316); both ids
+        # still pass through _bracket_message_id (the #254 guard).
         assert searches == [
-            ["HEADER", "Message-ID", "<bare@example.com>"],
-            ["HEADER", "Message-ID", "<wrapped@example.com>"],
+            ["OR",
+             ["HEADER", "Message-ID", "<bare@example.com>"],
+             ["HEADER", "Message-ID", "<wrapped@example.com>"]],
         ]
 
     @patch("apple_mail_mcp.imap_connector.IMAPClient")
@@ -1511,7 +1516,7 @@ class TestImapMoveMessages:
         client = MagicMock()
         mock_cls.return_value = client
         client.capabilities.return_value = {b"MOVE"}
-        client.search.side_effect = [[10], [], [11]]
+        client.search.return_value = [10, 11]
 
         moved = ImapConnector("h", 993, "u@e.com", "pw").move_messages(
             ["a@x", "b@x", "c@x"],
@@ -1521,6 +1526,58 @@ class TestImapMoveMessages:
 
         assert moved == 2
         client.move.assert_called_once_with([10, 11], "Archive")
+
+
+class TestResolveUidsBatch:
+    """#316: _resolve_uids_batch collapses N per-id SEARCH HEADER calls into
+    one OR-of-HEADER search per _MSGID_SEARCH_CHUNK ids."""
+
+    def test_single_id_is_a_bare_header_clause(self) -> None:
+        # No OR wrapper for one id — same shape as the old per-id search.
+        assert _or_message_id_criteria(["a@x"]) == [
+            "HEADER", "Message-ID", "<a@x>"
+        ]
+
+    def test_multiple_ids_fold_into_nested_or(self) -> None:
+        assert _or_message_id_criteria(["a@x", "b@x", "c@x"]) == [
+            "OR",
+            ["HEADER", "Message-ID", "<a@x>"],
+            ["OR",
+             ["HEADER", "Message-ID", "<b@x>"],
+             ["HEADER", "Message-ID", "<c@x>"]],
+        ]
+
+    def test_criteria_brackets_and_rejects_control_chars(self) -> None:
+        # Bracketless ids get wrapped; a control char is rejected (the #254
+        # CRLF-injection guard, via _bracket_message_id).
+        assert _or_message_id_criteria(["<x@y>"]) == [
+            "HEADER", "Message-ID", "<x@y>"
+        ]
+        with pytest.raises(ValueError, match="control character"):
+            _or_message_id_criteria(["a@x", "b\r\nEVIL@x"])
+
+    def test_empty_input_no_search(self) -> None:
+        client = MagicMock()
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        assert conn._resolve_uids_batch(client, []) == []
+        client.search.assert_not_called()
+
+    def test_one_search_per_chunk(self) -> None:
+        client = MagicMock()
+        client.search.return_value = []
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        ids = [f"id{i}@x" for i in range(_MSGID_SEARCH_CHUNK + 1)]
+        conn._resolve_uids_batch(client, ids)
+        # 51 ids @ chunk 50 → 2 searches (50 + 1).
+        assert client.search.call_count == 2
+
+    def test_dedupes_across_chunks_preserving_order(self) -> None:
+        client = MagicMock()
+        # Two chunks; overlapping UID 2 must appear once, first-seen order.
+        client.search.side_effect = [[1, 2], [2, 3]]
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        ids = [f"id{i}@x" for i in range(_MSGID_SEARCH_CHUNK + 1)]
+        assert conn._resolve_uids_batch(client, ids) == [1, 2, 3]
 
 
 # ---------------------------------------------------------------------------
@@ -1611,7 +1668,7 @@ class TestImapDeleteMessages:
         mock_cls.return_value = client
         client.capabilities.return_value = {b"IMAP4REV1", b"MOVE", b"UIDPLUS"}
         client.list_folders.return_value = self._trash_listing()
-        client.search.side_effect = [[101], [102]]
+        client.search.return_value = [101, 102]
 
         deleted = ImapConnector("h", 993, "u@e.com", "pw").delete_messages(
             ["a@example.com", "<b@example.com>"],
@@ -1634,7 +1691,7 @@ class TestImapDeleteMessages:
         mock_cls.return_value = client
         client.capabilities.return_value = {b"IMAP4REV1", b"UIDPLUS"}
         client.list_folders.return_value = self._trash_listing()
-        client.search.side_effect = [[201], [202]]
+        client.search.return_value = [201, 202]
 
         deleted = ImapConnector("h", 993, "u@e.com", "pw").delete_messages(
             ["a@x", "b@x"],
@@ -1794,16 +1851,19 @@ class TestImapDeleteMessages:
         mock_cls.return_value = client
         client.capabilities.return_value = {b"MOVE"}
         client.list_folders.return_value = self._trash_listing()
-        client.search.side_effect = [[1], [2]]
+        client.search.return_value = [1, 2]
 
         ImapConnector("h", 993, "u@e.com", "pw").delete_messages(
             ["bare@example.com", "<wrapped@example.com>"],
             source_mailbox="INBOX",
         )
         searches = [c[0][0] for c in client.search.call_args_list]
+        # One batched OR search instead of one per id (#316); both ids
+        # still pass through _bracket_message_id (the #254 guard).
         assert searches == [
-            ["HEADER", "Message-ID", "<bare@example.com>"],
-            ["HEADER", "Message-ID", "<wrapped@example.com>"],
+            ["OR",
+             ["HEADER", "Message-ID", "<bare@example.com>"],
+             ["HEADER", "Message-ID", "<wrapped@example.com>"]],
         ]
 
     @patch("apple_mail_mcp.imap_connector.IMAPClient")
@@ -1816,7 +1876,7 @@ class TestImapDeleteMessages:
         mock_cls.return_value = client
         client.capabilities.return_value = {b"MOVE"}
         client.list_folders.return_value = self._trash_listing()
-        client.search.side_effect = [[10], [], [11]]
+        client.search.return_value = [10, 11]
 
         deleted = ImapConnector("h", 993, "u@e.com", "pw").delete_messages(
             ["a@x", "b@x", "c@x"],
@@ -1837,7 +1897,7 @@ class TestImapSetReadStatus:
     ) -> None:
         client = MagicMock()
         mock_cls.return_value = client
-        client.search.side_effect = [[101], [102]]
+        client.search.return_value = [101, 102]
 
         marked = ImapConnector("h", 993, "u@e.com", "pw").set_read_status(
             ["a@example.com", "b@example.com"],
@@ -1858,7 +1918,7 @@ class TestImapSetReadStatus:
     ) -> None:
         client = MagicMock()
         mock_cls.return_value = client
-        client.search.side_effect = [[201], [202]]
+        client.search.return_value = [201, 202]
 
         marked = ImapConnector("h", 993, "u@e.com", "pw").set_read_status(
             ["a@x", "b@x"],
@@ -1898,7 +1958,7 @@ class TestImapSetReadStatus:
         arrive at SEARCH HEADER as the bracketed RFC 5322 form."""
         client = MagicMock()
         mock_cls.return_value = client
-        client.search.side_effect = [[1], [2]]
+        client.search.return_value = [1, 2]
 
         ImapConnector("h", 993, "u@e.com", "pw").set_read_status(
             ["bare@example.com", "<wrapped@example.com>"],
@@ -1906,9 +1966,12 @@ class TestImapSetReadStatus:
             read=True,
         )
         searches = [c[0][0] for c in client.search.call_args_list]
+        # One batched OR search instead of one per id (#316); both ids
+        # still pass through _bracket_message_id (the #254 guard).
         assert searches == [
-            ["HEADER", "Message-ID", "<bare@example.com>"],
-            ["HEADER", "Message-ID", "<wrapped@example.com>"],
+            ["OR",
+             ["HEADER", "Message-ID", "<bare@example.com>"],
+             ["HEADER", "Message-ID", "<wrapped@example.com>"]],
         ]
 
     @patch("apple_mail_mcp.imap_connector.IMAPClient")
@@ -1919,7 +1982,7 @@ class TestImapSetReadStatus:
         the 2; return 2."""
         client = MagicMock()
         mock_cls.return_value = client
-        client.search.side_effect = [[10], [], [11]]
+        client.search.return_value = [10, 11]
 
         marked = ImapConnector("h", 993, "u@e.com", "pw").set_read_status(
             ["a@x", "b@x", "c@x"],
@@ -1965,7 +2028,7 @@ class TestImapSetFlaggedStatus:
     ) -> None:
         client = MagicMock()
         mock_cls.return_value = client
-        client.search.side_effect = [[101], [102]]
+        client.search.return_value = [101, 102]
 
         marked = ImapConnector("h", 993, "u@e.com", "pw").set_flagged_status(
             ["a@example.com", "b@example.com"],
@@ -1986,7 +2049,7 @@ class TestImapSetFlaggedStatus:
     ) -> None:
         client = MagicMock()
         mock_cls.return_value = client
-        client.search.side_effect = [[201], [202]]
+        client.search.return_value = [201, 202]
 
         marked = ImapConnector("h", 993, "u@e.com", "pw").set_flagged_status(
             ["a@x", "b@x"],
@@ -2025,7 +2088,7 @@ class TestImapSetFlaggedStatus:
         """Mix of bracketless and bracketed Message-IDs as input."""
         client = MagicMock()
         mock_cls.return_value = client
-        client.search.side_effect = [[1], [2]]
+        client.search.return_value = [1, 2]
 
         ImapConnector("h", 993, "u@e.com", "pw").set_flagged_status(
             ["bare@example.com", "<wrapped@example.com>"],
@@ -2033,9 +2096,12 @@ class TestImapSetFlaggedStatus:
             flagged=True,
         )
         searches = [c[0][0] for c in client.search.call_args_list]
+        # One batched OR search instead of one per id (#316); both ids
+        # still pass through _bracket_message_id (the #254 guard).
         assert searches == [
-            ["HEADER", "Message-ID", "<bare@example.com>"],
-            ["HEADER", "Message-ID", "<wrapped@example.com>"],
+            ["OR",
+             ["HEADER", "Message-ID", "<bare@example.com>"],
+             ["HEADER", "Message-ID", "<wrapped@example.com>"]],
         ]
 
     @patch("apple_mail_mcp.imap_connector.IMAPClient")
@@ -2046,7 +2112,7 @@ class TestImapSetFlaggedStatus:
         the 2; return 2."""
         client = MagicMock()
         mock_cls.return_value = client
-        client.search.side_effect = [[10], [], [11]]
+        client.search.return_value = [10, 11]
 
         marked = ImapConnector("h", 993, "u@e.com", "pw").set_flagged_status(
             ["a@x", "b@x", "c@x"],


### PR DESCRIPTION
## Problem
The IMAP move/delete/flag/read mutators resolved each Message-ID with its own `SEARCH HEADER "Message-ID"` round-trip (~400ms on iCloud), so `update_message`'s bulk move-only fast path ran **~6× slower** than the AppleScript bulk path (~24s vs ~4s for 50 messages, #316).

## Fix
`_resolve_uids_batch` now folds up to `_MSGID_SEARCH_CHUNK` (50) ids into a single `OR HEADER Message-ID` search, so resolution costs **O(N/50) round-trips instead of O(N)** — and crucially scales with the **number of ids**, not mailbox size. Applied to all four mutators (move/delete/set_read/set_flagged).

## Built on @zsxh1990's #324
This builds directly on @zsxh1990's [PR #324](https://github.com/s-morgan-jeffries/apple-mail-mcp/pull/324), which correctly diagnosed the O(N) round-trips and introduced the shared `_resolve_uids_batch` helper — that structure is kept and they're credited as co-author. The change swaps the *resolution mechanism* from "`search("ALL")` + FETCH every `ENVELOPE` in the mailbox" to the OR search, which avoids:
- **Scaling with mailbox size** (the original fetched ~47k envelopes to move 3 messages out of a large INBOX; the #287 benchmark's small seeded source masked this);
- a **strict-`decode()` failure mode** (one malformed id aborting the whole op);
- **dropping the #254 CRLF-injection guard**.

## Safety
Every id still routes through `_bracket_message_id` (the #254 chokepoint), and a new `_validate_message_ids` keeps that guard firing **up front**, before the SELECT/capability checks — so a crafted id is rejected regardless of server capabilities (restores the ordering the per-method bracketing had).

## Tests
- **Unit:** new `TestResolveUidsBatch` (single→bare clause, N→nested OR, chunk boundary → 2 searches, cross-chunk dedupe, empty→no search, control-char→`ValueError`); the 4 mutator classes updated to assert one batched OR search; the CRLF-injection tests still pass (guard fires pre-capability).
- **Integration (live account):** new `test_flag_two_ids_resolves_via_single_or_search` flags two ids in one call — proving imapclient's nested-OR actually serializes and matches on a real server (2 passed against the live account).

## Validation
unit (1282) · e2e (29) · integration (real account) · lint · typecheck · complexity · doc-drift · applescript-safety · parity — all green.

Closes #316