### PR TITLE
release: v0.10.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Mail via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.9.1 | **Tests:** 1349 unit / 29 e2e / 59 integration | **Coverage:** 92%
+**Version:** v0.10.0 | **Tests:** 1351 unit / 29 e2e / 59 integration | **Coverage:** 92%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-06-05
+
+First release under the new name **`apple-mail-fast-mcp`** (#335) — the PyPI distribution, CLI command, and repo were renamed, and publishing now goes through PyPI OIDC trusted publishing. Feature-wise the theme is **richer composition and inspection**: drafts can carry an HTML body, a new tool reads an attachment's content inline without writing to disk, and IMAP credentials can come from an environment variable for uvx/headless/CI contexts. Alongside: a confirmation-prompt fix for current FastMCP, and CI/release hardening so parity drift and dependency advisories can't slip through (or hard-block a release) unnoticed.
+
+> **Renaming note:** install as `apple-mail-fast-mcp` (e.g. `pip install apple-mail-fast-mcp` / `uvx apple-mail-fast-mcp`) and invoke the CLI as `apple-mail-fast-mcp`. The Python import package remains `apple_mail_mcp` for now, and Keychain entries remain under the `apple-mail-mcp.imap.<account>` prefix (a brand migration is tracked in #336/#337).
+
+### Added
+
+**HTML body support for `create_draft` / `update_draft` (#251):** a new optional `body_html` parameter builds a `multipart/alternative` draft (HTML + a plain-text alternative, derived from the HTML when no plain `body` is given) over the clean IMAP-APPEND path. Limited to fresh save-as-draft and requires IMAP credentials; combining it with `send_now` or reply/forward is rejected, and if the IMAP path can't engage the call fails (`html_requires_imap`) rather than silently downgrading to plain text. HTML is caller-trusted (not sanitized).
+
+**`get_attachment_content` tool (#250):** read a single attachment's content inline — UTF-8 text for text-like types (`text/*`, `application/json`, …) or base64 otherwise — without writing to disk, for triage workflows. 0-based `attachment_index` matching `get_attachments` / `get_messages(include_attachments=True)`; ~25 MB inline cap (override via `APPLE_MAIL_MCP_MAX_INLINE_ATTACHMENT_BYTES`), over which it returns `attachment_too_large` and points at `save_attachments`.
+
+**Environment-variable fallback for the IMAP password (#248):** `APPLE_MAIL_MCP_IMAP_PASSWORD_<ACCOUNT>` (account name uppercased, non-alphanumerics → `_`) supplies the IMAP password where the macOS Keychain isn't usable (uvx, Docker/CI, headless). Checked before the Keychain and composes with the name↔UUID dual-form lookup (#243). Env vars are less private than the Keychain — documented as uvx/CI-only.
+
+**Weekly dependency-advisory workflow (#296):** a scheduled CI job (`dependency-audit.yml`) runs `pip-audit` and opens/updates (and auto-closes) a tracking issue when advisories appear, so freshly-disclosed CVEs on unchanged pins are discovered continuously and bumped on their own PRs — not mid-release.
+
+### Changed
+
+**Confirmation prompts pass an explicit `response_type` to `ctx.elicit` (#282):** the destructive-action confirmation gate now uses a boolean `response_type` (clearing FastMCP ≥3.3.1's `FastMCPDeprecationWarning` and the empty-form rendering bug in some clients, e.g. VS Code). Only an explicit affirmative proceeds; decline, cancel, accept-with-false, missing context, and elicit errors all block (fail-closed).
+
+**`update_rule` confirmation is dangerous-action-aware (#280):** updating a rule only elicits confirmation when the change touches conditions/match-logic or introduces a destructive action (delete/forward/move/copy), mirroring `create_rule` (#222) — purely organizational tweaks no longer prompt.
+
+**Clean drafts adopt the sole enabled account + warn on fallback (#321, #270):** with no explicit `from_account`, a single enabled account is adopted so the clean (no iOS cite-blockquote) IMAP-APPEND draft path can engage; save-as-draft calls that fall back to the AppleScript path now surface a warning.
+
+**Release dependency gate split: direct vs transitive (#296):** `check_dependencies.sh` now hard-fails only on advisories in direct deps (`fastmcp`/`imapclient`); transitive advisories are warnings (handled by the scheduled workflow above), so a freshly-disclosed transitive CVE no longer hard-blocks an otherwise-ready release.
+
+**Client/server parity check is now blocking (#277):** `check_client_server_parity.sh` fails CI when a public connector method is neither exposed as a tool nor in an intentionally-internal allowlist (and on stale allowlist entries), instead of always passing.
+
+**Faster bulk IMAP id resolution (#316):** `update_message`'s RFC Message-ID→UID resolution now batches into a chunked `OR` SEARCH instead of per-id lookups (~6× faster bulk moves on the IMAP path).
+
+### Fixed
+
+**Drafts surface promptly after IMAP-APPEND (#269):** the account is synchronized after an IMAP-APPEND draft so it appears in Mail.app's local Drafts pane without waiting for Mail's background poll.
+
+**Stricter name / draft_id validation (#325):** the forbidden-character set is now enforced in the name and `draft_id` validators.
+
+**`check_readme_claims.sh` tool-count under the `@_tool` wrapper (#346):** the doc-claims check counted bare `@mcp.tool()` (always 0 since the `@_tool` wrapper, #217); it now counts the wrapper, and CLAUDE.md's test counts were refreshed.
+
+**Env-var IMAP password whitespace stripped (#349):** the `APPLE_MAIL_MCP_IMAP_PASSWORD_<ACCOUNT>` value is now stripped of surrounding whitespace, so a trailing newline from a `.env` file / Docker / `export` no longer breaks IMAP login (mirrors the Keychain path's behavior).
+
+**Reply/forward draft folder-miss no longer trips the IMAP circuit breaker (#350):** when the seed message isn't in the guessed `seed_mailbox` the call falls back to AppleScript (which resolves across all folders) without opening the 30s breaker, so a normal reply to filed mail no longer degrades subsequent IMAP reads for the account.
+
+### Docs
+
+**Issue-claiming convention for non-collaborators (#327):** corrected the contributing docs for how non-collaborators claim issues.
+
 ## [0.9.1] - 2026-06-03
 
 Patch release. The theme is **IMAP-path correctness and interop robustness**: several contributor-relevant crashes and login edge cases on the IMAP fast path are fixed (concurrent-mutation FETCH, iCloud login resolution, split connect/operation timeouts), tool parameters arriving as stringified JSON from clients like Cowork are now coerced, and reply/forward drafts no longer render with an iOS cite-blockquote wrapper. Alongside the fixes: a new warn-only prompt-injection detector on read responses, an automated doc/artifact drift gate wired into CI and the release flow, and test-suite hardening (Hypothesis property tests on the escape/sanitize boundary, plus a fix for the unit suite leaking to real `osascript`).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server that provides programmatic access to Apple Mail, enabling AI assistants like Claude to read, send, search, and manage emails on macOS.
 
-> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-fast-mcp==0.9.1`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
+> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-fast-mcp==0.10.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
 
 ## Tools (24)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-mail-fast-mcp"
-version = "0.9.1"
+version = "0.10.0"
 description = "MCP server for Apple Mail integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apple_mail_mcp/__init__.py
+++ b/src/apple_mail_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Mail MCP Server
 A Model Context Protocol server for Apple Mail integration.
 """
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"

--- a/src/apple_mail_mcp/keychain.py
+++ b/src/apple_mail_mcp/keychain.py
@@ -88,7 +88,11 @@ def get_imap_password(mail_app_account: str, email: str) -> str:
                 env_name,
                 mail_app_account,
             )
-            return env_pw
+            # Strip surrounding whitespace — .env files / Docker / `export`
+            # commonly append a trailing newline, and sending it as part of
+            # the password fails LOGIN. Mirrors the Keychain path's rstrip.
+            # (#349)
+            return env_pw.strip()
     service = SERVICE_NAME_PREFIX + mail_app_account
     try:
         result = subprocess.run(

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -860,6 +860,19 @@ class AppleMailConnector:
             )
             return
 
+        if isinstance(exc, MailMessageNotFoundError):
+            # A reply/forward seed not in the guessed seed_mailbox is a
+            # benign folder-guess miss — AppleScript resolves the seed across
+            # all folders. Opening the breaker would poison every IMAP read
+            # for the account for 30s after a normal reply-to-filed-mail.
+            # (#350)
+            logger.debug(
+                "Seed message not in the guessed mailbox for %s; using "
+                "AppleScript (which resolves across all folders)",
+                account,
+            )
+            return
+
         # Non-benign failure: open the breaker.
         self._imap_failure_until[account] = (
             time.monotonic() + self._IMAP_BREAKER_TTL_S

--- a/tests/unit/test_keychain.py
+++ b/tests/unit/test_keychain.py
@@ -294,10 +294,21 @@ class TestEnvVarFallback:
 
     @patch("apple_mail_mcp.keychain.subprocess.run")
     def test_env_var_preserves_internal_whitespace(self, mock_run, monkeypatch):
-        # A non-empty value with internal spaces is returned verbatim (the
-        # value isn't a name we normalize — it's the password).
+        # A non-empty value with internal spaces keeps them (only surrounding
+        # whitespace is stripped). The value is the password, not a name.
         monkeypatch.setenv(
             "APPLE_MAIL_MCP_IMAP_PASSWORD_ICLOUD", "pw with spaces"
         )
         assert get_imap_password("iCloud", "u@i.com") == "pw with spaces"
+        mock_run.assert_not_called()
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_env_var_trailing_newline_stripped(self, mock_run, monkeypatch):
+        # #349: .env files / Docker / `export` commonly append a trailing
+        # newline; it must not be sent as part of the password (mirrors the
+        # Keychain path's rstrip). Surrounding whitespace is stripped.
+        monkeypatch.setenv(
+            "APPLE_MAIL_MCP_IMAP_PASSWORD_ICLOUD", "  secret\n"
+        )
+        assert get_imap_password("iCloud", "u@i.com") == "secret"
         mock_run.assert_not_called()

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1199,6 +1199,20 @@ class TestAppleMailConnector:
         assert "iCloud" not in connector._imap_failure_until
         assert connector._imap_breaker_open("iCloud") is False
 
+    def test_breaker_does_not_open_for_message_not_found(
+        self, connector: AppleMailConnector
+    ) -> None:
+        """#350: a reply/forward seed not in the guessed seed_mailbox raises
+        MailMessageNotFoundError — a benign folder-guess miss (AppleScript
+        resolves across all folders), not a credential/network failure. It
+        must NOT open the breaker, or a normal reply-to-filed-mail would
+        poison every IMAP read for the account for 30s."""
+        connector._log_imap_fallback(
+            "iCloud", MailMessageNotFoundError("not in INBOX")
+        )
+        assert "iCloud" not in connector._imap_failure_until
+        assert connector._imap_breaker_open("iCloud") is False
+
     def test_breaker_resets_after_ttl(
         self, connector: AppleMailConnector,
         monkeypatch: pytest.MonkeyPatch,

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-fast-mcp"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
First release under the **`apple-mail-fast-mcp`** name (#335), published to PyPI via OIDC trusted publishing on the tag.

## Highlights (full list in [CHANGELOG](CHANGELOG.md))
- **Added:** HTML draft bodies `body_html` (#251); `get_attachment_content` inline read (#250); IMAP password env-var fallback (#248); weekly dependency-advisory workflow (#296).
- **Changed:** explicit `bool` `response_type` for `ctx.elicit` — clears FastMCP deprecation + broken-form bug (#282); dangerous-action-aware `update_rule` confirmation (#280); sole-account auto-resolve for clean drafts (#321/#270); release deps gate split direct(block)/transitive(warn) (#296); parity gate now blocking (#277); faster bulk IMAP id resolution (#316).
- **Fixed:** drafts surface after IMAP-APPEND (#269); stricter name/draft_id validation (#325); `check_readme_claims` tool-count (#346); **env-var password whitespace strip (#349)**; **reply/forward folder-miss no longer trips the IMAP breaker (#350)**.

Closes #349, #350 (found and fixed in this release's code review).

## Validation (Phase 9 — all green)
- `make check-all` (version-sync, parity, complexity, lint, mypy, unit tests, doc-drift) ✅
- `make test-e2e` — 29 passed ✅
- `make audit` — deps gate (transitive `pip` advisory → warning, non-blocking, per #296), AppleScript-safety, readme-claims ✅
- Coverage 92% ≥ 90 ✅

## Deferred (no release gate depends on these)
- **Phase 8.5 #2/#3 not refreshed:** the benchmark baseline (needs real Mail.app + `MAIL_TEST_ACCOUNT`) and the blind-eval scored snapshot (needs `OPENROUTER_API_KEY`) — internal quality snapshots, not shipped. Can be refreshed on this branch before merge, or as a follow-up.

## Known / tracked
- `pip` 26.1.1 advisory (PYSEC-2026-196) is transitive/toolchain (we don't pin pip; uv provisions it) — non-blocking, tracked by the new dependency-audit workflow (#348).
- Follow-ups filed: #341 (iCloud login resolution), #351 (Bcc in Drafts MIME), #352 (test-mode account gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)