### PR TITLE
chore(#355): refresh blind-eval snapshot for v0.10.0 + new-tool scenarios

### DIFF
--- a/evals/agent_tool_usability/results/scored_results.md
+++ b/evals/agent_tool_usability/results/scored_results.md
@@ -1,11 +1,11 @@
 # Blind Agent Eval Results
 
-**Date:** 2026-05-31
-**Scenarios:** 42 (3 under-specified / MANUAL: #32, #33, #34 → not scored)
-**Version:** v0.9.0 (23 tools — drafts lifecycle, templates, rule CRUD, IMAP fast paths)
+**Date:** 2026-06-07
+**Scenarios:** 45 (3 under-specified / MANUAL: #32, #33, #34 → not scored). Adds v0.10.0 coverage: #43/#44 `get_attachment_content` (#250), #45 HTML draft `body_html` (#251).
+**Version:** v0.10.0 (24 tools — adds `get_attachment_content` + HTML draft bodies on top of v0.9.x).
 **Runs:** Claude 1 run (Claude Code subagent, deterministic). OpenRouter models 5 runs each @ temperature=0.
 **Scoring:** PASS=2, PARTIAL=1, FAIL=0, MANUAL=not scored. Rule-based regex scorer
-(`score_response_regex`). Max per run over 39 scored scenarios = 78.
+(`score_response_regex`). Max per run over 42 scored scenarios = 84.
 **Context:** Models receive *only* the server instructions + tool descriptions
 (`tool_descriptions.md`, generated from the live FastMCP server — see `generate_descriptions.py`).
 
@@ -15,42 +15,53 @@ Score = points (PASS=2, PARTIAL=1, FAIL=0) ÷ max, with MANUAL scenarios exclude
 
 | Model | Score | % | PASS | PARTIAL | FAIL |
 |-------|-------|---|------|---------|------|
-| DeepSeek V3 0324 (5 runs) | 387/390 | 99.2% | 193 | 1 | 1 |
-| Claude Sonnet 4.6 (subagent, 1 run) | 76/78 | 97.4% | 38 | 0 | 1 |
-| Llama 3.3 70B Instruct (5 runs) | 371/390 | 95.1% | 179 | 13 | 3 |
-| Qwen 2.5 72B Instruct (5 runs) | 367/390 | 94.1% | 177 | 13 | 5 |
-| Mistral Large 2411 (5 runs) | 361/394 | 91.6% | 177 | 7 | 4 |
+| DeepSeek V3 0324 (5 runs) | 412/420 | 98.1% | 206 | 0 | 4 |
+| Claude Sonnet 4.6 (subagent, 1 run) | 81/84 | 96.4% | 40 | 1 | 1 |
+| Llama 3.3 70B Instruct (5 runs) | 401/420 | 95.5% | 194 | 13 | 3 |
+| Qwen 2.5 72B Instruct (5 runs) | 394/420 | 93.8% | 189 | 16 | 5 |
 
-All five models land **92–99%** — the v0.9.0 tool descriptions are clear enough for a blind,
-unbriefed model to pick the right tool in nearly every scenario.
+All models land **94–98%** on the v0.10.0 surface — blind, unbriefed models pick the right tool in
+nearly every scenario, including the two new features.
+
+> **Mistral Large 2411 excluded this cycle.** `mistralai/mistral-large-2411` now returns
+> `404 No endpoints found` on OpenRouter (the model was retired), so all 225 of its calls errored —
+> no scoreable data. The `make eval-tools` model list needs updating to a current Mistral id (or a
+> replacement); tracked as a follow-up.
 
 ## Key Findings
 
-**1. Descriptions ship clear.** Run blind (server instructions + tool descriptions only, no codebase
-access), every model selects the correct tool and critical parameters on ~9 of every 10 scenarios;
-DeepSeek and Claude are essentially perfect. The descriptions are now **generated from the live
-server** (`generate_descriptions.py` / `make eval-descriptions`) so they can't silently drift from
-the shipped surface again — the previous hand-maintained copy had rotted to ~9 of 23 tools.
+**1. The new v0.10.0 tools read clearly blind — the point of this refresh.** Across the three
+working open models + Claude, the new-tool scenarios score essentially perfectly:
+`get_attachment_content` (#43 "read inline, don't save"; #44 "summarize the PDF") and the HTML draft
+`body_html` (#45) are PASS on 5/5 runs for DeepSeek and Qwen and for Claude. Models correctly prefer
+`get_attachment_content` over `save_attachments` when the user doesn't want a disk copy, and set
+`body_html` (not plain `body`) with `send_now` left off for an HTML *draft*. The only new-tool miss
+is Llama on #44 (1 of 5 runs) — the indirect "summarize the PDF" framing, where it reached for a
+different read path once.
 
-**2. The one cross-model miss is scenario #3** ("which account has the most unread"): all models
-reach for `search_messages(read_status=false)` per account rather than reading `unread_count` from
-`list_mailboxes` (the cheaper, intended path — no message fetch). Both are workable; the divergence
-suggests `list_mailboxes`' `unread_count` field could be surfaced more prominently in its
-description. Not a tool-selection error so much as an efficiency one. (It's also stochastic — the
-open models pass it on most runs.)
+**2. Descriptions ship clear overall.** Run blind (server instructions + tool descriptions only, no
+codebase access), every model selects the correct tool and critical parameters on ~9–10 of every 10
+scenarios; DeepSeek and Claude are essentially perfect. Descriptions are generated from the live
+server (`make eval-descriptions`), so they can't silently drift from the shipped surface.
 
-**3. Sub-PASS is mostly parameter-formatting PARTIALs**, not tool-selection errors — Llama and Qwen
-(~13 PARTIAL over 5×42) and Mistral (7) occasionally format a parameter loosely. Tool *selection* is
-near-perfect across the board.
+**3. The one cross-model miss is scenario #3** ("which account has the most unread"): models reach
+for `search_messages(read_status=false)` per account rather than reading `unread_count` from
+`list_mailboxes` (the cheaper, intended path). Both work; the divergence suggests `list_mailboxes`'
+`unread_count` could be surfaced more prominently. An efficiency divergence, not a tool-selection
+error — and stochastic (open models pass it on most runs).
 
-**4. MANUAL (correct behavior):** #32 ("delete all my old emails"), #33 ("email John" — ambiguous
+**4. Sub-PASS is mostly parameter-formatting PARTIALs**, not tool-selection errors — Llama (13) and
+Qwen (16, over 5×42) occasionally format a parameter loosely. Tool *selection* is near-perfect.
+
+**5. MANUAL (correct behavior):** #32 ("delete all my old emails"), #33 ("email John" — ambiguous
 recipient), #34 ("archive everything") are under-specified; the right move is to ask for
 clarification, which the scorer treats as not-scored.
 
 ## Notes
-- Claude scored via Claude Code subagent (Sonnet 4.6), blind: given only the generated descriptions,
-  forbidden from reading the repo. OpenRouter models run at `temperature=0`, 5 runs each.
-- Raw `raw_*.json` dumps stay git-ignored; only this summary is committed.
+- Claude scored via Claude Code subagent (Sonnet 4.6), blind: given only the generated descriptions
+  + server instructions, forbidden from reading the repo. OpenRouter models run at `temperature=0`,
+  5 runs each.
+- Raw `raw_*.json` dumps stay untracked; only this summary is committed.
 - Re-run anytime: `make eval-descriptions` (refresh inputs) then `make eval-tools` (open-weight
   models via OpenRouter; needs the `apple-mail-mcp-evals` / `openrouter` Keychain key). The Claude
   column is produced separately via subagent.

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -908,4 +908,78 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+
+    # =========================================================================
+    # Category 10: Attachments / Compose (v0.10.0 — get_attachment_content #250,
+    # body_html #251)
+    # =========================================================================
+    {
+        "id": 43,
+        "category": "Attachments",
+        "name": "Read attachment content inline (don't save)",
+        "prompt": "Show me the text of the first attachment on message 12345 — I don't want a copy saved to disk.",
+        "expected": {
+            "tools": ["get_attachment_content"],
+            "key_params": {
+                "get_attachment_content": {
+                    "message_id": "12345",
+                    "attachment_index": 0,
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: Calls get_attachment_content with message_id='12345' and "
+            "attachment_index=0 (0-based first attachment). "
+            "PARTIAL: Correct tool but wrong/missing index, or omits message_id. "
+            "FAIL: Calls save_attachments (user explicitly said don't save to disk) "
+            "or get_messages (returns body/metadata, not attachment content)."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 44,
+        "category": "Attachments",
+        "name": "Summarize a PDF attachment",
+        "prompt": "Summarize the PDF attached to message 98765 for me.",
+        "expected": {
+            "tools": ["get_attachment_content"],
+            "key_params": {
+                "get_attachment_content": {"message_id": "98765"},
+            },
+        },
+        "scoring_notes": (
+            "PASS: Calls get_attachment_content (message_id='98765', an "
+            "attachment_index) to pull the content inline, then summarizes. "
+            "PARTIAL: Reads attachment metadata via get_messages "
+            "(include_attachments) first but still reaches get_attachment_content. "
+            "FAIL: Calls save_attachments (writes to disk, doesn't return content) "
+            "or claims it can't read attachments."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 45,
+        "category": "Compose",
+        "name": "Compose a formatted HTML draft",
+        "prompt": "Draft (don't send) a nicely formatted HTML email to team@example.com with subject 'Q2 numbers' that includes a small table of our quarterly revenue.",
+        "expected": {
+            "tools": ["create_draft"],
+            "key_params": {
+                "create_draft": {
+                    "to": ["team@example.com"],
+                    "subject": "Q2 numbers",
+                    "body_html": "<table",
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: Calls create_draft with to, subject, and body_html (HTML "
+            "markup, e.g. a <table>); does NOT set send_now (the user said draft, "
+            "and body_html is save-as-draft only). "
+            "PARTIAL: Puts the HTML in plain `body` instead of `body_html`, or also "
+            "sets send_now=True. "
+            "FAIL: Wrong tool, or refuses claiming HTML isn't supported."
+        ),
+        "safety_critical": False,
+    },
 ]


### PR DESCRIPTION
Closes #355. Deferred from the v0.10.0 release (Phase 8.5 #3). Adds blind scenarios for the new surface and re-runs the eval against the live 24-tool descriptions.

## Scenarios (`scenarios.py`) — +3 (now 45; 42 scored, max 84)
- **#43** `get_attachment_content` — "read the first attachment inline, don't save" (discriminates vs `save_attachments`)
- **#44** `get_attachment_content` — "summarize the PDF" (discriminates vs `get_messages`/`save_attachments`)
- **#45** `create_draft` `body_html` — formatted HTML *draft* (expects `body_html`, not `send_now`)

## Results (`scored_results.md`) — v0.10.0 / 24 tools
| Model | % | PASS | PARTIAL | FAIL |
|---|---|---|---|---|
| DeepSeek V3 0324 (5 runs) | 98.1% | 206 | 0 | 4 |
| Claude Sonnet 4.6 (subagent, 1 run) | 96.4% | 40 | 1 | 1 |
| Llama 3.3 70B (5 runs) | 95.5% | 194 | 13 | 3 |
| Qwen 2.5 72B (5 runs) | 93.8% | 189 | 16 | 5 |

**Headline:** the new-tool scenarios read clearly blind — #43/#44/#45 score **5/5 for DeepSeek, Qwen, and Claude**; Llama's only new-tool miss is 1/5 on #44's indirect "summarize" framing. The `#3 "most unread"` cross-model miss persists (efficiency divergence, not tool-selection).

## Mistral excluded (follow-up #358)
`mistralai/mistral-large-2411` now returns **404 "No endpoints found"** on OpenRouter (retired) — all 225 calls errored, no data. The `make eval-tools` model list needs a current id; tracked in #358.

## Verification
`make eval-descriptions` (in sync, 24 tools) → `make eval-tools` (4 models × 5 runs over 45 scenarios; raw dumps untracked). Claude row via a blind subagent given only the server instructions + tool descriptions, scored locally with the harness's `score_response_regex`. Only `scenarios.py` + `scored_results.md` are committed.

v0.10.1 milestone: this closes #355; #356 (process gate) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)