### PR TITLE
chore(#335): rebrand to apple-mail-fast-mcp (repo + PyPI + CLI) + trusted publishing

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Vulnerability
-    url: https://github.com/s-morgan-jeffries/apple-mail-mcp/security/advisories/new
+    url: https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/security/advisories/new
     about: Report security vulnerabilities via private advisory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,23 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+
+  # Publish to PyPI via OIDC trusted publishing (#335) — no API token.
+  # Requires a PyPI trusted publisher registered for this repo with
+  # workflow `release.yml` and environment `pypi`. Runs only on real
+  # version tags (the `v*` / `!v*-rc*` filter above); RC tags go to
+  # release-hygiene.yml and never publish.
+  publish-pypi:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # mint the short-lived OIDC token for PyPI
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ The process changes shipping in this milestone (#87, #88, #90) — issue-first g
 ## Setup
 
 ```bash
-git clone https://github.com/s-morgan-jeffries/apple-mail-mcp.git
-cd apple-mail-mcp
+git clone https://github.com/s-morgan-jeffries/apple-mail-fast-mcp.git
+cd apple-mail-fast-mcp
 uv sync --dev
 ./scripts/install-git-hooks.sh
 ```

--- a/MCP_PLAYBOOK.md
+++ b/MCP_PLAYBOOK.md
@@ -174,7 +174,7 @@ All subprocess execution goes through one method (e.g., `_run_applescript(script
 
 | Element | Convention | Example |
 |---------|-----------|---------|
-| Project directory | kebab-case | `apple-mail-mcp` |
+| Project directory | kebab-case | `apple-mail-fast-mcp` |
 | Python package | snake_case | `apple_mail_mcp` |
 | Source modules | snake_case | `mail_connector.py` |
 | Test files | `test_` prefix + feature | `test_attachments.py` |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Apple Mail MCP Server
 
-[![Tests](https://github.com/s-morgan-jeffries/apple-mail-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/s-morgan-jeffries/apple-mail-mcp/actions/workflows/test.yml)
+[![Tests](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/actions/workflows/test.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 An MCP server that provides programmatic access to Apple Mail, enabling AI assistants like Claude to read, send, search, and manage emails on macOS.
 
-> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-mcp==0.9.1`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
+> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-fast-mcp==0.9.1`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
 
 ## Tools (23)
 
@@ -33,26 +33,26 @@ Destructive operations (`delete_*`, `create_rule` with move/forward/delete actio
 
 ```bash
 # From source (recommended for development)
-git clone https://github.com/s-morgan-jeffries/apple-mail-mcp.git
-cd apple-mail-mcp
+git clone https://github.com/s-morgan-jeffries/apple-mail-fast-mcp.git
+cd apple-mail-fast-mcp
 uv sync --dev
 ```
 
 ## Configuration
 
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`). `uv sync` installs a console script at `.venv/bin/apple-mail-mcp`; point Claude Desktop at its **absolute path** — it's the most reliable form under Claude Desktop's restricted spawn environment (no reliance on `uv` being on `PATH`):
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`). `uv sync` installs a console script at `.venv/bin/apple-mail-fast-mcp`; point Claude Desktop at its **absolute path** — it's the most reliable form under Claude Desktop's restricted spawn environment (no reliance on `uv` being on `PATH`):
 
 ```json
 {
   "mcpServers": {
     "apple-mail": {
-      "command": "/path/to/apple-mail-mcp/.venv/bin/apple-mail-mcp"
+      "command": "/path/to/apple-mail-fast-mcp/.venv/bin/apple-mail-fast-mcp"
     }
   }
 }
 ```
 
-(Equivalent alternative if you prefer driving it through uv: `"command": "uv", "args": ["--directory", "/path/to/apple-mail-mcp", "run", "apple-mail-mcp"]`.)
+(Equivalent alternative if you prefer driving it through uv: `"command": "uv", "args": ["--directory", "/path/to/apple-mail-fast-mcp", "run", "apple-mail-fast-mcp"]`.)
 
 ### Optional: split read / write servers
 
@@ -62,11 +62,11 @@ Claude Desktop prompts per-tool for permission. If you want to **batch-approve t
 {
   "mcpServers": {
     "apple-mail-read": {
-      "command": "/path/to/apple-mail-mcp/.venv/bin/apple-mail-mcp",
+      "command": "/path/to/apple-mail-fast-mcp/.venv/bin/apple-mail-fast-mcp",
       "args": ["--read-only"]
     },
     "apple-mail-write": {
-      "command": "/path/to/apple-mail-mcp/.venv/bin/apple-mail-mcp"
+      "command": "/path/to/apple-mail-fast-mcp/.venv/bin/apple-mail-fast-mcp"
     }
   }
 }
@@ -94,7 +94,7 @@ On first run, macOS will prompt for Automation access. Grant permission in:
 
 2. Run the `setup-imap` subcommand. It prompts for the password (no echo), writes the Keychain entry, and verifies by connecting:
    ```bash
-   apple-mail-mcp setup-imap --account iCloud
+   apple-mail-fast-mcp setup-imap --account iCloud
    ```
    Substitute the Mail.app account name exactly — whatever it's labeled in Mail.app (e.g. `iCloud`, `Gmail`, `"Yahoo!"`). The CLI:
    - looks up the account's primary email from Mail.app (override with `--email`),
@@ -104,7 +104,7 @@ On first run, macOS will prompt for Automation access. Grant permission in:
 
 3. If you see a one-time "security wants to use the 'login' keychain" prompt on the next IMAP-backed call, click **Always Allow**.
 
-To remove the entry later: `apple-mail-mcp setup-imap --account iCloud --uninstall`.
+To remove the entry later: `apple-mail-fast-mcp setup-imap --account iCloud --uninstall`.
 
 **Verifying the setup.** The `setup-imap` command does this for you. If you want to spot-check post-hoc:
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it via [GitHub private security advisory](https://github.com/s-morgan-jeffries/apple-mail-mcp/security/advisories/new).
+If you discover a security vulnerability, please report it via [GitHub private security advisory](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/security/advisories/new).
 
 **Do not open a public issue for security vulnerabilities.**
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -496,6 +496,6 @@ Security fixes are released as soon as possible:
 
 If you have security questions or concerns:
 
-- **General**: [GitHub Discussions](https://github.com/s-morgan-jeffries/apple-mail-mcp/discussions)
+- **General**: [GitHub Discussions](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/discussions)
 - **Vulnerabilities**: security@[domain] (private)
-- **Best Practices**: [GitHub Issues](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues)
+- **Best Practices**: [GitHub Issues](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues)

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -14,7 +14,7 @@ uv sync --dev
 ```
 
 Run anything in that environment with `uv run …` (e.g. `uv run pytest`, `uv run python -m
-apple_mail_mcp.server`). `uv sync` also installs the `apple-mail-mcp` console script into
+apple_mail_mcp.server`). `uv sync` also installs the `apple-mail-fast-mcp` console script into
 `.venv/bin/`.
 
 ## The canonical check: `make check-all`

--- a/docs/guides/SECURITY_CHECKLIST.md
+++ b/docs/guides/SECURITY_CHECKLIST.md
@@ -18,7 +18,7 @@ Any sanitized string that gets interpolated into AppleScript source must additio
 safe = escape_applescript_string(sanitize_input(user_value))
 ```
 
-A common mistake is escaping but forgetting the literal AppleScript string quotes around the interpolation site — `whose id is {safe}` parses dashes as subtraction operators on UUID-style ids and crashes. Always wrap in quotes: `whose id is "{safe}"`. See [#86](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/86) for the bug this prevented.
+A common mistake is escaping but forgetting the literal AppleScript string quotes around the interpolation site — `whose id is {safe}` parses dashes as subtraction operators on UUID-style ids and crashes. Always wrap in quotes: `whose id is "{safe}"`. See [#86](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/86) for the bug this prevented.
 
 For lists of values (e.g. message-id lists), each element must be individually sanitized + escaped + quoted, then joined:
 

--- a/docs/guides/THREAT_MODEL.md
+++ b/docs/guides/THREAT_MODEL.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-> Reviewer-oriented STRIDE analysis of the trust boundaries crossed by `apple-mail-mcp`. Companion to [`SECURITY_CHECKLIST.md`](SECURITY_CHECKLIST.md) (how to build safely) and [`../SECURITY.md`](../SECURITY.md) (user-facing posture).
+> Reviewer-oriented STRIDE analysis of the trust boundaries crossed by `apple-mail-fast-mcp`. Companion to [`SECURITY_CHECKLIST.md`](SECURITY_CHECKLIST.md) (how to build safely) and [`../SECURITY.md`](../SECURITY.md) (user-facing posture).
 
 ## Overview
 
@@ -115,10 +115,10 @@ Findings flagged `⚠️` in the tables above, mapped to tracked issues:
 
 | Boundary | Gap | Issue |
 |---|---|---|
-| osascript / AppleScript (§1) | Non-wrapped AS paths bypass `with timeout of N` | [#233](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/233) |
-| IMAP (§2) | Audit every IMAP→AS path applies `escape_applescript_string` | [#214](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/214) (property tests) |
-| MCP / LLM-as-conduit (§5) | Injection detection is warn-only + regex (recall-tuned) — surfaces a `prompt_injection` warning but doesn't block; subtle attacks may slip | [#225](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/225) (warn-only shipped; block / LLM-classifier deferred) |
-| MCP / LLM-as-conduit (§5) | `create_rule` does not gate dangerous actions (move / forward / delete / copy) | [#222](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/222) |
+| osascript / AppleScript (§1) | Non-wrapped AS paths bypass `with timeout of N` | [#233](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/233) |
+| IMAP (§2) | Audit every IMAP→AS path applies `escape_applescript_string` | [#214](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/214) (property tests) |
+| MCP / LLM-as-conduit (§5) | Injection detection is warn-only + regex (recall-tuned) — surfaces a `prompt_injection` warning but doesn't block; subtle attacks may slip | [#225](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/225) (warn-only shipped; block / LLM-classifier deferred) |
+| MCP / LLM-as-conduit (§5) | `create_rule` does not gate dangerous actions (move / forward / delete / copy) | [#222](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/222) |
 
 Lower-severity / informational items (not tracked as issues):
 

--- a/docs/plans/2026-05-22-issue-213-threat-model-design.md
+++ b/docs/plans/2026-05-22-issue-213-threat-model-design.md
@@ -13,7 +13,7 @@ The project has two existing security docs:
 
 Neither doc lets a reviewer answer "what's the worst thing an attacker could do, and what stops them?" without reading source. As the project moves toward broader distribution, an explicit STRIDE-style write-up makes trust boundaries legible and surfaces gaps the checklist wouldn't catch.
 
-This issue produces that doc. SECURITY.md's full reconciliation happens later in [#220](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/220) (docs refresh); here, we leave SECURITY.md alone except for a one-line cross-link pointing at the new threat model.
+This issue produces that doc. SECURITY.md's full reconciliation happens later in [#220](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/220) (docs refresh); here, we leave SECURITY.md alone except for a one-line cross-link pointing at the new threat model.
 
 ## Non-goals
 

--- a/docs/plans/2026-05-22-issue-213-threat-model.md
+++ b/docs/plans/2026-05-22-issue-213-threat-model.md
@@ -42,7 +42,7 @@ Create `docs/guides/THREAT_MODEL.md` with this exact content (sections will be f
 ```markdown
 # Threat Model
 
-> Reviewer-oriented STRIDE analysis of the trust boundaries crossed by `apple-mail-mcp`. Companion to [`SECURITY_CHECKLIST.md`](SECURITY_CHECKLIST.md) (how to build safely) and [`../SECURITY.md`](../SECURITY.md) (user-facing posture).
+> Reviewer-oriented STRIDE analysis of the trust boundaries crossed by `apple-mail-fast-mcp`. Companion to [`SECURITY_CHECKLIST.md`](SECURITY_CHECKLIST.md) (how to build safely) and [`../SECURITY.md`](../SECURITY.md) (user-facing posture).
 
 ## Overview
 
@@ -327,11 +327,11 @@ Findings flagged `⚠️` in the tables above, mapped to tracked issues:
 
 | Boundary | Gap | Issue |
 |---|---|---|
-| osascript / AppleScript (§1) | Non-wrapped AS paths bypass `with timeout of N` | [#233](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/233) |
-| IMAP (§2) | Audit every IMAP→AS path applies `escape_applescript_string` | [#214](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/214) (property tests) |
-| Filesystem (§4) | No byte cap on `save_attachments` | [#NNN](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/NNN) (filed from this work) |
-| MCP / LLM-as-conduit (§5) | No automated prompt-injection detection on `get_message` responses | [#225](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/225) (planning) |
-| MCP / LLM-as-conduit (§5) | `create_rule` does not gate dangerous actions (move / forward / delete / copy) | [#222](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/222) |
+| osascript / AppleScript (§1) | Non-wrapped AS paths bypass `with timeout of N` | [#233](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/233) |
+| IMAP (§2) | Audit every IMAP→AS path applies `escape_applescript_string` | [#214](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/214) (property tests) |
+| Filesystem (§4) | No byte cap on `save_attachments` | [#NNN](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/NNN) (filed from this work) |
+| MCP / LLM-as-conduit (§5) | No automated prompt-injection detection on `get_message` responses | [#225](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/225) (planning) |
+| MCP / LLM-as-conduit (§5) | `create_rule` does not gate dangerous actions (move / forward / delete / copy) | [#222](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/222) |
 
 Lower-severity / informational items (not tracked as issues):
 

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -30,7 +30,7 @@ with no extra setup. On top of that, several read and bulk-mutation operations t
 path** when two conditions hold:
 
 1. the caller hints the location — an `account` (and, where relevant, a `source_mailbox` / `mailbox`), and
-2. the account has Keychain IMAP credentials (opt-in via `apple-mail-mcp setup-imap`).
+2. the account has Keychain IMAP credentials (opt-in via `apple-mail-fast-mcp setup-imap`).
 
 When both hold, the connector issues server-side IMAP (e.g. `SEARCH`, `UID MOVE`, `STORE`) instead of
 driving Mail.app's per-message AppleScript loop. **On any IMAP failure** — no credentials, bad

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -62,7 +62,7 @@ Search for messages matching specified criteria.
 
 **Performance note for `body_contains` / `text_contains`:**
 
-On the IMAP path, body search is server-side and sub-second. On the AppleScript fallback, body search is **dramatically slower** — measured 148s for 100 cold-cache messages on a 47k-message INBOX, vs 1s for `subject_contains` on the same slice. This is because Mail.app must read each candidate message's body from disk. To get sub-second body search, run `apple-mail-mcp setup-imap --account <name>` to enable IMAP delegation for that account.
+On the IMAP path, body search is server-side and sub-second. On the AppleScript fallback, body search is **dramatically slower** — measured 148s for 100 cold-cache messages on a 47k-message INBOX, vs 1s for `subject_contains` on the same slice. This is because Mail.app must read each candidate message's body from disk. To get sub-second body search, run `apple-mail-fast-mcp setup-imap --account <name>` to enable IMAP delegation for that account.
 
 When the call commits to the AppleScript path **and** a body/text filter is set, the response includes a `warnings` field describing the cost — see "Warnings" below.
 
@@ -76,7 +76,7 @@ When the call commits to the AppleScript path **and** a body/text filter is set,
   "messages": [...],
   "count": 17,
   "warnings": [
-    "AppleScript body search can take minutes on large mailboxes (measured 148s for 100 cold-cache messages on a 47k-message Gmail INBOX). Run `apple-mail-mcp setup-imap --account 'Gmail'` for sub-second IMAP body search."
+    "AppleScript body search can take minutes on large mailboxes (measured 148s for 100 cold-cache messages on a 47k-message Gmail INBOX). Run `apple-mail-fast-mcp setup-imap --account 'Gmail'` for sub-second IMAP body search."
   ]
 }
 ```
@@ -172,7 +172,7 @@ Retrieve full details of one or more messages, with bodies. Returns a list (alwa
 
 **Performance note (path-dependent cost):**
 
-For accounts configured with IMAP (via `apple-mail-mcp setup-imap --account <name>`), `include_attachments` is essentially free — `BODYSTRUCTURE` bundles into the existing FETCH. For accounts without IMAP, the AppleScript fallback enumerates attachments per message — fine for small id lists (1-10) but can be slow on cold caches for larger lists. If you have a mix of IMAP-configured and non-IMAP accounts, expect variance. To opt out: pass `include_attachments=False`.
+For accounts configured with IMAP (via `apple-mail-fast-mcp setup-imap --account <name>`), `include_attachments` is essentially free — `BODYSTRUCTURE` bundles into the existing FETCH. For accounts without IMAP, the AppleScript fallback enumerates attachments per message — fine for small id lists (1-10) but can be slow on cold caches for larger lists. If you have a mix of IMAP-configured and non-IMAP accounts, expect variance. To opt out: pass `include_attachments=False`.
 
 **Returns:**
 
@@ -354,7 +354,7 @@ Patch one or more messages: change read state, flag color, and/or move to anothe
 - **Read-status-only patches (#151):** When `read_status` is the only field set and `account` + `source_mailbox` are provided, the read/unread mutation runs server-side via IMAP `UID STORE +/-FLAGS (\Seen)`. `\Seen` is base IMAP (RFC 3501), universal across all servers — no capability check needed.
 - **Flag-only patches (#152):** When `flagged` is the only field set (no `flag_color`) and `account` + `source_mailbox` are provided, the flag/unflag runs server-side via IMAP `UID STORE +/-FLAGS (\Flagged)`. Same base-IMAP universality as `\Seen`. Bare `\Flagged` renders identically in Mail.app to the existing AppleScript default flag (verified empirically, no UI divergence). **Caveat on unflag:** calling `flagged=False` via this path on a message that was previously color-flagged removes `\Flagged` but does NOT remove the `$MailFlagBit*` color keyword Mail.app set — standard IMAP clients show no flag, but Mail.app may resurface the color on next sync. To clean both: omit `source_mailbox` (forces AppleScript, which also clears `flag index`), or use `flag_color="none"` instead.
 
-Combined patches (move + read, read + flag, etc.) and any patch with `flag_color` set currently run via AppleScript regardless — Mail.app's color attributes (`$MailFlagBit*` user keywords) are out of IMAP scope. All fast paths require Keychain credentials per the IMAP setup flow (`apple-mail-mcp setup-imap --account <name>`); they fall back to AppleScript transparently when IMAP isn't configured.
+Combined patches (move + read, read + flag, etc.) and any patch with `flag_color` set currently run via AppleScript regardless — Mail.app's color attributes (`$MailFlagBit*` user keywords) are out of IMAP scope. All fast paths require Keychain credentials per the IMAP setup flow (`apple-mail-fast-mcp setup-imap --account <name>`); they fall back to AppleScript transparently when IMAP isn't configured.
 
 **Returns:**
 
@@ -778,7 +778,7 @@ Delete messages — always moves them to the account's Trash mailbox.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `message_ids` | list[string] | Yes | - | List of message IDs to delete |
-| `permanent` | boolean | No | False | Reserved; currently a no-op. Passing `True` emits a `DeprecationWarning`. See [issue #111](https://github.com/s-morgan-jeffries/apple-mail-mcp/issues/111). |
+| `permanent` | boolean | No | False | Reserved; currently a no-op. Passing `True` emits a `DeprecationWarning`. See [issue #111](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/111). |
 | `account` | string \| null | No | null | Account name (or UUID). Pair with `source_mailbox` to narrow the scan and unlock the IMAP fast path (#150). |
 | `source_mailbox` | string \| null | No | null | Mailbox the messages live in. Required to unlock the IMAP fast path (#150) — without it, the delete runs via AppleScript even when IMAP is configured. Either alone (without `account`) raises `validation_error`. |
 
@@ -808,7 +808,7 @@ delete_messages(
 )
 ```
 
-**Performance — IMAP fast path (#150):** When invoked with `account` and `source_mailbox`, the delete runs server-side via IMAP `UID MOVE` to the account's Trash folder. On a 47k-message Gmail INBOX this drops the operation from ~57s to <1s — the AppleScript path uses `whose message id is`, which is a linear scan against RFC 5322 Message-IDs. Trash folder is resolved via RFC 6154 SPECIAL-USE `\Trash`; falls back to conventional names (`Trash`, `[Gmail]/Trash`, `Deleted Messages`, `Deleted Items`). Capability fallback chain: `MOVE` → `UID COPY` + `UID STORE +FLAGS \Deleted` + `UID EXPUNGE` (UIDPLUS only) → AppleScript. Requires Keychain credentials per the IMAP setup flow (`apple-mail-mcp setup-imap --account <name>`); falls back to AppleScript transparently when IMAP isn't configured or the server lacks both `MOVE` and `UIDPLUS`.
+**Performance — IMAP fast path (#150):** When invoked with `account` and `source_mailbox`, the delete runs server-side via IMAP `UID MOVE` to the account's Trash folder. On a 47k-message Gmail INBOX this drops the operation from ~57s to <1s — the AppleScript path uses `whose message id is`, which is a linear scan against RFC 5322 Message-IDs. Trash folder is resolved via RFC 6154 SPECIAL-USE `\Trash`; falls back to conventional names (`Trash`, `[Gmail]/Trash`, `Deleted Messages`, `Deleted Items`). Capability fallback chain: `MOVE` → `UID COPY` + `UID STORE +FLAGS \Deleted` + `UID EXPUNGE` (UIDPLUS only) → AppleScript. Requires Keychain credentials per the IMAP setup flow (`apple-mail-fast-mcp setup-imap --account <name>`); falls back to AppleScript transparently when IMAP isn't configured or the server lacks both `MOVE` and `UIDPLUS`.
 
 **Note on `permanent`:**
 
@@ -878,7 +878,7 @@ Mail controls the final UI refresh (#269).
 response includes an optional `warnings: list[str]` field noting the body
 may render as a blockquote on iOS Mail (Mail.app bug FB11734014, #245).
 The field is **omitted** on the clean path. Configure IMAP for the account
-(`apple-mail-mcp setup-imap`) — or pass `from_account` — to avoid it.
+(`apple-mail-fast-mcp setup-imap`) — or pass `from_account` — to avoid it.
 
 **Examples:**
 

--- a/docs/research/imap-auth-options-decision.md
+++ b/docs/research/imap-auth-options-decision.md
@@ -131,7 +131,7 @@ def get_imap_password(mail_app_account: str, email: str) -> str:
 **Server-side setup helper (tracked in #76):**
 
 ```bash
-apple-mail-mcp setup-imap --account iCloud --email user@icloud.com
+apple-mail-fast-mcp setup-imap --account iCloud --email user@icloud.com
 # → prompts for app password, writes to Keychain with the right service/account
 ```
 

--- a/docs/research/imap-hybrid-approach.md
+++ b/docs/research/imap-hybrid-approach.md
@@ -268,7 +268,7 @@ The conclusion is cheap and definitive: the spike's hypothesis is falsified on t
 
 | # | Option | Trade-off |
 |---|--------|-----------|
-| a | User-supplied Keychain item under a known service name (e.g. `apple-mail-mcp.<account>`) populated via a setup script | Simplest; works with app passwords across all providers; requires one-time user setup |
+| a | User-supplied Keychain item under a known service name (e.g. `apple-mail-fast-mcp.<account>`) populated via a setup script | Simplest; works with app passwords across all providers; requires one-time user setup |
 | b | Extract Google OAuth refresh tokens from Keychain and speak XOAUTH2 | Gmail/Google only; must handle token refresh; brittle against Google OAuth changes |
 | c | Read the Accounts framework DB via a TCC-entitled helper | Requires user to grant Full Disk Access; entitlement distribution issues; heavyweight |
 | d | Plain env vars / config file for IMAP credentials | Trivial to implement; no Keychain integration; worst UX and worst security story |

--- a/docs/research/imap-thread-strategies.md
+++ b/docs/research/imap-thread-strategies.md
@@ -28,7 +28,7 @@ This doc evaluates two server-side alternatives:
 
 ## What we measured
 
-Only one account on this machine has IMAP delegation set up: **iCloud** (host `p42-imap.mail.me.com`). MobileMe, Gmail, Yahoo, and a Pitt account exist in Mail.app but have no Keychain entries, so they can't be queried over IMAP without credentials we don't have (running `apple-mail-mcp setup-imap --account <name>` would unblock them; any future revision of this doc should re-run on whatever's available).
+Only one account on this machine has IMAP delegation set up: **iCloud** (host `p42-imap.mail.me.com`). MobileMe, Gmail, Yahoo, and a Pitt account exist in Mail.app but have no Keychain entries, so they can't be queried over IMAP without credentials we don't have (running `apple-mail-fast-mcp setup-imap --account <name>` would unblock them; any future revision of this doc should re-run on whatever's available).
 
 ### iCloud — `CAPABILITY` advertisement
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "apple-mail-mcp"
+name = "apple-mail-fast-mcp"
 version = "0.9.1"
 description = "MCP server for Apple Mail integration"
 readme = "README.md"
@@ -58,12 +58,12 @@ dev = [
 ]
 
 [project.scripts]
-apple-mail-mcp = "apple_mail_mcp.server:main"
+apple-mail-fast-mcp = "apple_mail_mcp.server:main"
 
 [project.urls]
-Homepage = "https://github.com/s-morgan-jeffries/apple-mail-mcp"
-Repository = "https://github.com/s-morgan-jeffries/apple-mail-mcp"
-Issues = "https://github.com/s-morgan-jeffries/apple-mail-mcp/issues"
+Homepage = "https://github.com/s-morgan-jeffries/apple-mail-fast-mcp"
+Repository = "https://github.com/s-morgan-jeffries/apple-mail-fast-mcp"
+Issues = "https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/apple_mail_mcp"]

--- a/src/apple_mail_mcp/cli.py
+++ b/src/apple_mail_mcp/cli.py
@@ -1,4 +1,4 @@
-"""CLI subcommands for the ``apple-mail-mcp`` entry point.
+"""CLI subcommands for the ``apple-mail-fast-mcp`` entry point.
 
 Today the only subcommand is ``setup-imap`` (issue #76). The default
 invocation (no subcommand) starts the MCP server — that path lives in

--- a/src/apple_mail_mcp/keychain.py
+++ b/src/apple_mail_mcp/keychain.py
@@ -2,7 +2,7 @@
 
 Entries live under service name
 ``apple-mail-mcp.imap.<mail_app_account_name>`` keyed by the account's
-email. The ``apple-mail-mcp setup-imap`` CLI is the supported way to
+email. The ``apple-mail-fast-mcp setup-imap`` CLI is the supported way to
 write entries; this module also exposes set/delete helpers that the
 CLI uses, plus the read helper used by the IMAP fallback path at
 runtime.

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -857,7 +857,7 @@ class AppleMailConnector:
                 logger.warning(
                     "IMAP login rejected for %r — likely an expired or "
                     "revoked app password. To refresh: "
-                    "`apple-mail-mcp setup-imap --account %s`. The "
+                    "`apple-mail-fast-mcp setup-imap --account %s`. The "
                     "AppleScript fallback is being used in the meantime; "
                     "results will be correct but slower.",
                     account, account,
@@ -1782,7 +1782,7 @@ class AppleMailConnector:
                 f"AppleScript body search can take minutes on large "
                 f"mailboxes (measured 148s for 100 cold-cache messages on "
                 f"a 47k-message Gmail INBOX). Run "
-                f"`apple-mail-mcp setup-imap --account {account!r}` for "
+                f"`apple-mail-fast-mcp setup-imap --account {account!r}` for "
                 f"sub-second IMAP body search."
             )
 
@@ -4844,14 +4844,14 @@ class AppleMailConnector:
                 "Draft created via AppleScript: no from_account was given "
                 "and there isn't exactly one enabled account, so the clean "
                 f"IMAP draft path couldn't be auto-selected. {tail} Pass "
-                "from_account, or set up IMAP with `apple-mail-mcp "
+                "from_account, or set up IMAP with `apple-mail-fast-mcp "
                 "setup-imap`."
             )
         return (
             "Draft created via AppleScript fallback: the IMAP draft path is "
             f"unavailable for {effective_account!r} (IMAP not configured, "
             f"unreachable, or a non-RFC reply seed). {tail} Configure or "
-            "repair IMAP for the account with `apple-mail-mcp setup-imap`."
+            "repair IMAP for the account with `apple-mail-fast-mcp setup-imap`."
         )
 
     def _effective_from_account(

--- a/src/apple_mail_mcp/security.py
+++ b/src/apple_mail_mcp/security.py
@@ -418,7 +418,7 @@ RULE_GATED_OPERATIONS = {
     "delete_rule",
 }
 
-RULE_TEST_PREFIX = "[apple-mail-mcp-test]"
+RULE_TEST_PREFIX = "[apple-mail-fast-mcp-test]"
 
 
 def _is_test_mode_enabled() -> bool:

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -3047,7 +3047,7 @@ def delete_draft(draft_id: str) -> dict[str, Any]:
 
 def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="apple-mail-mcp",
+        prog="apple-mail-fast-mcp",
         description=(
             "Apple Mail MCP server. With no subcommand, starts the MCP "
             "server (this is what Claude Desktop / mcp clients invoke)."

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -242,7 +242,7 @@ def bench_source(
     once per run.
 
     Skips cleanly if MAIL_TEST_ACCOUNT has no Keychain IMAP creds (the
-    synthetic seeding needs the IMAP path). Run `apple-mail-mcp setup-imap
+    synthetic seeding needs the IMAP path). Run `apple-mail-fast-mcp setup-imap
     --account <acct>` first."""
     from imapclient import IMAPClient
 
@@ -263,7 +263,7 @@ def bench_source(
     except (MailKeychainEntryNotFoundError, MailKeychainAccessDeniedError):
         pytest.skip(
             f"No Keychain IMAP creds for {test_account!r}; the synthetic "
-            f"bench source can't be seeded. Run `apple-mail-mcp setup-imap "
+            f"bench source can't be seeded. Run `apple-mail-fast-mcp setup-imap "
             f"--account {test_account}`. See docs/guides/BENCHMARKING.md."
         )
 
@@ -403,7 +403,7 @@ def _make_synthetic_message(i: int) -> bytes:
         f"Date: Thu, 01 May 2026 12:00:00 +0000\r\n"
         f"\r\n"
         f"Synthetic benchmark message #{i} for issue #101. "
-        f"If you see this in your inbox, the apple-mail-mcp benchmark "
+        f"If you see this in your inbox, the apple-mail-fast-mcp benchmark "
         f"fixture leaked.\r\n"
     ).encode()
 

--- a/tests/benchmarks/test_bulk_ops.py
+++ b/tests/benchmarks/test_bulk_ops.py
@@ -152,7 +152,7 @@ def test_update_message_move_50_msgs_imap(
     except MailKeychainEntryNotFoundError:
         pytest.skip(
             f"IMAP not configured for {test_account!r}; nothing to "
-            f"benchmark. Run `apple-mail-mcp setup-imap --account "
+            f"benchmark. Run `apple-mail-fast-mcp setup-imap --account "
             f"{test_account}` to enable."
         )
 

--- a/tests/benchmarks/test_imap_pool.py
+++ b/tests/benchmarks/test_imap_pool.py
@@ -54,7 +54,7 @@ def _skip_if_no_imap(
     except (MailKeychainEntryNotFoundError, MailKeychainAccessDeniedError):
         pytest.skip(
             f"No Keychain entry for {test_account!r} — pool can't be "
-            f"exercised. Run `apple-mail-mcp setup-imap` first."
+            f"exercised. Run `apple-mail-fast-mcp setup-imap` first."
         )
 
     for mb in ("INBOX", "Archive", "Sent Messages"):

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -289,7 +289,7 @@ class TestMailIntegration:
         ):
             pytest.skip(
                 f"No Keychain entry for {test_account!r} — IMAP path "
-                f"can't be exercised. Run `apple-mail-mcp setup-imap` first."
+                f"can't be exercised. Run `apple-mail-fast-mcp setup-imap` first."
             )
 
         matches = connector.search_messages(
@@ -410,7 +410,7 @@ class TestMailIntegration:
         ):
             pytest.skip(
                 f"No Keychain entry for {test_account!r} — IMAP path "
-                f"can't be exercised. Run `apple-mail-mcp setup-imap` first."
+                f"can't be exercised. Run `apple-mail-fast-mcp setup-imap` first."
             )
 
         matches = connector.search_messages(
@@ -531,7 +531,7 @@ class TestDraftsLifecycleIntegration:
         ):
             pytest.skip(
                 f"No Keychain entry for {test_account!r} — IMAP-APPEND path "
-                f"can't be exercised. Run `apple-mail-mcp setup-imap` first."
+                f"can't be exercised. Run `apple-mail-fast-mcp setup-imap` first."
             )
 
         result = connector.create_draft(
@@ -593,7 +593,7 @@ class TestDraftsLifecycleIntegration:
         ):
             pytest.skip(
                 f"No Keychain entry for {test_account!r} — IMAP-APPEND path "
-                f"can't be exercised. Run `apple-mail-mcp setup-imap` first."
+                f"can't be exercised. Run `apple-mail-fast-mcp setup-imap` first."
             )
 
         result = connector.create_draft(
@@ -687,7 +687,7 @@ class TestDraftsLifecycleIntegration:
         ):
             pytest.skip(
                 f"No Keychain entry for {test_account!r} — IMAP path can't "
-                f"be exercised. Run `apple-mail-mcp setup-imap` first."
+                f"be exercised. Run `apple-mail-fast-mcp setup-imap` first."
             )
 
     def test_fetch_raw_message_happy_and_folder_miss(
@@ -711,7 +711,7 @@ class TestDraftsLifecycleIntegration:
 
         suffix = _uuid.uuid4().hex[:8]
         src = f"ZZZ-AMM-FETCHRAW-{suffix}"
-        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-fast-mcp-test.invalid"
         host, port, email = connector._resolve_imap_config(test_account)
         pw = get_imap_password(test_account, email)
 
@@ -719,8 +719,8 @@ class TestDraftsLifecycleIntegration:
         try:
             now = format_datetime(datetime.now(tz=timezone.utc))
             raw = (
-                f"From: sender@apple-mail-mcp-test.invalid\r\n"
-                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"From: sender@apple-mail-fast-mcp-test.invalid\r\n"
+                f"To: rcpt@apple-mail-fast-mcp-test.invalid\r\n"
                 f"Subject: AMM #293 fetch-raw test\r\n"
                 f"Date: {now}\r\n"
                 f"Message-ID: <{msg_id_local}>\r\n"
@@ -768,15 +768,15 @@ class TestDraftsLifecycleIntegration:
 
         suffix = _uuid.uuid4().hex[:8]
         src = f"ZZZ-AMM-REPLYSRC-{suffix}"
-        orig_id = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+        orig_id = f"{_uuid.uuid4().hex}@apple-mail-fast-mcp-test.invalid"
 
         assert connector.create_mailbox(account=test_account, name=src)
         draft_id = ""
         try:
             now = format_datetime(datetime.now(tz=timezone.utc))
             raw = (
-                f"From: Ada Original <ada@apple-mail-mcp-test.invalid>\r\n"
-                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"From: Ada Original <ada@apple-mail-fast-mcp-test.invalid>\r\n"
+                f"To: rcpt@apple-mail-fast-mcp-test.invalid\r\n"
                 f"Subject: AMM 293 original subject\r\n"
                 f"Date: {now}\r\n"
                 f"Message-ID: <{orig_id}>\r\n"
@@ -1065,7 +1065,7 @@ class TestDraftsLifecycleIntegration:
         suffix = _uuid.uuid4().hex[:8]
         src = f"ZZZ-AMM-MV-SRC-{suffix}"
         dst = f"ZZZ-AMM-MV-DST-{suffix}"
-        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-fast-mcp-test.invalid"
         bracketed = f"<{msg_id_local}>"
 
         host, port, email = connector._resolve_imap_config(test_account)
@@ -1079,8 +1079,8 @@ class TestDraftsLifecycleIntegration:
             # gives us a known Message-ID without going through Mail.app.
             now = format_datetime(datetime.now(tz=timezone.utc))
             raw = (
-                f"From: sender@apple-mail-mcp-test.invalid\r\n"
-                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"From: sender@apple-mail-fast-mcp-test.invalid\r\n"
+                f"To: rcpt@apple-mail-fast-mcp-test.invalid\r\n"
                 f"Subject: AMM #149 IMAP move test\r\n"
                 f"Date: {now}\r\n"
                 f"Message-ID: {bracketed}\r\n"
@@ -1148,7 +1148,7 @@ class TestDraftsLifecycleIntegration:
 
         suffix = _uuid.uuid4().hex[:8]
         src = f"ZZZ-AMM-DEL-SRC-{suffix}"
-        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-fast-mcp-test.invalid"
         bracketed = f"<{msg_id_local}>"
 
         host, port, email = connector._resolve_imap_config(test_account)
@@ -1161,8 +1161,8 @@ class TestDraftsLifecycleIntegration:
             # we have a known Message-ID without going through Mail.app.
             now = format_datetime(datetime.now(tz=timezone.utc))
             raw = (
-                f"From: sender@apple-mail-mcp-test.invalid\r\n"
-                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"From: sender@apple-mail-fast-mcp-test.invalid\r\n"
+                f"To: rcpt@apple-mail-fast-mcp-test.invalid\r\n"
                 f"Subject: AMM #150 IMAP delete test\r\n"
                 f"Date: {now}\r\n"
                 f"Message-ID: {bracketed}\r\n"
@@ -1264,7 +1264,7 @@ class TestDraftsLifecycleIntegration:
 
         suffix = _uuid.uuid4().hex[:8]
         src = f"ZZZ-AMM-READ-SRC-{suffix}"
-        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-fast-mcp-test.invalid"
         bracketed = f"<{msg_id_local}>"
 
         host, port, email = connector._resolve_imap_config(test_account)
@@ -1277,8 +1277,8 @@ class TestDraftsLifecycleIntegration:
             # explicitly without \Seen.
             now = format_datetime(datetime.now(tz=timezone.utc))
             raw = (
-                f"From: sender@apple-mail-mcp-test.invalid\r\n"
-                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"From: sender@apple-mail-fast-mcp-test.invalid\r\n"
+                f"To: rcpt@apple-mail-fast-mcp-test.invalid\r\n"
                 f"Subject: AMM #151 IMAP read-status test\r\n"
                 f"Date: {now}\r\n"
                 f"Message-ID: {bracketed}\r\n"
@@ -1365,7 +1365,7 @@ class TestDraftsLifecycleIntegration:
 
         suffix = _uuid.uuid4().hex[:8]
         src = f"ZZZ-AMM-FLAG-SRC-{suffix}"
-        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-fast-mcp-test.invalid"
         bracketed = f"<{msg_id_local}>"
 
         host, port, email = connector._resolve_imap_config(test_account)
@@ -1376,8 +1376,8 @@ class TestDraftsLifecycleIntegration:
         try:
             now = format_datetime(datetime.now(tz=timezone.utc))
             raw = (
-                f"From: sender@apple-mail-mcp-test.invalid\r\n"
-                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"From: sender@apple-mail-fast-mcp-test.invalid\r\n"
+                f"To: rcpt@apple-mail-fast-mcp-test.invalid\r\n"
                 f"Subject: AMM #152 IMAP flag round-trip test\r\n"
                 f"Date: {now}\r\n"
                 f"Message-ID: {bracketed}\r\n"
@@ -1466,7 +1466,7 @@ class TestDraftsLifecycleIntegration:
         suffix = _uuid.uuid4().hex[:8]
         src = f"ZZZ-AMM-OR316-{suffix}"
         ids_local = [
-            f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid" for _ in range(2)
+            f"{_uuid.uuid4().hex}@apple-mail-fast-mcp-test.invalid" for _ in range(2)
         ]
 
         host, port, email = connector._resolve_imap_config(test_account)
@@ -1480,8 +1480,8 @@ class TestDraftsLifecycleIntegration:
             try:
                 for mid in ids_local:
                     raw = (
-                        f"From: s@apple-mail-mcp-test.invalid\r\n"
-                        f"To: r@apple-mail-mcp-test.invalid\r\n"
+                        f"From: s@apple-mail-fast-mcp-test.invalid\r\n"
+                        f"To: r@apple-mail-fast-mcp-test.invalid\r\n"
                         f"Subject: AMM #316 OR-search test\r\n"
                         f"Date: {now}\r\n"
                         f"Message-ID: <{mid}>\r\n"
@@ -1537,7 +1537,7 @@ class TestDraftsLifecycleIntegration:
 
         suffix = _uuid.uuid4().hex[:8]
         src = f"ZZZ-AMM-DUAL-EMIT-{suffix}"
-        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-fast-mcp-test.invalid"
         bracketed = f"<{msg_id_local}>"
 
         host, port, email = connector._resolve_imap_config(test_account)
@@ -1548,8 +1548,8 @@ class TestDraftsLifecycleIntegration:
         try:
             now = format_datetime(datetime.now(tz=timezone.utc))
             raw = (
-                f"From: sender@apple-mail-mcp-test.invalid\r\n"
-                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"From: sender@apple-mail-fast-mcp-test.invalid\r\n"
+                f"To: rcpt@apple-mail-fast-mcp-test.invalid\r\n"
                 f"Subject: AMM #148 dual-emit test\r\n"
                 f"Date: {now}\r\n"
                 f"Message-ID: {bracketed}\r\n"
@@ -1635,7 +1635,7 @@ class TestDraftsLifecycleIntegration:
 
         suffix = _uuid.uuid4().hex[:8]
         src = f"ZZZ-AMM-RFC-FLAG-{suffix}"
-        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-mcp-test.invalid"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-fast-mcp-test.invalid"
         bracketed = f"<{msg_id_local}>"
 
         host, port, email = connector._resolve_imap_config(test_account)
@@ -1645,8 +1645,8 @@ class TestDraftsLifecycleIntegration:
         try:
             now = format_datetime(datetime.now(tz=timezone.utc))
             raw = (
-                f"From: sender@apple-mail-mcp-test.invalid\r\n"
-                f"To: rcpt@apple-mail-mcp-test.invalid\r\n"
+                f"From: sender@apple-mail-fast-mcp-test.invalid\r\n"
+                f"To: rcpt@apple-mail-fast-mcp-test.invalid\r\n"
                 f"Subject: AMM #291 rfc-id flag test\r\n"
                 f"Date: {now}\r\n"
                 f"Message-ID: {bracketed}\r\n"
@@ -1842,13 +1842,13 @@ class TestRuleCRUDIntegration:
     even if intermediate assertions fail. Idempotent: a leftover from a
     previous failed run is detected and removed at the start.
 
-    Refers to a rule whose name starts with '[apple-mail-mcp-test]' —
+    Refers to a rule whose name starts with '[apple-mail-fast-mcp-test]' —
     this is the test prefix the safety gate uses, but the connector
     itself doesn't enforce it. We use a recognizable name so manual
     cleanup is easy if all else fails.
     """
 
-    TEST_RULE_NAME = "[apple-mail-mcp-test] integration test rule"
+    TEST_RULE_NAME = "[apple-mail-fast-mcp-test] integration test rule"
 
     def _delete_test_rule_if_present(
         self, connector: AppleMailConnector

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the apple-mail-mcp CLI entry point and setup-imap subcommand."""
+"""Tests for the apple-mail-fast-mcp CLI entry point and setup-imap subcommand."""
 
 from __future__ import annotations
 

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1315,7 +1315,7 @@ class TestAppleMailConnector:
         msg = warnings[0].getMessage()
         assert "iCloud" in msg
         # The actionable instruction must be present and command-perfect.
-        assert "apple-mail-mcp setup-imap --account iCloud" in msg
+        assert "apple-mail-fast-mcp setup-imap --account iCloud" in msg
         # Reassurance that the user isn't blocked.
         assert "AppleScript fallback" in msg
 

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -384,7 +384,7 @@ class TestCheckTestModeSafety:
         assert (
             check_test_mode_safety(
                 "update_rule",
-                rule_name="[apple-mail-mcp-test] my rule",
+                rule_name="[apple-mail-fast-mcp-test] my rule",
             )
             is None
         )
@@ -400,7 +400,7 @@ class TestCheckTestModeSafety:
         )
         assert result is not None
         assert result["error_type"] == "safety_violation"
-        assert "[apple-mail-mcp-test]" in result["error"]
+        assert "[apple-mail-fast-mcp-test]" in result["error"]
 
     def test_rule_mutation_outside_test_mode_allowed(
         self, monkeypatch: Any

--- a/tests/unit/test_server_annotations.py
+++ b/tests/unit/test_server_annotations.py
@@ -207,13 +207,13 @@ class TestReadOnlyFlag:
     def test_pre_parse_returns_false_with_no_args(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("sys.argv", ["apple-mail-mcp"])
+        monkeypatch.setattr("sys.argv", ["apple-mail-fast-mcp"])
         assert server._pre_parse_read_only() is False
 
     def test_pre_parse_returns_true_with_flag(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setattr("sys.argv", ["apple-mail-mcp", "--read-only"])
+        monkeypatch.setattr("sys.argv", ["apple-mail-fast-mcp", "--read-only"])
         assert server._pre_parse_read_only() is True
 
     def test_pre_parse_ignores_unknown_args(
@@ -221,7 +221,7 @@ class TestReadOnlyFlag:
     ) -> None:
         """The pre-parse uses parse_known_args; downstream args don't crash it."""
         monkeypatch.setattr(
-            "sys.argv", ["apple-mail-mcp", "setup-imap", "--account", "Gmail"]
+            "sys.argv", ["apple-mail-fast-mcp", "setup-imap", "--account", "Gmail"]
         )
         assert server._pre_parse_read_only() is False
 

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 ]
 
 [[package]]
-name = "apple-mail-mcp"
+name = "apple-mail-fast-mcp"
 version = "0.9.1"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
Full rebrand to **`apple-mail-fast-mcp`** — "fast" names our real differentiator (the IMAP fast path) vs the AppleScript-only `apple-mail-mcp` we collided with (#331). Done pre-publish, while there's no installed base to disrupt.

## Brand surface changed
- **GitHub repo** renamed to `apple-mail-fast-mcp` (GitHub redirects old URLs/clones); `[project.urls]`, README badge/clone, CONTRIBUTING, and docs updated.
- **PyPI distribution name** → `apple-mail-fast-mcp` (`[project].name`); `uv.lock` regenerated.
- **CLI console script** → `apple-mail-fast-mcp` (rename-only, no alias — negligible installed base).
- **New `publish-pypi` job in `release.yml`:** tokenless **OIDC trusted publishing** (`environment: pypi`, `id-token: write`) on `v*` tags via `pypa/gh-action-pypi-publish`.

## Deliberately NOT changed (tracked separately)
- **Python import package** `apple_mail_mcp` — zero user visibility; #336 (v0.11.0).
- **Keychain identifiers** `apple-mail-mcp.imap.` and `apple-mail-mcp-evals` — renaming orphans stored credentials; #337 (rename-with-fallback at 0.11.0, drop at 1.0.0).
- **Benchmark account names** (`apple-mail-mcp-bench…`) and **CHANGELOG history** — left as accurate records.

The brand sweep used a guarded substitution (negative lookaheads for `.imap` / `-bench`; the underscore import form can't match), verified by diff review.

## Validation
unit (1284) · e2e (29) · lint · typecheck · complexity · version-sync · doc-drift · parity — all green. `uv build` produces `apple_mail_fast_mcp-0.9.1` (sdist+wheel) with console script `apple-mail-fast-mcp`.

## Action required from maintainer (not blocking this PR)
Register the PyPI **pending trusted publisher** (reserves the name): https://pypi.org/manage/account/publishing/ → Project `apple-mail-fast-mcp`, Owner `s-morgan-jeffries`, Repo `apple-mail-fast-mcp`, Workflow `release.yml`, Environment `pypi`. First publish happens at the v0.10.0 release via the new job.

After merge, your local Claude Desktop `command` path becomes `…/.venv/bin/apple-mail-fast-mcp` (one-line config update + restart).

Closes #335