### PR TITLE
feat(#280): make update_rule confirmation dangerous-action-aware

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -449,12 +449,15 @@ Patch semantics: only fields you provide are changed. ``conditions`` and
 ``actions``, when provided, REPLACE their respective structures wholesale
 (not merged).
 
-Conditional confirmation: prompts the user via MCP elicitation only when
-the patch touches ``conditions``, ``actions``, or ``match_logic`` —
-those replacements are irrecoverable. Patches limited to ``enabled``
-and/or ``name`` (trivially reversible) skip the prompt. The
-enable/disable path replaces the removed ``set_rule_enabled`` tool: call
-``update_rule(rule_index, enabled=True|False)``.
+Conditional confirmation: prompts the user via MCP elicitation when the
+patch touches ``conditions`` or ``match_logic`` (which alter matching
+scope), or replaces ``actions`` with a set that includes a dangerous
+action (move / forward / delete / copy). An ``actions`` patch limited to
+organizational flags (``mark_read`` / ``mark_flagged`` / ``flag_color``)
+skips the prompt, as do patches limited to ``enabled`` and/or ``name``
+(trivially reversible). The enable/disable path replaces the removed
+``set_rule_enabled`` tool: call ``update_rule(rule_index,
+enabled=True|False)``.
 
 Refuses to update any rule whose existing actions include something
 outside the supported schema (run-AppleScript, redirect, reply text,

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -549,12 +549,15 @@ async def update_rule(
     ``actions``, when provided, REPLACE their respective structures wholesale
     (not merged).
 
-    Conditional confirmation: prompts the user via MCP elicitation only when
-    the patch touches ``conditions``, ``actions``, or ``match_logic`` —
-    those replacements are irrecoverable. Patches limited to ``enabled``
-    and/or ``name`` (trivially reversible) skip the prompt. The
-    enable/disable path replaces the removed ``set_rule_enabled`` tool: call
-    ``update_rule(rule_index, enabled=True|False)``.
+    Conditional confirmation: prompts the user via MCP elicitation when the
+    patch touches ``conditions`` or ``match_logic`` (which alter matching
+    scope), or replaces ``actions`` with a set that includes a dangerous
+    action (move / forward / delete / copy). An ``actions`` patch limited to
+    organizational flags (``mark_read`` / ``mark_flagged`` / ``flag_color``)
+    skips the prompt, as do patches limited to ``enabled`` and/or ``name``
+    (trivially reversible). The enable/disable path replaces the removed
+    ``set_rule_enabled`` tool: call ``update_rule(rule_index,
+    enabled=True|False)``.
 
     Refuses to update any rule whose existing actions include something
     outside the supported schema (run-AppleScript, redirect, reply text,
@@ -593,10 +596,15 @@ async def update_rule(
         if safety_err:
             return safety_err
 
+        # Dangerous-action-aware gate (#280, mirrors create_rule #222):
+        # conditions / match_logic patches alter matching scope and always
+        # confirm; an actions patch confirms only when it carries a
+        # dangerous action (move/forward/delete/copy) — organizational-only
+        # patches (mark_read / mark_flagged / flag_color) skip the prompt.
         needs_confirmation = (
             conditions is not None
-            or actions is not None
             or match_logic is not None
+            or (actions is not None and _rule_actions_require_confirmation(actions))
         )
         if needs_confirmation:
             summary = (

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -501,15 +501,17 @@ class TestUpdateRule:
         mock_ctx_accept.elicit.assert_awaited_once()
         mock_mail.update_rule.assert_called_once()
 
-    async def test_actions_patch_prompts_and_succeeds(
+    async def test_dangerous_actions_patch_prompts_and_succeeds(
         self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
     ) -> None:
+        # #280: a patch that installs a dangerous action (move/forward/
+        # delete/copy) still confirms.
         mock_mail.list_rules.return_value = [
             {"index": 1, "name": "Junk filter", "enabled": True},
         ]
         result = await update_rule(
             rule_index=1,
-            actions={"mark_read": True},
+            actions={"move_to": "Archive"},
             ctx=mock_ctx_accept,
         )
         assert result["success"] is True
@@ -596,6 +598,37 @@ class TestUpdateRule:
             {"index": 1, "name": "X", "enabled": True},
         ]
         result = await update_rule(rule_index=1, enabled=True)
+        assert result["success"] is True
+        mock_mail.update_rule.assert_called_once()
+
+    async def test_organizational_actions_patch_does_not_prompt(
+        self, mock_mail: MagicMock, mock_ctx_accept: MagicMock
+    ) -> None:
+        # #280: an actions patch limited to organizational flags
+        # (mark_read / mark_flagged / flag_color) skips the prompt.
+        mock_mail.list_rules.return_value = [
+            {"index": 1, "name": "Junk filter", "enabled": True},
+        ]
+        result = await update_rule(
+            rule_index=1,
+            actions={"mark_read": True, "mark_flagged": True},
+            ctx=mock_ctx_accept,
+        )
+        assert result["success"] is True
+        mock_ctx_accept.elicit.assert_not_awaited()
+        mock_mail.update_rule.assert_called_once()
+
+    async def test_organizational_actions_patch_succeeds_without_ctx(
+        self, mock_mail: MagicMock
+    ) -> None:
+        # #280 ergonomics: organizational-only actions no longer fail closed
+        # when no ctx is available (previously every actions patch gated).
+        mock_mail.list_rules.return_value = [
+            {"index": 1, "name": "X", "enabled": True},
+        ]
+        result = await update_rule(
+            rule_index=1, actions={"mark_read": True}
+        )
         assert result["success"] is True
         mock_mail.update_rule.assert_called_once()
 


### PR DESCRIPTION
Follow-up to #222 (which made `create_rule`'s confirmation dangerous-action-aware).

## Problem
`update_rule` prompted via `_elicit_confirmation` on **every** `conditions` / `actions` / `match_logic` patch — including organizational-only `actions` patches like `{"mark_read": True}`. Safe (it over-gates, never under-gates), but annoying ergonomics.

## Change
Reuse the existing `_rule_actions_require_confirmation` helper so the gate is:
```python
needs_confirmation = (
    conditions is not None
    or match_logic is not None
    or (actions is not None and _rule_actions_require_confirmation(actions))
)
```
- `conditions` / `match_logic` patches → still always confirm (they alter matching scope).
- `actions` patch → confirms only with a dangerous action (move / forward / delete / copy); organizational-only (mark_read / mark_flagged / flag_color) skips the prompt.
- Decline / `ctx=None` fail-closed behavior preserved for every case that still gates.

Mirrors `create_rule`. Docstring updated; no connector/AppleScript change.

## Tests
- Org-only actions patch → no prompt; succeeds (incl. without `ctx`, the ergonomics win).
- Dangerous actions patch (`move_to`) → still prompts.
- `conditions` / `match_logic` prompt tests and the dangerous-action decline test unchanged.

## Validation
unit (1284) · e2e (29) · lint · typecheck · complexity · doc-drift (eval descriptions regenerated) · parity — all green. No AppleScript touched, so no integration test required.

Closes #280