### PR TITLE
ci(#277): hard-enforce client/server parity via an intended-internals allowlist

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,7 +17,7 @@ make typecheck             # Mypy strict mode
 make check-all             # All checks (lint, typecheck, test, complexity, version-sync, parity)
 make coverage              # Coverage report
 ./scripts/check_complexity.sh          # Cyclomatic complexity check
-./scripts/check_client_server_parity.sh  # Verify all connector methods are exposed
+./scripts/check_client_server_parity.sh  # Blocking: connector methods must be a tool or allowlisted (docs/guides/CLIENT_SERVER_PARITY.md)
 ./scripts/check_version_sync.sh        # Version consistency across files
 ```
 

--- a/docs/guides/CLIENT_SERVER_PARITY.md
+++ b/docs/guides/CLIENT_SERVER_PARITY.md
@@ -1,0 +1,60 @@
+# Client/Server Parity
+
+This project enforces that every **public** method on `AppleMailConnector` (in [`mail_connector.py`](../../src/apple_mail_mcp/mail_connector.py)) is either exposed as an MCP tool in [`server.py`](../../src/apple_mail_mcp/server.py) or explicitly marked intentionally-internal. The gate is [`scripts/check_client_server_parity.sh`](../../scripts/check_client_server_parity.sh), run as part of `make check-all` and in CI.
+
+## What it enforces
+
+The connector is the capability layer; the server is the MCP surface. When a new public connector method lands, it almost always should become a tool — otherwise the capability exists but no client can reach it. The gate catches the case where someone adds a public method and forgets to expose it.
+
+The script:
+
+1. Extracts public connector methods (`def <name>`, excluding `_private` and `__init__`).
+2. Extracts server tools (functions decorated with `@_tool(...)` or `@mcp.tool(...)`).
+3. Computes the methods present on the connector but **not** exposed as tools.
+4. Checks each against the **allowlist** of intentionally-internal methods.
+
+**The gate fails (`exit 1`) when:**
+
+- A public connector method is **neither** a tool **nor** in the allowlist (real parity drift), or
+- An allowlist entry is **stale** — the method is now exposed as a tool, or no longer exists (renamed/removed).
+
+Otherwise it prints `Parity OK: N intentionally-internal method(s), all allowlisted.` and exits 0.
+
+## The allowlist
+
+[`scripts/check_client_server_parity.sh`](../../scripts/check_client_server_parity.sh) carries an `ALLOWLIST` dict mapping each intentionally-internal method name to a one-line reason. It's a **shrinking ratchet**: when you expose a previously-internal method as a tool, remove its entry (the stale check enforces this).
+
+These methods are public on the connector but deliberately not tools — they're subsumed by a CRUD-style tool (per the [api-design](../../.claude/skills/api-design/SKILL.md) "no per-field tools" rule) or used only as internal helpers:
+
+| Method | Why it's internal |
+|---|---|
+| `mark_as_read` | Subsumed by `update_message(read_status=…)`. |
+| `move_messages` | Subsumed by `update_message(destination_mailbox=…)`. |
+| `flag_message` | Subsumed by `update_message(flagged=/flag_color=…)`. |
+| `set_rule_enabled` | Subsumed by `update_rule(enabled=…)`. |
+| `get_message` | Singular fetch; the tool is `get_messages` (plural). |
+| `get_attachments` | Attachment metadata; surfaced via `get_messages(include_attachments=True)`. |
+| `get_selected_messages` | Mail.app UI selection; surfaced via the read tools (#92), not standalone. |
+| `get_draft_state` | Reads a draft's current fields for `update_draft`'s merge. |
+| `find_message_by_message_id` | Internal RFC-id→Mail-id lookup (e.g. `update_draft` seed recovery). |
+| `extract_draft_attachments` | Helper for `update_draft`'s delete-and-recreate attachment preservation. |
+| `auto_template_vars` | Auto-fills template variables; used by the template/draft path, not standalone. |
+
+## Resolving a failure
+
+**"public connector method not exposed as a tool and not allowlisted":** you added a public method. Either —
+
+- **Expose it** — add an `@_tool({...})` function in `server.py` that calls it (the common case; also update `docs/reference/TOOLS.md`, the README tool count, and regenerate eval descriptions — the doc-drift gate enforces these), or
+- **Keep it internal** — add an entry to `ALLOWLIST` with a one-line reason and a row to the table above, in the same PR.
+
+If you can't write a one-sentence reason for keeping it internal, it probably should be a tool.
+
+**"stale ALLOWLIST entry":** you exposed or removed a method that's still allowlisted. Delete its `ALLOWLIST` entry (and table row).
+
+## Checking locally
+
+```bash
+./scripts/check_client_server_parity.sh
+```
+
+This mirrors the per-function allowlist mechanism documented in [COMPLEXITY.md](COMPLEXITY.md) — same "enforce, don't just warn; allowlist with reasons; ratchet down" philosophy (#277).

--- a/scripts/check_client_server_parity.sh
+++ b/scripts/check_client_server_parity.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# Verify every public method in mail_connector.py has a corresponding @mcp.tool() in server.py.
+# Verify every public method in mail_connector.py is either exposed as a
+# server tool (@_tool / @mcp.tool) OR listed in the intentionally-internal
+# ALLOWLIST below. A new public connector method that is neither fails the
+# gate (exit 1). See docs/guides/CLIENT_SERVER_PARITY.md.
 set -euo pipefail
 
 CONNECTOR="src/apple_mail_mcp/mail_connector.py"
@@ -22,24 +25,58 @@ SERVER_TOOLS=$(awk '
     }
 ' "$SERVER" | sort)
 
-echo ""
-echo "Connector public methods:"
-echo "$CONNECTOR_METHODS" | sed 's/^/  /'
-echo ""
-echo "Server tools:"
-echo "$SERVER_TOOLS" | sed 's/^/  /'
-echo ""
-
-# Find methods in connector but not in server
+# Find public connector methods not exposed as a server tool.
 MISSING=$(comm -23 <(echo "$CONNECTOR_METHODS") <(echo "$SERVER_TOOLS"))
 
-if [ -n "$MISSING" ]; then
-    echo "WARNING: Connector methods without @mcp.tool() wrapper:"
-    echo "$MISSING" | sed 's/^/  - /'
-    echo ""
-    echo "These may be intentional (internal helpers) or may need server exposure."
-    # Don't fail — some methods may be intentionally internal
-    exit 0
-else
-    echo "All connector methods have corresponding server tools."
-fi
+# Classify MISSING against the intentionally-internal allowlist. A public
+# method that is neither a tool nor allowlisted fails the gate; stale
+# allowlist entries (now exposed, or removed) also fail so the list stays a
+# shrinking, honest ratchet. Mirrors scripts/check_complexity.sh.
+echo "$MISSING" | python3 -c '
+import sys
+
+# Intentionally-internal connector methods: name -> reason. These are public
+# on the connector but deliberately NOT exposed as MCP tools (subsumed by a
+# CRUD-style tool, or used only as internal helpers). Adding a genuinely new
+# internal method? Add it here WITH a reason. Exposing one as a tool? Remove
+# its entry. See docs/guides/CLIENT_SERVER_PARITY.md.
+ALLOWLIST = {
+    "mark_as_read": "Subsumed by update_message(read_status=...).",
+    "move_messages": "Subsumed by update_message(destination_mailbox=...).",
+    "flag_message": "Subsumed by update_message(flagged=/flag_color=...).",
+    "set_rule_enabled": "Subsumed by update_rule(enabled=...).",
+    "get_message": "Singular fetch; the tool is get_messages (plural).",
+    "get_attachments": "Metadata surfaced via get_messages(include_attachments=True).",
+    "get_selected_messages": "Mail.app UI selection; surfaced via the read tools (#92), not standalone.",
+    "get_draft_state": "Reads a draft\x27s current fields for update_draft\x27s merge.",
+    "find_message_by_message_id": "Internal RFC-id->Mail-id lookup (e.g. update_draft seed recovery).",
+    "extract_draft_attachments": "Helper for update_draft delete-and-recreate attachment preservation.",
+    "auto_template_vars": "Auto-fills template variables; used by the template/draft path, not standalone.",
+}
+
+missing = {line.strip() for line in sys.stdin if line.strip()}
+unexpected = sorted(missing - ALLOWLIST.keys())
+stale = sorted(ALLOWLIST.keys() - missing)
+
+problems = False
+if unexpected:
+    problems = True
+    print("FAIL: public connector method(s) not exposed as a tool and not allowlisted:")
+    for m in unexpected:
+        print(f"  - {m}: add an @_tool wrapper in server.py, OR add it to "
+              f"ALLOWLIST (with a reason) in scripts/check_client_server_parity.sh")
+if stale:
+    problems = True
+    print("FAIL: stale ALLOWLIST entr(y/ies) — now exposed as a tool, or no "
+          "longer a public connector method:")
+    for m in stale:
+        print(f"  - {m}: remove it from ALLOWLIST in "
+              f"scripts/check_client_server_parity.sh")
+
+if problems:
+    print("")
+    print("See docs/guides/CLIENT_SERVER_PARITY.md.")
+    sys.exit(1)
+
+print(f"Parity OK: {len(missing)} intentionally-internal method(s), all allowlisted.")
+'


### PR DESCRIPTION
Closes #277.

## Problem
`scripts/check_client_server_parity.sh` listed public connector methods lacking a `@_tool`/`@mcp.tool` but **always `exit 0`** (warning-only) — so real parity drift (a new public connector method that should be a tool but isn't) was invisible in CI.

## Change
Mirror the complexity-gate pattern (`check_complexity.sh` + `COMPLEXITY.md`): add an explicit **allowlist of intentionally-internal methods (name → reason)** and make the gate **fail (`exit 1`)** on drift.

The script classifies the not-exposed set against the allowlist:
- **unexpected** — public method, not a tool, not allowlisted → `exit 1` (expose it as a tool, or allowlist it with a reason).
- **stale** — allowlisted but now exposed as a tool, or removed → `exit 1`, keeping the allowlist a shrinking, honest ratchet.

The existing bash extraction (connector methods / server tools / `comm`) is **unchanged** — only the warn→fail verdict is new (an inline `python3` block, like `check_complexity.sh`).

## Allowlist (11, all subsumed by a CRUD tool or internal helpers)
`mark_as_read`, `move_messages`, `flag_message`, `set_rule_enabled` (→ `update_message`/`update_rule`); `get_message`, `get_attachments`, `get_selected_messages` (→ the plural/`include_attachments` read tools); `get_draft_state`, `find_message_by_message_id`, `extract_draft_attachments` (draft-update helpers); `auto_template_vars` (template helper). Each carries a one-line reason in the script and the new guide.

Since all 11 are allowlisted, the gate **passes today** — #274 already made the gates blocking, so flipping this to blocking is no surprise to CI.

## Files
- **scripts/check_client_server_parity.sh** — `ALLOWLIST` + exit-1 verdict.
- **docs/guides/CLIENT_SERVER_PARITY.md** — new; mirrors `COMPLEXITY.md` (what it enforces, the allowlist, how to resolve a failure, the stale-entry rule).
- **.claude/CLAUDE.md** — note the gate is now blocking + link the guide.

## Verification
- **Positive:** `./scripts/check_client_server_parity.sh` → exit 0, `Parity OK: 11 intentionally-internal method(s), all allowlisted.`
- **Negative (unexpected):** dropping an allowlist entry → exit 1 naming it with the actionable hint.
- **Negative (stale):** adding a bogus entry → exit 1 flagging it stale.
- **Positive (real exposure):** the newly-added `get_attachment_content` (#250) is correctly seen as a tool (not in the internal set).
- `make check-all` → green end-to-end with the gate now blocking.

## Out of scope
No product code or new tools — CI gate + docs only. Bash method-extraction regexes left untouched (they already work in CI). No `make test` impact; bash gate scripts have no unit tests here (consistent with `check_complexity.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)