### PR TITLE
feat(#251): HTML body support for create_draft / update_draft

### DIFF
--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -846,6 +846,7 @@ Create a draft (fresh, reply, or forward). Optionally send immediately.
 | `bcc` | array[string] | No | None | BCC recipients. |
 | `subject` | string | When fresh | None | Subject. For reply/forward, `None` keeps Mail's `Re:`/`Fwd:` prefix. |
 | `body` | string | No | "" | Body text. For reply/forward, a non-empty body **replaces** Mail's auto-quoted content (the auto-quote isn't readable from AppleScript before save). Empty body leaves Mail's auto-quote intact. |
+| `body_html` | string | No | None | Optional HTML body (#251). Builds a `multipart/alternative` draft (HTML + a plain-text alternative from `body`, or derived from the HTML when `body` is empty). **Requires IMAP credentials** for the account (built over the clean IMAP path; Mail's AppleScript path is plain-text only) and is **fresh-draft-only**: combining `body_html` with `send_now` or `reply_to`/`forward_of` is rejected (`validation_error`), and if IMAP can't engage the call fails with `html_requires_imap` rather than silently dropping the HTML. HTML is caller-trusted (not sanitized). |
 | `attachment_paths` | array[string] | No | None | List of file paths to attach. |
 | `reply_all` | boolean | No | False | For `reply_to` only — use `reply to all`. |
 | `template_name` | string | No | None | Optional template to render for `subject` + `body`. Caller-supplied `subject`/`body` override the rendered output. |
@@ -914,10 +915,11 @@ create_draft(
 
 **Error Codes:**
 
-- `validation_error`: Mutually exclusive seeds, missing required fields, or `template_vars` without `template_name`.
+- `validation_error`: Mutually exclusive seeds, missing required fields, `template_vars` without `template_name`, or `body_html` combined with `send_now` / `reply_to` / `forward_of`.
 - `message_not_found`: `reply_to` / `forward_of` doesn't match any Mail.app message.
 - `account_not_found`: `from_account` doesn't match.
 - `file_not_found`: An attachment path doesn't exist.
+- `html_requires_imap`: `body_html` was set but the clean IMAP path couldn't engage (no Keychain opt-in / IMAP credentials). HTML drafts are never silently downgraded to plain text.
 - `cancelled`: User declined the elicitation prompt (when `send_now=True`).
 - `applescript_error`, `unknown`: Lower-level failures.
 
@@ -942,6 +944,7 @@ after this call. Callers caching the id must re-read the response.
 | `to` / `cc` / `bcc` | array[string] | No | None | Override recipient groups: `None` keeps existing, `[]` clears, populated list replaces. |
 | `subject` | string | No | None | Override subject. `None` keeps existing. |
 | `body` | string | No | None | Override body. `None` keeps existing; non-None replaces (including `""`). |
+| `body_html` | string | No | None | Optional HTML body for the recreated draft (#251); see `create_draft`. Requires IMAP credentials; limited to fresh-seed drafts (not reply/forward) and `send_now=False`. **Not auto-preserved:** because update is delete-and-recreate and draft state captures only plain text, existing HTML is dropped unless `body_html` is passed again. |
 | `attachment_paths` | array[string] | No | None | Override attachments: `None` **preserves existing** (extracted to a temp dir and re-attached); `[]` clears; populated list replaces. |
 | `template_name` / `template_vars` | string / object | No | None | Optional template render. User-supplied `subject`/`body` override the rendered output. |
 | `from_account` | string | No | None | Override sender. |

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -45,6 +45,7 @@ it for later or send it now.
 - `bcc` (list[string], optional)
 - `subject` (string, optional): Subject. Required when both seeds are None. For reply/forward, ``None`` keeps Mail's ``Re:``/``Fwd:`` prefix.
 - `body` (string, optional) (default: ''): Body text. For reply/forward, a non-empty body REPLACES Mail's auto-quoted content; an empty body leaves the auto-quote intact (matches Mail.app's default reply behavior).
+- `body_html` (string, optional): Optional HTML body. When set, the draft is built as a multipart/alternative (HTML + a plain-text alternative taken from ``body``, or derived from the HTML when ``body`` is empty). HTML drafts are created over the clean IMAP path, so they REQUIRE IMAP credentials for the account and are limited to fresh save-as-draft: passing ``body_html`` with ``send_now`` or with ``reply_to``/``forward_of`` is rejected, and if IMAP can't engage the call fails (``error_type: "html_requires_imap"``) rather than silently downgrading to plain text. HTML is caller-trusted (not sanitized). (#251)
 - `attachment_paths` (list[string], optional): List of file paths to attach.
 - `reply_all` (boolean, optional) (default: False): For ``reply_to`` only — use ``reply to all``.
 - `template_name` (string, optional): Optional template to render for ``subject`` and ``body``. Caller-supplied ``subject``/``body`` override the rendered output. ``template_vars`` override auto-fills.
@@ -382,6 +383,7 @@ explicit body if so.
 - `bcc` (list[string], optional)
 - `subject` (string, optional): Override subject. None keeps existing.
 - `body` (string, optional): Override body. None keeps existing. Non-None replaces (including the empty string, which clears).
+- `body_html` (string, optional): Optional HTML body for the recreated draft (see ``create_draft``). Requires IMAP credentials and is limited to drafts whose seed is a fresh draft (not reply/forward) and to ``send_now=False``. NOTE: because the draft is recreated and draft state captures only plain text, an existing HTML draft is NOT preserved across an update unless ``body_html`` is passed again. (#251)
 - `attachment_paths` (list[string], optional): Override attachments. None preserves existing via temp-dir extraction; [] clears; list replaces.
 - `template_name` (string, optional)
 - `template_vars` (object, optional)

--- a/src/apple_mail_mcp/draft_builder.py
+++ b/src/apple_mail_mcp/draft_builder.py
@@ -47,6 +47,7 @@ def build_draft_mime(
     to: list[str],
     subject: str,
     body: str,
+    body_html: str | None = None,
     cc: list[str] | None = None,
     bcc: list[str] | None = None,
     attachments: list[Path] | None = None,
@@ -54,11 +55,18 @@ def build_draft_mime(
     references: list[str] | None = None,
     forwarded_attachments: list[ForwardedAttachment] | None = None,
 ) -> tuple[str, bytes]:
-    """Build a plain-text draft message.
+    """Build a draft message (plain-text, or multipart/alternative for HTML).
 
     Returns ``(message_id, raw_bytes)`` where ``message_id`` is the
     generated RFC 5322 Message-ID (angle-bracketed) and ``raw_bytes`` is
     the serialized message suitable for ``IMAPClient.append``.
+
+    HTML body (issue #251): when ``body_html`` is given the message is built
+    as ``multipart/alternative`` with a ``text/html`` part and a
+    ``text/plain`` alternative. The plain part is ``body`` when supplied,
+    otherwise a crude text rendering of the HTML (so non-HTML readers and
+    reply-quoting still have something). ``body_html`` is caller-trusted
+    content (like ``body``); it is MIME-encoded but not HTML-sanitized.
 
     Reply/forward extras (issue #245 follow-up):
 
@@ -85,7 +93,14 @@ def build_draft_mime(
         msg["In-Reply-To"] = _sanitize_header(in_reply_to)
     if references:
         msg["References"] = " ".join(_sanitize_header(r) for r in references)
-    msg.set_content(body)
+    if body_html is not None:
+        # multipart/alternative: text/plain first (fallback + reply quoting),
+        # then text/html. Derive the plain part from the HTML when no
+        # explicit plain body was supplied. (#251)
+        msg.set_content(body if body else _html_to_text(body_html))
+        msg.add_alternative(body_html, subtype="html")
+    else:
+        msg.set_content(body)
 
     for path in attachments or []:
         path = Path(path)

--- a/src/apple_mail_mcp/exceptions.py
+++ b/src/apple_mail_mcp/exceptions.py
@@ -165,6 +165,17 @@ class MailDraftNotFoundError(MailDraftError):
     pass
 
 
+class MailDraftHtmlUnavailableError(MailDraftError):
+    """An HTML draft (``body_html``) was requested but the clean IMAP-APPEND
+    path could not run (no Keychain opt-in / IMAP credentials, breaker open,
+    or APPEND failed). HTML drafts are built as RFC822 multipart/alternative
+    over IMAP — Mail.app's AppleScript ``content`` setter is plain-text only —
+    so we fail loud rather than silently downgrade to a plain-text draft.
+    (#251)"""
+
+    pass
+
+
 class MailTemplateError(MailError):
     """Base class for email-template errors."""
 

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -29,6 +29,7 @@ from .drafts import _validate_draft_id
 from .exceptions import (
     MailAccountNotFoundError,
     MailAppleScriptError,
+    MailDraftHtmlUnavailableError,
     MailDraftNotFoundError,
     MailImapMoveUnsupportedError,
     MailImapRequiredError,
@@ -4284,10 +4285,15 @@ class AppleMailConnector:
         subject: str,
         body: str,
         attachment_paths: list[Path] | None,
+        body_html: str | None = None,
     ) -> dict[str, str]:
         """Create a save-as-draft by APPENDing a clean RFC822 message over
         IMAP (issue #245), instead of Mail.app's AppleScript ``content``
         setter. Returns the generated RFC Message-ID as ``draft_id``.
+
+        When ``body_html`` is given the message is a multipart/alternative
+        (text/plain + text/html); HTML drafts only exist on this IMAP path
+        (#251).
 
         Raises the standard ``_IMAP_FALLBACK_EXCS`` (e.g. no Keychain
         opt-in, network failure) which ``create_draft`` catches to fall
@@ -4305,6 +4311,7 @@ class AppleMailConnector:
             bcc=bcc,
             subject=subject,
             body=body,
+            body_html=body_html,
             attachments=(
                 [Path(p) for p in attachment_paths] if attachment_paths else None
             ),
@@ -4428,6 +4435,7 @@ class AppleMailConnector:
         subject: str | None,
         body: str,
         attachment_paths: list[Path] | None,
+        body_html: str | None = None,
     ) -> dict[str, str] | None:
         """IMAP-APPEND path for a ``seed="new"`` save-as-draft (issue #245).
 
@@ -4435,7 +4443,8 @@ class AppleMailConnector:
         signal ``create_draft`` to fall through to the AppleScript path.
         Scoped to ``seed="new"`` save-as-draft with a known account; on the
         usual IMAP-degradation signals (e.g. no Keychain opt-in) it logs
-        and returns ``None``, preserving prior behavior.
+        and returns ``None``, preserving prior behavior. ``body_html``
+        builds a multipart/alternative draft (#251).
         """
         if not (
             seed == "new"
@@ -4452,6 +4461,7 @@ class AppleMailConnector:
                 bcc=bcc,
                 subject=subject or "",
                 body=body,
+                body_html=body_html,
                 attachment_paths=attachment_paths,
             )
         except _IMAP_FALLBACK_EXCS as exc:
@@ -4527,6 +4537,7 @@ class AppleMailConnector:
         bcc: list[str] | None = None,
         subject: str | None = None,
         body: str = "",
+        body_html: str | None = None,
         attachment_paths: list[Path] | None = None,
         reply_all: bool = False,
         from_account: str | None = None,
@@ -4627,6 +4638,7 @@ class AppleMailConnector:
             bcc=bcc,
             subject=subject,
             body=body,
+            body_html=body_html,
             reply_all=reply_all,
             attachment_paths=attachment_paths,
         )
@@ -4637,6 +4649,18 @@ class AppleMailConnector:
             # the local UI promptly. (#269)
             self._sync_account_drafts(effective_account)
             return imap_result
+
+        # HTML drafts exist only on the clean IMAP path (Mail.app's
+        # AppleScript `content` setter is plain-text only). If the IMAP path
+        # couldn't engage, fail loud rather than silently dropping the HTML
+        # into a plain-text AppleScript draft. (#251)
+        if body_html is not None:
+            raise MailDraftHtmlUnavailableError(
+                "HTML drafts require IMAP credentials"
+                + (f" for account {effective_account!r}" if effective_account else "")
+                + ". Opt in to Keychain IMAP access (see docs) or omit "
+                "body_html to create a plain-text draft."
+            )
 
         # Committed to the AppleScript path, which carries Mail.app's
         # cite-blockquote wrapper (FB11734014). Warn save-as-draft callers
@@ -4883,10 +4907,15 @@ class AppleMailConnector:
         body: str,
         reply_all: bool,
         attachment_paths: list[Path] | None,
+        body_html: str | None = None,
     ) -> dict[str, str] | None:
         """Try the clean IMAP-APPEND draft paths (compose, then
         reply/forward), returning a draft dict or ``None`` to fall through
-        to AppleScript. (#245)"""
+        to AppleScript. (#245)
+
+        ``body_html`` is honored only on the compose (``seed="new"``) path;
+        reply/forward HTML is out of scope for #251.
+        """
         result = self._try_imap_compose_draft(
             seed=seed,
             send_now=send_now,
@@ -4896,6 +4925,7 @@ class AppleMailConnector:
             bcc=bcc,
             subject=subject,
             body=body,
+            body_html=body_html,
             attachment_paths=attachment_paths,
         )
         if result is not None:

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -20,6 +20,7 @@ from .exceptions import (
     MailAccountNotFoundError,
     MailAppleScriptError,
     MailDraftError,
+    MailDraftHtmlUnavailableError,
     MailDraftInvalidIdError,
     MailDraftNotFoundError,
     MailImapRequiredError,
@@ -2351,6 +2352,8 @@ def _draft_error_response(e: MailDraftError) -> dict[str, Any]:
         et = "draft_not_found"
     elif isinstance(e, MailDraftInvalidIdError):
         et = "invalid_draft_id"
+    elif isinstance(e, MailDraftHtmlUnavailableError):
+        et = "html_requires_imap"
     else:
         et = "draft_error"
     return {"success": False, "error": str(e), "error_type": et}
@@ -2466,6 +2469,60 @@ def _build_draft_send_summary(
         preview = body[:200] + "..." if len(body) > 200 else body
         lines.append(f"\n{preview}")
     return verb + "\n\n" + "\n".join(lines)
+
+
+def _validate_draft_common_inputs(
+    template_name: str | None,
+    template_vars: dict[str, Any] | None,
+    body_html: str | None,
+    send_now: bool,
+) -> dict[str, Any] | None:
+    """Param-shape checks shared by create_draft and update_draft. Returns a
+    validation_error response, or None when inputs are valid.
+
+    HTML drafts (#251) have no send path (send_now is AppleScript, which is
+    plain-text only), so body_html + send_now is rejected here.
+    """
+    if template_vars and not template_name:
+        return {
+            "success": False,
+            "error": "template_vars requires template_name",
+            "error_type": "validation_error",
+        }
+    if body_html is not None and send_now:
+        return {
+            "success": False,
+            "error": "body_html cannot be combined with send_now",
+            "error_type": "validation_error",
+        }
+    return None
+
+
+def _validate_create_draft_seed_inputs(
+    reply_to: str | None,
+    forward_of: str | None,
+    body_html: str | None,
+) -> dict[str, Any] | None:
+    """create_draft seed-shape checks. Returns a validation_error response,
+    or None when valid. HTML reply/forward quoting is out of scope (#251),
+    so body_html is fresh-draft-only.
+    """
+    if reply_to and forward_of:
+        return {
+            "success": False,
+            "error": "reply_to and forward_of are mutually exclusive",
+            "error_type": "validation_error",
+        }
+    if body_html is not None and (reply_to or forward_of):
+        return {
+            "success": False,
+            "error": (
+                "body_html is only supported for fresh drafts, not "
+                "reply_to/forward_of"
+            ),
+            "error_type": "validation_error",
+        }
+    return None
 
 
 def _resolve_create_draft_seed(
@@ -2670,6 +2727,7 @@ async def create_draft(
     bcc: StrList | None = None,
     subject: str | None = None,
     body: str = "",
+    body_html: str | None = None,
     attachment_paths: StrList | None = None,
     reply_all: bool = False,
     template_name: str | None = None,
@@ -2709,6 +2767,16 @@ async def create_draft(
         body: Body text. For reply/forward, a non-empty body REPLACES
             Mail's auto-quoted content; an empty body leaves the
             auto-quote intact (matches Mail.app's default reply behavior).
+        body_html: Optional HTML body. When set, the draft is built as a
+            multipart/alternative (HTML + a plain-text alternative taken
+            from ``body``, or derived from the HTML when ``body`` is empty).
+            HTML drafts are created over the clean IMAP path, so they
+            REQUIRE IMAP credentials for the account and are limited to
+            fresh save-as-draft: passing ``body_html`` with ``send_now`` or
+            with ``reply_to``/``forward_of`` is rejected, and if IMAP can't
+            engage the call fails (``error_type: "html_requires_imap"``)
+            rather than silently downgrading to plain text. HTML is
+            caller-trusted (not sanitized). (#251)
         attachment_paths: List of file paths to attach.
         reply_all: For ``reply_to`` only — use ``reply to all``.
         template_name: Optional template to render for ``subject`` and
@@ -2739,18 +2807,16 @@ async def create_draft(
         # ----------------------------------------------------------------
         # Param-shape validation
         # ----------------------------------------------------------------
-        if reply_to and forward_of:
-            return {
-                "success": False,
-                "error": "reply_to and forward_of are mutually exclusive",
-                "error_type": "validation_error",
-            }
-        if template_vars and not template_name:
-            return {
-                "success": False,
-                "error": "template_vars requires template_name",
-                "error_type": "validation_error",
-            }
+        common_err = _validate_draft_common_inputs(
+            template_name, template_vars, body_html, send_now
+        )
+        if common_err:
+            return common_err
+        seed_err = _validate_create_draft_seed_inputs(
+            reply_to, forward_of, body_html
+        )
+        if seed_err:
+            return seed_err
 
         seed_kind, seed_id = _resolve_create_draft_seed(reply_to, forward_of)
 
@@ -2816,6 +2882,7 @@ async def create_draft(
             bcc=bcc,
             subject=subject,
             body=body,
+            body_html=body_html,
             attachment_paths=attachment_path_objs,
             reply_all=reply_all,
             from_account=from_account,
@@ -2871,6 +2938,7 @@ async def update_draft(
     bcc: StrList | None = None,
     subject: str | None = None,
     body: str | None = None,
+    body_html: str | None = None,
     attachment_paths: StrList | None = None,
     template_name: str | None = None,
     template_vars: StrDict | None = None,
@@ -2904,6 +2972,13 @@ async def update_draft(
         subject: Override subject. None keeps existing.
         body: Override body. None keeps existing. Non-None replaces
             (including the empty string, which clears).
+        body_html: Optional HTML body for the recreated draft (see
+            ``create_draft``). Requires IMAP credentials and is limited to
+            drafts whose seed is a fresh draft (not reply/forward) and to
+            ``send_now=False``. NOTE: because the draft is recreated and
+            draft state captures only plain text, an existing HTML draft is
+            NOT preserved across an update unless ``body_html`` is passed
+            again. (#251)
         attachment_paths: Override attachments. None preserves existing
             via temp-dir extraction; [] clears; list replaces.
         template_name / template_vars: Optional template render. User-
@@ -2917,12 +2992,11 @@ async def update_draft(
     """
     tempdir: tempfile.TemporaryDirectory[str] | None = None
     try:
-        if template_vars and not template_name:
-            return {
-                "success": False,
-                "error": "template_vars requires template_name",
-                "error_type": "validation_error",
-            }
+        common_err = _validate_draft_common_inputs(
+            template_name, template_vars, body_html, send_now
+        )
+        if common_err:
+            return common_err
 
         try:
             state = mail.get_draft_state(draft_id)
@@ -2933,6 +3007,15 @@ async def update_draft(
         seed_kind, seed_id, reply_all = _resolve_draft_seed(
             draft_id, state, store
         )
+        if body_html is not None and seed_kind != "new":
+            return {
+                "success": False,
+                "error": (
+                    "body_html is only supported for fresh drafts, not "
+                    "reply/forward drafts"
+                ),
+                "error_type": "validation_error",
+            }
 
         try:
             final_subject, final_body = _resolve_update_subject_body(
@@ -2989,6 +3072,7 @@ async def update_draft(
             bcc=final_bcc,
             subject=final_subject,
             body=final_body or "",
+            body_html=body_html,
             attachment_paths=final_attachments,
             reply_all=reply_all,
             from_account=from_account,

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -620,6 +620,69 @@ class TestDraftsLifecycleIntegration:
         finally:
             assert connector.delete_draft(draft_id) is True
 
+    def test_create_draft_html_body_round_trips_as_multipart_alternative(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """#251: a draft created with body_html is APPENDed as a real
+        multipart/alternative and the HTML survives a round-trip fetch from
+        the Drafts folder over IMAP."""
+        import email as _email
+        from email import policy as _policy
+
+        from apple_mail_mcp.exceptions import (
+            MailKeychainAccessDeniedError,
+            MailKeychainEntryNotFoundError,
+            MailMessageNotFoundError,
+        )
+        from apple_mail_mcp.imap_connector import ImapConnector
+        from apple_mail_mcp.keychain import get_imap_password
+
+        try:
+            host, port, email = connector._resolve_imap_config(test_account)
+            password = get_imap_password(test_account, email)
+        except (
+            MailKeychainEntryNotFoundError,
+            MailKeychainAccessDeniedError,
+        ):
+            pytest.skip(
+                f"No Keychain entry for {test_account!r} — HTML IMAP-APPEND "
+                f"path can't be exercised. Run `apple-mail-fast-mcp setup-imap`."
+            )
+
+        marker = "ZZZ-AMM-INTEG-HTML251"
+        result = connector.create_draft(
+            seed="new",
+            from_account=test_account,
+            to=["test1@example.com"],
+            subject=marker,
+            body="plain fallback",
+            body_html=f"<p>Revenue <b>{marker}</b></p>",
+        )
+        draft_id = result["draft_id"]
+        assert "@" in draft_id, (
+            f"expected IMAP-APPEND path (bare Message-ID); got {draft_id!r}"
+        )
+        try:
+            # Fetch the raw draft back over IMAP from the Drafts folder.
+            imap = ImapConnector(host, port, email, password)
+            raw = None
+            for folder in ImapConnector._CONVENTIONAL_DRAFTS_NAMES:
+                try:
+                    raw = imap.fetch_raw_message(draft_id, folder)
+                    break
+                except MailMessageNotFoundError:
+                    continue
+            assert raw is not None, "HTML draft not found in any Drafts folder"
+            msg = _email.message_from_bytes(raw, policy=_policy.default)
+            assert msg.get_content_type() == "multipart/alternative"
+            html = msg.get_body(preferencelist=("html",))
+            plain = msg.get_body(preferencelist=("plain",))
+            assert html is not None and plain is not None
+            assert f"<b>{marker}</b>" in html.get_content()
+            assert "plain fallback" in plain.get_content()
+        finally:
+            assert connector.delete_draft(draft_id) is True
+
     def test_reply_save_preserves_threading_headers(
         self,
         connector: AppleMailConnector,

--- a/tests/unit/test_draft_builder.py
+++ b/tests/unit/test_draft_builder.py
@@ -90,6 +90,88 @@ def test_sanitizes_header_injection_chars():
     assert msg["X-Injected"] is None
 
 
+# --- HTML body support (issue #251) --------------------------------------
+
+
+def test_body_html_only_builds_multipart_alternative_with_derived_plain():
+    """body_html alone -> multipart/alternative with a text/html part and a
+    text/plain part auto-derived from the HTML (so non-HTML readers and
+    reply-quoting still have something)."""
+    _msgid, raw = build_draft_mime(
+        sender="me@example.invalid",
+        to=["you@example.invalid"],
+        subject="Q2 numbers",
+        body="",
+        body_html="<p>Revenue <b>up 12%</b></p>",
+    )
+    msg = email.message_from_bytes(raw, policy=policy.default)
+    assert msg.get_content_type() == "multipart/alternative"
+
+    html_part = msg.get_body(preferencelist=("html",))
+    plain_part = msg.get_body(preferencelist=("plain",))
+    assert html_part is not None and plain_part is not None
+    assert "<b>up 12%</b>" in html_part.get_content()
+    # Derived plain strips tags but keeps the text.
+    derived = plain_part.get_content()
+    assert "Revenue" in derived and "up 12%" in derived
+    assert "<b>" not in derived
+
+
+def test_body_and_body_html_uses_body_as_plain_part():
+    """When both are given, body is the text/plain alternative verbatim and
+    body_html is the text/html part (standard multipart shape)."""
+    _msgid, raw = build_draft_mime(
+        sender="me@example.invalid",
+        to=["you@example.invalid"],
+        subject="hi",
+        body="plain fallback text",
+        body_html="<p>rich text</p>",
+    )
+    msg = email.message_from_bytes(raw, policy=policy.default)
+    assert msg.get_content_type() == "multipart/alternative"
+    assert msg.get_body(preferencelist=("plain",)).get_content().strip() == (
+        "plain fallback text"
+    )
+    assert "<p>rich text</p>" in msg.get_body(
+        preferencelist=("html",)
+    ).get_content()
+
+
+def test_body_only_stays_single_text_plain():
+    """No body_html -> unchanged behavior: a single text/plain part."""
+    _msgid, raw = build_draft_mime(
+        sender="me@example.invalid",
+        to=["you@example.invalid"],
+        subject="hi",
+        body="just text",
+    )
+    msg = email.message_from_bytes(raw, policy=policy.default)
+    assert msg.get_content_type() == "text/plain"
+    assert "just text" in msg.get_content()
+
+
+def test_body_html_with_attachment_nests_alternative_in_mixed(tmp_path):
+    """body_html + attachment -> multipart/mixed wrapping the
+    multipart/alternative and the attachment."""
+    pdf = tmp_path / "report.pdf"
+    pdf.write_bytes(b"%PDF-1.7\nfake")
+    _msgid, raw = build_draft_mime(
+        sender="me@example.invalid",
+        to=["you@example.invalid"],
+        subject="report",
+        body="see attached",
+        body_html="<p>see <i>attached</i></p>",
+        attachments=[pdf],
+    )
+    msg = email.message_from_bytes(raw, policy=policy.default)
+    assert msg.get_content_type() == "multipart/mixed"
+    # Both alternatives still reachable.
+    assert msg.get_body(preferencelist=("html",)) is not None
+    assert msg.get_body(preferencelist=("plain",)) is not None
+    names = [p.get_filename() for p in msg.iter_attachments()]
+    assert "report.pdf" in names
+
+
 # --- Reply/forward extensions (issue #245 follow-up) ---------------------
 
 from apple_mail_mcp.draft_builder import (  # noqa: E402

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -7209,6 +7209,89 @@ class TestCreateDraftImapAppend:
         mock_applescript.assert_called_once()
         assert result["draft_id"] == "123"
 
+    @patch.object(AppleMailConnector, "_run_applescript")
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password", return_value="pw")
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_imap_config",
+        return_value=("imap.host", 993, "appleid@fmasi.eu"),
+    )
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_account_to_sender",
+        return_value="Fred <email@fmasi.eu>",
+    )
+    def test_body_html_appends_multipart_alternative(
+        self, _sender, _cfg, _pw, mock_imap_cls, mock_applescript
+    ):
+        """#251: body_html threads into the IMAP MIME as a
+        multipart/alternative (text/plain + text/html)."""
+        import email as _email
+        from email import policy as _policy
+
+        conn = self._conn()
+        result = conn.create_draft(
+            seed="new",
+            to=["lazar@hadleigh.co.uk"],
+            subject="Q2 numbers",
+            body="plain fallback",
+            body_html="<p>Revenue <b>up</b></p>",
+            from_account="iCloud",
+            send_now=False,
+        )
+        raw = mock_imap_cls.return_value.append_draft.call_args[0][0]
+        msg = _email.message_from_bytes(raw, policy=_policy.default)
+        assert msg.get_content_type() == "multipart/alternative"
+        assert "<b>up</b>" in msg.get_body(preferencelist=("html",)).get_content()
+        assert msg.get_body(preferencelist=("plain",)).get_content().strip() == (
+            "plain fallback"
+        )
+        assert "@" in result["draft_id"]
+
+    @patch.object(AppleMailConnector, "_run_applescript", return_value="123")
+    @patch("apple_mail_mcp.mail_connector.ImapConnector")
+    @patch("apple_mail_mcp.mail_connector.get_imap_password", return_value="pw")
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_imap_config",
+        return_value=("imap.host", 993, "appleid@fmasi.eu"),
+    )
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_account_to_sender",
+        return_value="Fred <email@fmasi.eu>",
+    )
+    def test_body_html_fails_loud_when_imap_unavailable(
+        self, _sender, _cfg, _pw, mock_imap_cls, mock_applescript
+    ):
+        """#251: when body_html is set and the IMAP path can't engage, raise
+        MailDraftHtmlUnavailableError — never silently downgrade to a
+        plain-text AppleScript draft."""
+        from apple_mail_mcp.exceptions import (
+            MailDraftHtmlUnavailableError,
+            MailKeychainEntryNotFoundError,
+        )
+
+        mock_imap_cls.return_value.append_draft.side_effect = (
+            MailKeychainEntryNotFoundError("no creds")
+        )
+        conn = self._conn()
+        with pytest.raises(MailDraftHtmlUnavailableError):
+            conn.create_draft(
+                seed="new",
+                to=["x@example.invalid"],
+                subject="hi",
+                body="body",
+                body_html="<p>rich</p>",
+                from_account="iCloud",
+                send_now=False,
+            )
+        # IMAP was attempted, but NO AppleScript draft-build fallback ran.
+        mock_imap_cls.return_value.append_draft.assert_called_once()
+        scripts = [c[0][0] for c in mock_applescript.call_args_list]
+        assert not any("make new outgoing message" in s for s in scripts)
+
 
 class TestCreateReplyForwardDraftViaImap:
     """Issue #245 follow-up: reply/forward save-as-draft via IMAP APPEND of

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2920,6 +2920,86 @@ class TestCreateDraftTool:
         assert kwargs["send_now"] is False
 
     @pytest.mark.asyncio
+    async def test_body_html_threads_to_connector(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """#251: body_html is passed through to the connector for a fresh
+        save-as-draft."""
+        from apple_mail_mcp.server import create_draft
+
+        mock_mail.create_draft.return_value = {
+            "draft_id": "161099", "sent_message_id": ""
+        }
+        result = await create_draft(
+            to=["a@example.com"], subject="hi",
+            body="plain", body_html="<p>rich</p>",
+        )
+        assert result["success"] is True
+        kwargs = mock_mail.create_draft.call_args.kwargs
+        assert kwargs["body_html"] == "<p>rich</p>"
+
+    @pytest.mark.asyncio
+    async def test_body_html_with_send_now_rejected(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """#251: no HTML send path — body_html + send_now is a
+        validation_error and never reaches the connector."""
+        from apple_mail_mcp.server import create_draft
+
+        result = await create_draft(
+            to=["a@example.com"], subject="hi",
+            body_html="<p>rich</p>", send_now=True,
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_mail.create_draft.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_body_html_with_reply_to_rejected(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """#251: HTML reply/forward is out of scope — rejected as a
+        validation_error before the connector."""
+        from apple_mail_mcp.server import create_draft
+
+        result = await create_draft(
+            reply_to="160989", body_html="<p>rich</p>",
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_mail.create_draft.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_body_html_unavailable_maps_to_html_requires_imap(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """#251: the connector's fail-loud exception surfaces as
+        error_type 'html_requires_imap'."""
+        from apple_mail_mcp.exceptions import MailDraftHtmlUnavailableError
+        from apple_mail_mcp.server import create_draft
+
+        mock_mail.create_draft.side_effect = MailDraftHtmlUnavailableError(
+            "HTML drafts require IMAP credentials"
+        )
+        result = await create_draft(
+            to=["a@example.com"], subject="hi", body_html="<p>rich</p>",
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "html_requires_imap"
+
+    @pytest.mark.asyncio
     async def test_reply_to_routes_to_reply_seed(
         self,
         isolated_drafts: Any,
@@ -3270,6 +3350,68 @@ class TestUpdateDraftTool:
         assert kwargs["body"] == "new body"
         # Recipients preserved from existing state.
         assert kwargs["to"] == ["alice@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_update_body_html_threads_for_fresh_seed(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """#251: body_html threads to the recreated draft when the seed is a
+        fresh draft."""
+        from apple_mail_mcp.server import update_draft
+
+        mock_mail.get_draft_state.return_value = {
+            "draft_id": "160991",
+            "to": ["alice@example.com"], "cc": [], "bcc": [],
+            "subject": "hi", "body": "old",
+            "in_reply_to": "", "references": "",
+            "attachment_names": [],
+        }
+        mock_mail.delete_draft.return_value = True
+        mock_mail.create_draft.return_value = {
+            "draft_id": "161000", "sent_message_id": ""
+        }
+        result = await update_draft(
+            draft_id="160991", body_html="<p>rich</p>"
+        )
+        assert result["success"] is True
+        kwargs = mock_mail.create_draft.call_args.kwargs
+        assert kwargs["seed"] == "new"
+        assert kwargs["body_html"] == "<p>rich</p>"
+
+    @pytest.mark.asyncio
+    async def test_update_body_html_rejected_for_reply_seed(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+    ) -> None:
+        """#251: HTML reply/forward drafts are out of scope — reject and
+        leave the existing draft untouched (no delete/recreate)."""
+        from apple_mail_mcp.drafts import DraftStateStore, SeedRecord
+        from apple_mail_mcp.server import update_draft
+
+        store = DraftStateStore()
+        store.set_seed(
+            "160991",
+            SeedRecord(seed_kind="reply", seed_id="160000", reply_all=False),
+        )
+        mock_mail.get_draft_state.return_value = {
+            "draft_id": "160991",
+            "to": ["alice@example.com"], "cc": [], "bcc": [],
+            "subject": "Re: hi", "body": "old",
+            "in_reply_to": "<orig@x>", "references": "<orig@x>",
+            "attachment_names": [],
+        }
+        result = await update_draft(
+            draft_id="160991", body_html="<p>rich</p>"
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "validation_error"
+        mock_mail.delete_draft.assert_not_called()
+        mock_mail.create_draft.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_update_falls_back_to_in_reply_to(


### PR DESCRIPTION
Closes #251.

## What
Adds an optional `body_html` parameter to `create_draft` and `update_draft`. When set, the draft is built as a `multipart/alternative` (text/html + a text/plain alternative — taken from `body`, or derived from the HTML via the existing `_html_to_text` when `body` is empty) over the clean IMAP-APPEND path. Mail.app's AppleScript `content` setter is plain-text only, so HTML can only live on the IMAP/MIME path.

Per the `api-design` decision tree, this extends the existing compose tools rather than adding a new one.

## Scope (MVP — confirmed during planning)
Fresh save-as-draft only:
- `body_html` + `send_now` → `validation_error` (no SMTP/HTML send path; `send_now` is AppleScript).
- `body_html` + `reply_to`/`forward_of` → `validation_error` (HTML reply/forward quoting deferred).
- **Fail loud, never downgrade:** if the IMAP path can't engage (no Keychain opt-in / creds, breaker open, APPEND failure), the call raises `MailDraftHtmlUnavailableError` → `error_type: "html_requires_imap"` instead of silently producing a plain-text draft.

HTML is caller-trusted content (MIME-encoded, not HTML-sanitized), mirroring the plain `body`.

## Changes
- **draft_builder.py** — `build_draft_mime` gains `body_html`; emits `multipart/alternative`.
- **mail_connector.py** — threads `body_html` through `create_draft` → `_try_imap_draft_paths` → `_try_imap_compose_draft` → `_create_draft_via_imap`; fail-loud when IMAP can't engage.
- **exceptions.py** — `MailDraftHtmlUnavailableError`.
- **server.py** — `body_html` on both tools; validation extracted to `_validate_draft_common_inputs` / `_validate_create_draft_seed_inputs` (keeps both tools under the CC≤20 gate); maps the new exception to `html_requires_imap`.
- **docs/reference/TOOLS.md** + eval tool descriptions.

## Tests / verification
- `make test` — 1299 passed (12 new unit tests: builder shapes, connector threading + fail-loud, server validation + error mapping for both tools).
- `make test-e2e` — 29 passed.
- `make check-all` — lint, mypy strict, complexity, parity, doc/eval-sync all pass.
- **Integration (real iCloud IMAP):** `test_create_draft_html_body_round_trips_as_multipart_alternative` **passes** — HTML draft APPENDed, fetched back from Drafts, verified `multipart/alternative` with both parts.
- **Manual:** draft renders as formatted HTML (heading, bold, link, bordered table) in Mail.app — no cite-blockquote wrapper.

## Out of scope (follow-ups)
HTML reply/forward, HTML `send_now` (needs SMTP), HTML preservation across `update_draft` without re-passing `body_html`, Markdown→HTML, inline `cid:` images, receive-side HTML sanitization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)