### PR TITLE
fix(#282): pass explicit bool response_type to ctx.elicit (clear FastMCPDeprecationWarning)

### DIFF
--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -171,9 +171,16 @@ async def _elicit_confirmation(
     """Elicit user confirmation via MCP. Fails closed — confirmation gates
     the destructive operation entirely.
 
+    Uses a boolean ``response_type`` (FastMCP ≥3.3.1 requires a non-``None``
+    schema; the legacy ``None``/empty-schema form is deprecated and renders a
+    broken empty form in some clients — #282). Only an explicit affirmative
+    (``True``) proceeds.
+
     Returns:
-        - ``None`` only when the user explicitly accepted.
-        - ``{"error_type": "cancelled"}`` when the user declined.
+        - ``None`` only when the user explicitly affirmed (accepted with
+          ``True``).
+        - ``{"error_type": "cancelled"}`` when the user declined, cancelled,
+          or accepted with ``False``.
         - ``{"error_type": "confirmation_required"}`` when no context was
           provided or the client's elicitation call failed (capability
           unsupported, IO error). Pre-#226 these paths silently
@@ -193,7 +200,20 @@ async def _elicit_confirmation(
             "error_type": "confirmation_required",
         }
     try:
-        result = await ctx.elicit(summary, None)
+        # mypy 1.20.x collapses every ctx.elicit overload to the
+        # response_type=None variant (the inter-overload docstrings break
+        # its overload grouping), so it reports a bogus arg-type here and
+        # types result.data as dict[str, Any] below — hence the ignore and
+        # the cast. At runtime FastMCP wraps the bool and returns a real
+        # bool in result.data.
+        result = await ctx.elicit(
+            summary,
+            response_type=bool,  # type: ignore[arg-type]
+            response_title="Confirm",
+            response_description=(
+                "Set to true to proceed with this operation."
+            ),
+        )
     except Exception as e:
         logger.warning(
             "Elicitation unavailable; blocking %s: %s", operation, e
@@ -209,7 +229,13 @@ async def _elicit_confirmation(
             ),
             "error_type": "confirmation_required",
         }
-    if not isinstance(result, AcceptedElicitation):
+    # Fail closed unless the user explicitly affirmed (accepted *and* set
+    # the confirm flag true). Decline, cancel, and accept-with-false all
+    # block. (#282)
+    if not (
+        isinstance(result, AcceptedElicitation)
+        and cast(bool, result.data) is True
+    ):
         operation_logger.log_operation(operation, params, "cancelled")
         return {
             "success": False,

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -62,9 +62,21 @@ def mock_logger() -> Any:
 
 @pytest.fixture
 def mock_ctx_accept() -> MagicMock:
-    """Mock MCP Context that accepts elicitation."""
+    """Mock MCP Context that accepts elicitation with an affirmative
+    ``True`` (the confirm checkbox is set). Under the bool confirmation
+    pattern (#282) only an explicit ``True`` proceeds."""
     ctx = MagicMock()
-    ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data={}))
+    ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data=True))
+    return ctx
+
+
+@pytest.fixture
+def mock_ctx_accept_false() -> MagicMock:
+    """Mock MCP Context that accepts the elicitation but with ``False``
+    (the user submitted the form without confirming). This must block,
+    same as a decline (#282)."""
+    ctx = MagicMock()
+    ctx.elicit = AsyncMock(return_value=AcceptedElicitation(data=False))
     return ctx
 
 
@@ -145,6 +157,39 @@ class TestElicitConfirmationFailsClosed:
             operation="op", params={"k": "v"},
         )
         assert result is None
