### PR TITLE
ci(#296): periodic dependency-advisory refresh + release-gate direct/transitive split

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -65,7 +65,7 @@ Run ALL checks (stop on failure):
 3. `./scripts/check_complexity.sh`
 4. `make test`
 5. `make test-e2e` — **mandatory** (requires `MAIL_TEST_MODE=true` + a test Mail.app account). CI excludes e2e, so this is the only gate that catches a stale e2e failure. A pre-existing failure on `main` is a **release-blocker**, not a known issue to ship around (#257).
-6. `./scripts/check_dependencies.sh`
+6. `./scripts/check_dependencies.sh` — hard-fails only on advisories in **direct** deps (`fastmcp`/`imapclient`); transitive advisories are warnings (exit 0), surfaced continuously off the release path by `.github/workflows/dependency-audit.yml` so they don't block a release (#296). A direct-dep advisory still blocks — bump the pin and re-run.
 7. `./scripts/check_applescript_safety.sh`
 8. `./scripts/check_docs.sh` — doc/artifact drift gate (tool-set coverage, removed-name, cross-refs, eval-description sync) (#288)
 

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,89 @@
+name: Dependency Audit
+
+# Weekly off-the-release-path advisory scan (#296). pip-audit checks published
+# advisories against our pinned versions, so it goes red over time on UNCHANGED
+# pins as new CVEs are disclosed. Discovering that at release time forces
+# last-minute bumps on the release branch (the v0.9.0 idna/starlette/urllib3
+# pain). This job surfaces advisories continuously into a tracking issue, so
+# bumps land on their own PRs with their own test cycle.
+
+on:
+  schedule:
+    # Mondays 09:17 UTC. Off-the-hour: GitHub delays cron jobs scheduled on
+    # the hour due to load.
+    - cron: "17 9 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: dependency-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_TITLE: "[deps] Dependency advisories detected"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - run: uv python install 3.10
+
+      - run: uv sync --dev
+
+      - name: Run pip-audit
+        id: audit
+        run: |
+          set +e
+          uv run pip-audit --format markdown > audit.md 2> audit.err
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          echo "----- pip-audit (markdown) -----"
+          cat audit.md
+          echo "----- pip-audit (stderr) -----"
+          cat audit.err
+
+      - name: Open or update tracking issue
+        if: steps.audit.outputs.exit != '0'
+        run: |
+          {
+            echo "Automated weekly \`pip-audit\` (#296) found known advisories against the current pins."
+            echo ""
+            echo "_Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} — updated $(date -u '+%Y-%m-%d %H:%M UTC')._"
+            echo ""
+            cat audit.md
+            echo ""
+            echo "---"
+            echo "Bump the affected dependencies on their own PR (not on a release branch). Direct-dep advisories also hard-block the release gate (\`scripts/check_dependencies.sh\`); transitive ones are warnings there."
+          } > issue-body.md
+
+          existing=$(gh issue list --state open --label dependencies \
+            --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #$existing"
+            gh issue edit "$existing" --body-file issue-body.md
+            gh issue comment "$existing" --body "Refreshed by the weekly dependency audit ($(date -u '+%Y-%m-%d'))."
+          else
+            echo "Creating new tracking issue"
+            gh issue create --title "$ISSUE_TITLE" \
+              --label dependencies --label security \
+              --body-file issue-body.md
+          fi
+
+      - name: Resolve tracking issue when clean
+        if: steps.audit.outputs.exit == '0'
+        run: |
+          existing=$(gh issue list --state open --label dependencies \
+            --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "No advisories; closing issue #$existing"
+            gh issue comment "$existing" --body "Resolved: \`pip-audit\` reports no known advisories as of $(date -u '+%Y-%m-%d %H:%M UTC') (run ${{ github.run_id }})."
+            gh issue close "$existing"
+          else
+            echo "No advisories and no open tracking issue — nothing to do."
+          fi

--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-# Check for known vulnerabilities in dependencies using pip-audit.
+# Check dependencies for known advisories with pip-audit (release gate).
+#
+# Direct-vs-transitive split (#296): this gate hard-fails (exit 1) ONLY on
+# advisories affecting our DIRECT runtime deps (pyproject [project].dependencies
+# — fastmcp, imapclient). Advisories in TRANSITIVE deps are printed as warnings
+# and DO NOT block (exit 0): a freshly-disclosed transitive CVE shouldn't force a
+# last-minute bump on a release branch. Transitive advisories are surfaced
+# continuously off the release path by the weekly .github/workflows/dependency-audit.yml
+# job, which opens/updates a tracking issue so they land on their own PRs.
 set -euo pipefail
 
 echo "Checking dependencies for vulnerabilities..."
@@ -7,12 +15,84 @@ echo "Checking dependencies for vulnerabilities..."
 # pip-audit is declared in pyproject.toml's dev dep group, so `uv sync --dev`
 # installs it into .venv. `uv run` resolves it from there — calling bare
 # `pip-audit` (or trying to install it ad-hoc) doesn't work because the
-# .venv bin isn't on the script-runtime PATH.
-uv run pip-audit 2>&1 || {
-    echo ""
-    echo "WARNING: Vulnerability scan found issues. Review and update dependencies."
-    exit 1
-}
+# .venv bin isn't on the script-runtime PATH. pip-audit exits non-zero when it
+# finds advisories; we drive the verdict from the JSON, so swallow that here.
+AUDIT_JSON=$(uv run pip-audit --format json 2>/dev/null) || true
 
-echo ""
-echo "No known vulnerabilities found."
+# Pass the JSON via the environment, not stdin: `python3 - <<'PY'` already uses
+# stdin for the program text, so a piped payload would be swallowed.
+AUDIT_JSON="$AUDIT_JSON" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+# Direct runtime deps = names declared in pyproject.toml [project].dependencies.
+# Parsed by regex (not tomllib) so this works on Python 3.10 too. Names are
+# normalized (lowercased, '_'->'-') to match pip-audit's reporting.
+def _norm(name):
+    return re.split(r"[<>=!~;\[\s]", name, 1)[0].strip().lower().replace("_", "-")
+
+direct = set()
+try:
+    pyproject = open("pyproject.toml", encoding="utf-8").read()
+    m = re.search(r"(?ms)^\[project\].*?^dependencies\s*=\s*\[(.*?)\]", pyproject)
+    if m:
+        for raw in re.findall(r'"([^"]+)"', m.group(1)):
+            n = _norm(raw)
+            if n:
+                direct.add(n)
+except OSError:
+    pass
+
+raw = os.environ.get("AUDIT_JSON", "").strip()
+if not raw:
+    # pip-audit produced no JSON (e.g. scanner/network failure). Fail closed —
+    # a release gate that can't actually scan must not silently pass.
+    print("ERROR: pip-audit produced no output; cannot assess advisories.")
+    sys.exit(1)
+
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    print("ERROR: could not parse pip-audit output:")
+    print(raw)
+    sys.exit(1)
+
+deps = data.get("dependencies", []) if isinstance(data, dict) else data
+
+direct_hits, transitive_hits = [], []
+for dep in deps:
+    vulns = dep.get("vulns") or []
+    if not vulns:
+        continue
+    name = _norm(dep.get("name", ""))
+    version = dep.get("version", "?")
+    for v in vulns:
+        vid = v.get("id", "?")
+        fixes = ", ".join(v.get("fix_versions") or []) or "no fix listed"
+        line = f"  {name} {version} — {vid} (fix: {fixes})"
+        (direct_hits if name in direct else transitive_hits).append(line)
+
+if transitive_hits:
+    print("")
+    print("WARNING: advisories in TRANSITIVE dependencies (not release-blocking):")
+    print("\n".join(transitive_hits))
+    print("")
+    print("  These are tracked off the release path by the weekly dependency-audit")
+    print("  workflow (see the open '[deps] Dependency advisories detected' issue).")
+
+if direct_hits:
+    print("")
+    print("FAIL: advisories in DIRECT dependencies (release-blocking):")
+    print("\n".join(direct_hits))
+    print("")
+    print("  Bump the affected direct dependency in pyproject.toml and re-run.")
+    sys.exit(1)
+
+if not transitive_hits:
+    print("")
+    print("No known vulnerabilities found.")
+else:
+    print("OK: no direct-dependency advisories (transitive warnings above).")
+PY


### PR DESCRIPTION
Closes #296.

## Problem
`scripts/check_dependencies.sh` (release gate) runs `pip-audit`, which checks **published advisories against our pinned versions** — so it goes red over time on **unchanged** pins as new CVEs are disclosed. At v0.9.0 it was red purely because `idna`/`starlette`/`urllib3` advisories landed after v0.8.2, forcing last-minute transitive bumps on the release branch. All three are **transitive** (via `fastmcp`); our only direct runtime deps are `fastmcp` + `imapclient`.

## Changes (scope: scheduled scan + gate split; Dependabot deferred)

### 1. `.github/workflows/dependency-audit.yml` (new) — discovery off the release path
Weekly `cron` (Mon 09:17 UTC, off-the-hour) + `workflow_dispatch`. Runs `pip-audit` and **idempotently opens/updates a single tracking issue** (`[deps] Dependency advisories detected`, labels `dependencies`+`security`) on findings; **closes it when clean**. Advisories now surface continuously and get bumped on their own PRs with their own test cycle — not mid-release. `permissions: issues: write`.

### 2. `scripts/check_dependencies.sh` — direct/transitive split
Classifies `pip-audit --format json` into **direct** (parsed from `pyproject` `[project].dependencies` → `fastmcp`, `imapclient`) vs **transitive**. **Hard-fails (exit 1) only on direct-dep advisories**; transitive advisories are warnings (exit 0), since the scheduled job keeps them current. **Fails closed** if the scanner emits no/invalid JSON. Direct-dep set parsed by regex (tomllib-free, 3.10-safe).

### 3. `release` skill Phase 9
Notes the gate now hard-fails only on direct deps; transitive advisories are warnings handled by the scheduled workflow.

## Verification
- **Real run:** `./scripts/check_dependencies.sh` → clean, exit 0.
- **Simulated classification:** direct hit (`fastmcp`) → exit 1; transitive-only (`idna`, the v0.9.0 case) → exit 0 + warning; malformed JSON → exit 1 (fail closed).
- **Workflow:** YAML parses; the `gh issue list --search 'in:title …'` idempotency lookup runs cleanly against the repo. True end-to-end is a post-merge `workflow_dispatch` (scheduled/issue-writing workflows can't run from a branch).
- `make check-all` green (the deps gate isn't part of `check-all`).

## Out of scope / notes
- **Dependabot** deferred to a follow-up (independent mechanism, PR noise, uv-lockfile maturity).
- **Unrelated pre-existing finding** (NOT touched here): `make audit`'s `check_readme_claims.sh` is red on `main` — its tool-count checks count bare `@mcp.tool()` and find 0 (the project uses the `@_tool()` wrapper since #217), and its test-count claim (CLAUDE.md "1249 unit") is stale (now 1349). Neither is in `check-all`/CI/release-Phase-9. Worth a small separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)