### PR TITLE
feat(#248): env-var fallback for the IMAP password (uvx / headless / CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ On first run, macOS will prompt for Automation access. Grant permission in:
 
 `search_messages` works out of the box via AppleScript. For large mailboxes (thousands of messages), AppleScript's `whose` clause can take 1–5 seconds per query. If you want faster server-side search, you can enable IMAP delegation per account by adding a Keychain entry.
 
-**How it works.** If a Keychain entry exists for an account, the server uses IMAP (fast, server-side SEARCH). Otherwise — or on any IMAP failure (offline, wrong password, timeout) — it silently falls back to AppleScript. You never lose functionality; you only gain speed when IMAP is configured and reachable. No config flags, no environment variables; the Keychain entry's presence is the opt-in.
+**How it works.** If credentials exist for an account, the server uses IMAP (fast, server-side SEARCH). Otherwise — or on any IMAP failure (offline, wrong password, timeout) — it silently falls back to AppleScript. You never lose functionality; you only gain speed when IMAP is configured and reachable. The normal opt-in is a Keychain entry (below); an environment-variable fallback ([further down](#environment-variable-fallback-uvx--headless--ci)) covers contexts where the Keychain isn't usable.
 
 **One-time setup per account.**
 
@@ -105,6 +105,29 @@ On first run, macOS will prompt for Automation access. Grant permission in:
 3. If you see a one-time "security wants to use the 'login' keychain" prompt on the next IMAP-backed call, click **Always Allow**.
 
 To remove the entry later: `apple-mail-fast-mcp setup-imap --account iCloud --uninstall`.
+
+### Environment-variable fallback (uvx / headless / CI)
+
+Some contexts have no usable Keychain: `uvx` runs (ephemeral binary paths break the Keychain ACL, causing re-prompts or failures), Docker / CI (no Keychain at all), and background services (the ACL prompt blocks forever with no UI attached). For those, you can supply the IMAP password via an environment variable instead:
+
+```
+APPLE_MAIL_MCP_IMAP_PASSWORD_<SUFFIX>
+```
+
+`<SUFFIX>` is the Mail.app account name **uppercased**, with each run of non-alphanumeric characters collapsed to a single underscore and leading/trailing underscores trimmed:
+
+| Account name | Environment variable |
+|---|---|
+| `iCloud` | `APPLE_MAIL_MCP_IMAP_PASSWORD_ICLOUD` |
+| `Gmail` | `APPLE_MAIL_MCP_IMAP_PASSWORD_GMAIL` |
+| `Yahoo!` | `APPLE_MAIL_MCP_IMAP_PASSWORD_YAHOO` |
+| `My Gmail` | `APPLE_MAIL_MCP_IMAP_PASSWORD_MY_GMAIL` |
+
+When set to a non-empty value, the env var is used **in preference to** any Keychain entry for that account (it's checked first, with no `security` shell-out). An empty or whitespace-only value is ignored and the Keychain path is used. The lookup composes with the name↔UUID fallback, so an env var keyed on the account name is still found when a caller passes the account's UUID.
+
+> ⚠️ **Security tradeoff.** Environment variables are far less private than the Keychain — they're visible via `ps -E`, `launchctl getenv`, `/proc`-style introspection, and process crash dumps, and they're easy to leak into logs or shell history. **Use this only when the Keychain genuinely isn't an option** (uvx, Docker, CI, headless). For Claude Desktop and standard local installs, stick with `setup-imap` + Keychain.
+>
+> Caveat: the name→suffix mapping isn't reversible — `Yahoo!` and `Yahoo` both map to `YAHOO`, and an account name with no ASCII letters/digits has no env-var form (use the Keychain for those).
 
 **Verifying the setup.** The `setup-imap` command does this for you. If you want to spot-check post-hoc:
 ```bash

--- a/src/apple_mail_mcp/keychain.py
+++ b/src/apple_mail_mcp/keychain.py
@@ -15,6 +15,9 @@ design decisions.
 
 from __future__ import annotations
 
+import logging
+import os
+import re
 import subprocess
 
 from apple_mail_mcp.exceptions import (
@@ -23,11 +26,36 @@ from apple_mail_mcp.exceptions import (
     MailKeychainError,
 )
 
+logger = logging.getLogger(__name__)
+
 SERVICE_NAME_PREFIX = "apple-mail-mcp.imap."
+
+# Env-var fallback for the IMAP password (#248). Convention:
+# APPLE_MAIL_MCP_IMAP_PASSWORD_<SUFFIX>, where <SUFFIX> is the account name
+# uppercased with runs of non-[A-Z0-9] collapsed to a single underscore and
+# leading/trailing underscores trimmed (e.g. "My Gmail" -> "MY_GMAIL").
+IMAP_PASSWORD_ENV_PREFIX = "APPLE_MAIL_MCP_IMAP_PASSWORD_"
+
+_ENV_SUFFIX_SEP_RE = re.compile(r"[^A-Z0-9]+")
 
 _EXIT_ITEM_NOT_FOUND = 44
 _EXIT_INTERACTION_NOT_ALLOWED = 128
 _ACCESS_DENIED_MARKERS = ("-25308", "-128", "not allowed", "user canceled")
+
+
+def _env_var_name(mail_app_account: str) -> str | None:
+    """Return the env-var name an account's IMAP password may be read from,
+    or ``None`` when the account name has no ASCII alphanumerics to build a
+    usable suffix from (e.g. an all-non-ASCII name — use Keychain instead).
+
+    The mapping is not injective: ``"Yahoo!"`` and ``"Yahoo"`` both yield
+    ``YAHOO``. This is documented; distinct accounts that collide must use
+    Keychain. (#248)
+    """
+    suffix = _ENV_SUFFIX_SEP_RE.sub("_", mail_app_account.upper()).strip("_")
+    if not suffix:
+        return None
+    return IMAP_PASSWORD_ENV_PREFIX + suffix
 
 
 def get_imap_password(mail_app_account: str, email: str) -> str:
@@ -44,7 +72,23 @@ def get_imap_password(mail_app_account: str, email: str) -> str:
         MailKeychainEntryNotFoundError: No matching Keychain item.
         MailKeychainAccessDeniedError: ACL or user denial.
         MailKeychainError: Any other ``security(1)`` failure.
+
+    Env-var fallback (#248): for uvx / headless / CI contexts where the
+    Keychain isn't usable, an env var named per ``_env_var_name`` is checked
+    first; a present, non-empty value is returned without shelling out to
+    ``security``. This is less private than Keychain (env vars show up in
+    ``ps`` / ``launchctl env`` / crash dumps) — see the README.
     """
+    env_name = _env_var_name(mail_app_account)
+    if env_name:
+        env_pw = os.environ.get(env_name)
+        if env_pw and env_pw.strip():
+            logger.debug(
+                "Using env-var IMAP password (%s) for account %r",
+                env_name,
+                mail_app_account,
+            )
+            return env_pw
     service = SERVICE_NAME_PREFIX + mail_app_account
     try:
         result = subprocess.run(

--- a/tests/unit/test_keychain.py
+++ b/tests/unit/test_keychain.py
@@ -10,7 +10,9 @@ from apple_mail_mcp.exceptions import (
     MailKeychainError,
 )
 from apple_mail_mcp.keychain import (
+    IMAP_PASSWORD_ENV_PREFIX,
     SERVICE_NAME_PREFIX,
+    _env_var_name,
     delete_imap_password,
     get_imap_password,
     set_imap_password,
@@ -24,6 +26,18 @@ def _mock_security(returncode: int, stdout: str = "", stderr: str = "") -> Magic
     m.stdout = stdout
     m.stderr = stderr
     return m
+
+
+@pytest.fixture(autouse=True)
+def _clear_imap_password_env(monkeypatch):
+    """Keep the env-var fallback (#248) from leaking into the Keychain-path
+    tests: strip any APPLE_MAIL_MCP_IMAP_PASSWORD_* set in the runner's
+    shell. Individual env-fallback tests set their own with monkeypatch."""
+    import os
+
+    for key in list(os.environ):
+        if key.startswith(IMAP_PASSWORD_ENV_PREFIX):
+            monkeypatch.delenv(key, raising=False)
 
 
 class TestServiceNamePrefix:
@@ -203,3 +217,87 @@ class TestDeleteImapPassword:
         with pytest.raises(MailKeychainError) as exc_info:
             delete_imap_password("iCloud", "u@i.com")
         assert type(exc_info.value) is MailKeychainError
+
+
+class TestEnvVarName:
+    """#248: account name -> APPLE_MAIL_MCP_IMAP_PASSWORD_<SUFFIX>."""
+
+    def test_prefix(self):
+        assert IMAP_PASSWORD_ENV_PREFIX == "APPLE_MAIL_MCP_IMAP_PASSWORD_"
+
+    @pytest.mark.parametrize(
+        "account, expected",
+        [
+            ("iCloud", "APPLE_MAIL_MCP_IMAP_PASSWORD_ICLOUD"),
+            ("Gmail", "APPLE_MAIL_MCP_IMAP_PASSWORD_GMAIL"),
+            ("MobileMe", "APPLE_MAIL_MCP_IMAP_PASSWORD_MOBILEME"),
+            ("Yahoo!", "APPLE_MAIL_MCP_IMAP_PASSWORD_YAHOO"),
+            ("My Gmail", "APPLE_MAIL_MCP_IMAP_PASSWORD_MY_GMAIL"),
+            ("iCloud (Work)", "APPLE_MAIL_MCP_IMAP_PASSWORD_ICLOUD_WORK"),
+            ("a.b-c__d", "APPLE_MAIL_MCP_IMAP_PASSWORD_A_B_C_D"),
+            ("  spaced  ", "APPLE_MAIL_MCP_IMAP_PASSWORD_SPACED"),
+        ],
+    )
+    def test_normalization_round_trips(self, account, expected):
+        assert _env_var_name(account) == expected
+
+    @pytest.mark.parametrize("account", ["日本語", "!!!", "   ", ""])
+    def test_empty_suffix_returns_none(self, account):
+        # No ASCII alphanumerics -> no usable env var name; caller skips
+        # the env path and uses Keychain.
+        assert _env_var_name(account) is None
+
+
+class TestEnvVarFallback:
+    """#248: env-var password fallback for uvx / headless / CI."""
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_env_var_present_returns_value_without_shellout(
+        self, mock_run, monkeypatch
+    ):
+        monkeypatch.setenv("APPLE_MAIL_MCP_IMAP_PASSWORD_ICLOUD", "envpw")
+        assert get_imap_password("iCloud", "u@icloud.com") == "envpw"
+        mock_run.assert_not_called()
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_env_var_takes_precedence_over_keychain(self, mock_run, monkeypatch):
+        # Even when Keychain would succeed, a present env var wins.
+        mock_run.return_value = _mock_security(0, stdout="keychainpw\n")
+        monkeypatch.setenv("APPLE_MAIL_MCP_IMAP_PASSWORD_ICLOUD", "envpw")
+        assert get_imap_password("iCloud", "u@icloud.com") == "envpw"
+        mock_run.assert_not_called()
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_empty_env_var_falls_through_to_keychain(self, mock_run, monkeypatch):
+        mock_run.return_value = _mock_security(0, stdout="keychainpw\n")
+        monkeypatch.setenv("APPLE_MAIL_MCP_IMAP_PASSWORD_ICLOUD", "")
+        assert get_imap_password("iCloud", "u@icloud.com") == "keychainpw"
+        mock_run.assert_called_once()
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_whitespace_only_env_var_falls_through_to_keychain(
+        self, mock_run, monkeypatch
+    ):
+        mock_run.return_value = _mock_security(0, stdout="keychainpw\n")
+        monkeypatch.setenv("APPLE_MAIL_MCP_IMAP_PASSWORD_ICLOUD", "   ")
+        assert get_imap_password("iCloud", "u@icloud.com") == "keychainpw"
+        mock_run.assert_called_once()
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_absent_env_var_uses_keychain(self, mock_run, monkeypatch):
+        monkeypatch.delenv(
+            "APPLE_MAIL_MCP_IMAP_PASSWORD_ICLOUD", raising=False
+        )
+        mock_run.return_value = _mock_security(0, stdout="keychainpw\n")
+        assert get_imap_password("iCloud", "u@icloud.com") == "keychainpw"
+        mock_run.assert_called_once()
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_env_var_preserves_internal_whitespace(self, mock_run, monkeypatch):
+        # A non-empty value with internal spaces is returned verbatim (the
+        # value isn't a name we normalize — it's the password).
+        monkeypatch.setenv(
+            "APPLE_MAIL_MCP_IMAP_PASSWORD_ICLOUD", "pw with spaces"
+        )
+        assert get_imap_password("iCloud", "u@i.com") == "pw with spaces"
+        mock_run.assert_not_called()

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -6991,6 +6991,45 @@ class TestKeychainDualFormLookup:
         with pytest.raises(MailKeychainEntryNotFoundError):
             c._get_imap_password_with_fallback("Unknown", "alice@example.com")
 
+    def test_env_var_keyed_on_name_found_when_caller_passes_uuid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#248 + #243 compose: the env var is keyed on the account NAME, but
+        the caller passes the UUID. The real get_imap_password is exercised —
+        the UUID form misses (env + Keychain), the wrapper resolves UUID→name,
+        and the name form hits the env var (no Keychain shell-out for it)."""
+        from apple_mail_mcp.mail_connector import AppleMailConnector
+
+        monkeypatch.setenv("APPLE_MAIL_MCP_IMAP_PASSWORD_GMAIL", "ENV-PW")
+        # The UUID form has no env var and its Keychain lookup must report
+        # not-found (exit 44) so the wrapper falls back to the name form.
+        run_calls: list[list[str]] = []
+
+        def fake_run(cmd, *a, **kw):
+            run_calls.append(cmd)
+            m = MagicMock()
+            m.returncode = 44  # item not found
+            m.stdout = ""
+            m.stderr = "could not be found in the keychain."
+            return m
+
+        monkeypatch.setattr(
+            "apple_mail_mcp.keychain.subprocess.run", fake_run
+        )
+        c = AppleMailConnector()
+        monkeypatch.setattr(
+            c, "list_accounts",
+            lambda: [{"name": "Gmail", "id": "04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16"}],
+        )
+        result = c._get_imap_password_with_fallback(
+            "04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16", "alice@gmail.com"
+        )
+        assert result == "ENV-PW"
+        # Only the UUID form shelled out to `security`; the name form was
+        # satisfied by the env var without a Keychain call.
+        assert len(run_calls) == 1
+        assert "apple-mail-mcp.imap.04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16" in run_calls[0]
+
 
 # =============================================================================
 # Mailbox resolver shape (#247)


### PR DESCRIPTION
Closes #248.

## What
Adds an opt-in environment-variable fallback for the IMAP password so contexts with no usable Keychain can still use the IMAP fast path. `get_imap_password` now checks an env var **before** shelling out to `security`.

Convention: `APPLE_MAIL_MCP_IMAP_PASSWORD_<SUFFIX>`, where `<SUFFIX>` is the Mail.app account name uppercased with runs of non-`[A-Z0-9]` collapsed to a single `_` and trimmed (`iCloud`→`ICLOUD`, `My Gmail`→`MY_GMAIL`).

## Why
Three real contexts have no usable Keychain (per the issue):
- **uvx** — ephemeral binary paths break the Keychain ACL (re-prompts/failures).
- **headless / Docker / CI** — no Keychain at all.
- **background services** — the ACL prompt blocks forever with no UI.

Explicitly **not** a fix for Claude Desktop / Cowork (those work post-#243) — purely for the no-Keychain minority cases.

## Behavior
- Present, non-empty env var **wins** over any Keychain entry (checked first, no `security` call).
- Empty / whitespace-only → ignored, falls through to Keychain.
- Names that normalize to empty (all non-ASCII) → no env form, use Keychain.
- **Composes with #243** for free: because the check lives inside `get_imap_password`, an env var keyed on the account **name** is found even when a caller passes the **UUID** (and vice versa).

## Security
Env vars are far less private than the Keychain (visible in `ps`, `launchctl getenv`, crash dumps). The README documents the tradeoff and steers Claude Desktop / local installs to keep using `setup-imap` + Keychain. Naming isn't injective (`Yahoo!`/`Yahoo`→`YAHOO`) — documented.

## Changes
- **keychain.py** — `IMAP_PASSWORD_ENV_PREFIX`, `_env_var_name` helper, env check at the top of `get_imap_password` (debug-logs the var name, never the value). `set`/`delete` unchanged.
- **tests** — `test_keychain.py`: env present/empty/whitespace/precedence/absent, normalization round-trips, empty-suffix→None guard, value-preserved-verbatim. `test_mail_connector.py`: #243 composition (env keyed on name, caller passes UUID → real `get_imap_password` exercised, only the UUID form shells out).
- **README.md** — revised the IMAP opt-in wording (the old "no environment variables" line) + new "Environment-variable fallback" subsection.

## Verification
- `make test` — 1319 passed (20 new).
- `make check-all` — lint, mypy strict, complexity, parity (no new tool), doc/eval-sync all pass.
- **Live check** — with `APPLE_MAIL_MCP_IMAP_PASSWORD_MOBILEME` set, the real `get_imap_password('MobileMe', …)` returns the env value with no Keychain shell-out.

## Out of scope
No new tool/param. No change to `setup-imap`, `set`/`delete_imap_password`, or the IMAP-vs-AppleScript fallback. Doesn't touch #341 (iCloud login resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)