+
+    async def test_returns_cancelled_when_accepted_but_false(
+        self, mock_ctx_accept_false: MagicMock,
+    ) -> None:
+        """#282: under the bool confirmation pattern, an elicitation that
+        is *accepted* but carries ``False`` must still block — only an
+        explicit affirmative proceeds. Fail-closed by construction."""
+        result = await _elicit_confirmation(
+            ctx=mock_ctx_accept_false, summary="Do X?",
+            operation="op", params={"k": "v"},
+        )
+        assert result is not None
+        assert result["success"] is False
+        assert result["error_type"] == "cancelled"
+
+    async def test_elicit_called_with_non_none_response_type(
+        self, mock_ctx_accept: MagicMock,
+    ) -> None:
+        """#282: the gate must pass an explicit, non-``None`` response_type
+        to ``ctx.elicit`` — passing ``None`` triggers FastMCPDeprecationWarning
+        and renders a broken empty form in some clients. Unit tests mock
+        ``ctx.elicit`` so they can't observe the warning directly; this
+        asserts the call shape that avoids it."""
+        await _elicit_confirmation(
+            ctx=mock_ctx_accept, summary="Do X?",
+            operation="op", params={"k": "v"},
+        )
+        mock_ctx_accept.elicit.assert_awaited_once()
+        call = mock_ctx_accept.elicit.await_args
+        response_type = call.kwargs.get("response_type")
+        if response_type is None and len(call.args) > 1:
+            response_type = call.args[1]
+        assert response_type is bool
 
     async def test_logs_to_audit_trail_on_missing_ctx(
         self, monkeypatch: pytest.MonkeyPatch,
@@ -346,6 +391,19 @@ class TestDeleteRule:
             {"index": 1, "name": "Junk filter", "enabled": True},
         ]
         result = await delete_rule(rule_index=1, ctx=mock_ctx_decline)
+        assert result["success"] is False
+        assert result["error_type"] == "cancelled"
+        mock_mail.delete_rule.assert_not_called()
+
+    async def test_accepted_but_false_blocks_delete(
+        self, mock_mail: MagicMock, mock_ctx_accept_false: MagicMock
+    ) -> None:
+        """#282: accepting the confirmation form with ``False`` (confirm
+        unchecked) blocks the destructive op, end to end."""
+        mock_mail.list_rules.return_value = [
+            {"index": 1, "name": "Junk filter", "enabled": True},
+        ]
+        result = await delete_rule(rule_index=1, ctx=mock_ctx_accept_false)
         assert result["success"] is False
         assert result["error_type"] == "cancelled"
         mock_mail.delete_rule.assert_not_called()


### PR DESCRIPTION
Closes #282.

## Problem
`_elicit_confirmation` ([server.py](src/apple_mail_mcp/server.py)) called `ctx.elicit(summary, None)`. FastMCP ≥3.3.1 raises `FastMCPDeprecationWarning` whenever `response_type is None`, and the `None`/empty-schema form renders as a **broken, non-functional form** in some clients (e.g. VS Code). When FastMCP removes the `None` path, the confirmation gate behind **every** destructive tool (`delete_messages`, `delete_mailbox`, `delete_rule`, `delete_template`, `create_rule`, `update_rule`, `create_draft`/`update_draft` `send_now`) breaks.

## Change
- Pass `response_type=bool` with a `"Confirm"` title/description.
- Proceed **only** on an explicit affirmative — an `AcceptedElicitation` whose `data is True`. Decline, cancel, **accept-with-false**, no-ctx, and elicit-error all block. This is strictly more conservative than the prior "any accept proceeds" behavior and keeps the gate's fail-closed contract (defense-in-depth, appropriate for a security-labeled gate).
- No call sites change — all callers still do `if cancel_err: return cancel_err`.

### mypy note
mypy 1.20.x collapses every `ctx.elicit` overload to the `response_type=None` variant (the inter-overload docstrings break its overload grouping), so it reports a bogus `arg-type` and types `result.data` as `dict`. A scoped, documented `# type: ignore[arg-type]` + `cast(bool, ...)` handle that; runtime returns a real bool.

## Tests
- `mock_ctx_accept` now returns `AcceptedElicitation(data=True)`.
- Added `mock_ctx_accept_false` + tests proving accept-with-false **blocks** (helper-level and end-to-end via `delete_rule`).
- Added a regression guard asserting `ctx.elicit` is called with a non-`None` `response_type` (`is bool`) — the enforceable unit-level proxy for "no deprecation warning," since unit tests mock `ctx.elicit`.

## Verification
- `make test` — 1287 passed.
- `make test-e2e` — 29 passed; **0** `FastMCPDeprecationWarning` in output.
- `make check-all` — lint, mypy strict, complexity, parity, version/doc-sync all pass.
- **Manual real-client check (MCP Inspector)** — required by the issue's acceptance:
  - Confirm control renders correctly (not the old empty form).
  - Box checked → `success: true`; box unchecked / declined → `error_type: "cancelled"`.
  - No `FastMCPDeprecationWarning` in stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)