### PR TITLE
fix(#341): persist IMAP login override for iCloud third-party Apple IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ On first run, macOS will prompt for Automation access. Grant permission in:
    apple-mail-fast-mcp setup-imap --account iCloud
    ```
    Substitute the Mail.app account name exactly — whatever it's labeled in Mail.app (e.g. `iCloud`, `Gmail`, `"Yahoo!"`). The CLI:
-   - looks up the account's primary email from Mail.app (override with `--email`),
+   - looks up the account's primary email from Mail.app (override with `--email`, which is **persisted** so runtime uses the same login — see the iCloud quirk below),
    - prompts via `getpass` so the password never lands in shell history,
    - writes to Keychain at `apple-mail-mcp.imap.<account>` (idempotent — re-running with a new password updates the existing entry),
    - opens an IMAP connection and runs a real LOGIN to confirm the password works. On rejection it rolls back the Keychain entry so you can retry without leaving a broken item behind.
@@ -138,7 +138,7 @@ If IMAP is working, the call returns in ~1 second. If it logs a WARNING about fa
 
 **Known provider quirks.**
 
-- **iCloud:** the IMAP server accepts `@icloud.com` / `@me.com` aliases as LOGIN username, not the Apple ID email. The server (and `setup-imap`) reads `email addresses of account` from Mail.app for that reason.
+- **iCloud:** the IMAP server accepts `@icloud.com` / `@me.com` aliases as LOGIN username, not the Apple ID email. The server (and `setup-imap`) reads `email addresses of account` from Mail.app for that reason. If your iCloud Apple ID is a *third-party* address (e.g. a `@gmail.com` Apple ID) **and** Mail.app reports no `@icloud.com` address for the account, auto-detection can't find the right login — `setup-imap` will fail with a hint to re-run with `--email <your @icloud.com/@me.com address>`. That `--email` value is **persisted** (in `~/.apple_mail_mcp/imap_login_overrides.json`) so runtime resolution uses the same login (#341). It's a general override — use it for any account whose auto-detected IMAP login is wrong.
 - **Yahoo:** app passwords have been progressively deprecated; the option may not be available for all accounts. If Yahoo's account-security page doesn't show the option, IMAP setup isn't possible for that account and AppleScript is the only path.
 - **Gmail:** requires 2-Step Verification enabled. If your Google Workspace admin has disabled app passwords at the tenant level, IMAP setup isn't possible for that account.
 - **Gmail thread retrieval — All Mail visibility tradeoff.** `find_thread_members` (used internally by thread-aware queries) is fastest when `[Gmail]/All Mail` is exposed over IMAP — that path is ~5 round-trips, mailbox-count-independent. Many users hide All Mail (Gmail Settings → Forwarding and POP/IMAP → Folder size limits → "Do not show in IMAP") because it duplicates every message. When hidden, the connector falls back to a per-mailbox X-GM-THRID iteration (still ~6× faster than the universal BFS, but proportional to your label count — ~25s on a 92-label account). Expose All Mail if you want the headline speed; keep it hidden if you prefer the cleaner IMAP folder list.

--- a/src/apple_mail_mcp/cli.py
+++ b/src/apple_mail_mcp/cli.py
@@ -19,12 +19,14 @@ from .exceptions import (
     MailKeychainError,
 )
 from .imap_connector import ImapConnector
+from .imap_overrides import delete_login_override, set_login_override
 from .keychain import (
     delete_imap_password,
     get_imap_password,
     set_imap_password,
 )
 from .mail_connector import AppleMailConnector
+from .utils import is_apple_hosted_address, is_icloud_imap_host
 
 
 def _print_available_accounts(accounts: list[dict[str, object]]) -> None:
@@ -40,6 +42,27 @@ def _account_exists(
     accounts: list[dict[str, object]], requested_name: str
 ) -> bool:
     return any(acc.get("name") == requested_name for acc in accounts)
+
+
+def _maybe_print_icloud_login_hint(
+    cli_email: str | None, host: str, email: str
+) -> None:
+    """On an iCloud login failure, if no `--email` was given and the login
+    we tried isn't an Apple-hosted address, this is the classic #341 shape
+    (third-party Apple ID, no @icloud.com alias in Mail.app). Point the user
+    at the override path. No-op otherwise (incl. legitimate #201 custom-domain
+    accounts, whose login succeeds and never reaches here)."""
+    if (
+        not cli_email
+        and is_icloud_imap_host(host)
+        and not is_apple_hosted_address(email)
+    ):
+        print(
+            "  Hint: this looks like an iCloud account whose Apple ID is "
+            "a third-party email. Re-run with `--email <your "
+            "@icloud.com/@me.com address>` to set the correct IMAP login.",
+            file=sys.stderr,
+        )
 
 
 def run_setup_imap(
@@ -111,6 +134,9 @@ def run_setup_imap(
         except MailKeychainError as exc:
             print(f"ERROR: {exc}", file=sys.stderr)
             return 1
+        # Also drop any persisted login override (#341) so a re-setup starts
+        # from Mail.app's derived login rather than a stale override.
+        delete_login_override(account_name)
         print(f"Removed Keychain entry for {account_name!r} ({email}).")
         return 0
 
@@ -136,6 +162,11 @@ def run_setup_imap(
     print(
         f"Stored in Keychain as 'apple-mail-mcp.imap.{account_name}'."
     )
+    # Persist an explicit --email as a login override so runtime resolution
+    # (_resolve_imap_config) uses the same login this setup verifies — without
+    # it, runtime re-derives the login from Mail.app and ignores --email (#341).
+    if cli_email:
+        set_login_override(account_name, email)
 
     print(f"Testing IMAP connection to {host}:{port}...")
     imap = (imap_factory or ImapConnector)(host, port, email, password)
@@ -146,16 +177,19 @@ def run_setup_imap(
     except LoginError as exc:
         # Bad password — roll the entry back so the user can retry without
         # leaving a broken Keychain item that get_imap_password would
-        # happily return.
+        # happily return. Mirror the rollback for any override just written.
         try:
             delete_imap_password(account_name, email)
         except MailKeychainError:
             pass
+        if cli_email:
+            delete_login_override(account_name)
         print(
             f"ERROR: IMAP login was rejected ({exc}). The Keychain entry "
             "has been removed; please re-run with the correct password.",
             file=sys.stderr,
         )
+        _maybe_print_icloud_login_hint(cli_email, host, email)
         return 1
     except (OSError, IMAPClientError) as exc:
         # Network / protocol error. The password may be fine but we can't

--- a/src/apple_mail_mcp/imap_overrides.py
+++ b/src/apple_mail_mcp/imap_overrides.py
@@ -1,0 +1,99 @@
+"""Persisted per-account IMAP login overrides (#341).
+
+`_resolve_imap_config` derives the IMAP LOGIN username from Mail.app's
+account properties. For a few account shapes that derivation is wrong and
+can't be corrected from the properties alone — notably an iCloud account
+whose Apple ID is a third-party email (e.g. ``@gmail.com``) with no
+``@icloud.com`` alias in Mail.app's ``email addresses`` (#299's apple-alias
+rule has nothing to pick from). The login then fails with
+AUTHENTICATIONFAILED against ``*.mail.me.com``.
+
+This module persists an explicit ``account -> login email`` override the
+user supplies via ``setup-imap --email``, so runtime resolution honors the
+same login that setup verified. The override value is a non-secret email
+address (the password stays in the Keychain), so a small JSON file under
+``~/.apple_mail_mcp/`` is the right home — matching the templates/ and
+drafts/ stores.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+def _overrides_path() -> Path:
+    """Path to the overrides file, honoring ``APPLE_MAIL_MCP_HOME``.
+
+    Resolved at call time so env-var overrides and test-time monkeypatching
+    are honored (same convention as templates/drafts ``default_root``).
+    """
+    home_override = os.environ.get("APPLE_MAIL_MCP_HOME")
+    base = (
+        Path(home_override)
+        if home_override
+        else Path.home() / ".apple_mail_mcp"
+    )
+    return base / "imap_login_overrides.json"
+
+
+def _load() -> dict[str, str]:
+    """Load the override map. A missing, unreadable, or corrupt file yields
+    an empty map — overrides must never raise into the IMAP resolve path."""
+    path = _overrides_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    # Keep only str->str entries; ignore anything malformed.
+    return {
+        str(k): str(v)
+        for k, v in data.items()
+        if isinstance(k, str) and isinstance(v, str)
+    }
+
+
+def get_login_override(account: str) -> str | None:
+    """Return the persisted IMAP login email for ``account``, or ``None``.
+
+    Empty/whitespace-only stored values are treated as absent.
+    """
+    value = _load().get(account)
+    if value and value.strip():
+        return value.strip()
+    return None
+
+
+def set_login_override(account: str, email: str) -> None:
+    """Persist ``account -> email`` (the IMAP LOGIN username). Creates the
+    home directory and file if needed; merges with any existing entries."""
+    overrides = _load()
+    overrides[account] = email.strip()
+    path = _overrides_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(overrides, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def delete_login_override(account: str) -> None:
+    """Remove ``account``'s override if present. No-op when absent or when
+    the file doesn't exist."""
+    overrides = _load()
+    if account not in overrides:
+        return
+    del overrides[account]
+    path = _overrides_path()
+    if overrides:
+        path.write_text(
+            json.dumps(overrides, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    else:
+        # Last entry removed — drop the file so an empty store leaves no
+        # stray artifact.
+        path.unlink(missing_ok=True)

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -47,6 +47,7 @@ from .exceptions import (
     MailUnsupportedRuleActionError,
 )
 from .imap_connector import ImapConnectionPool, ImapConnector
+from .imap_overrides import get_login_override
 from .keychain import get_imap_password
 from .utils import (
     applescript_account_clause,
@@ -1617,6 +1618,11 @@ class AppleMailConnector:
             `user name` when none exists, which keeps the #201 custom-domain
             case correct).
 
+            An explicit per-account login override (``setup-imap --email``,
+            persisted via ``imap_overrides``) takes precedence over all of the
+            above — the escape hatch for accounts whose correct LOGIN can't be
+            derived from Mail.app's properties (#341).
+
         Raises:
             MailAccountNotFoundError: If the account doesn't exist.
         """
@@ -1659,6 +1665,15 @@ class AppleMailConnector:
             )
             if apple_alias:
                 email = apple_alias
+        # (#341) An explicit per-account login override (set via
+        # `setup-imap --email`) wins over everything Mail.app reports. It's
+        # the escape hatch for accounts whose correct IMAP LOGIN can't be
+        # derived from the account properties — e.g. an iCloud account with a
+        # third-party Apple ID and an empty `email addresses` list, where the
+        # #299 apple-alias rule has nothing to choose from.
+        override = get_login_override(account)
+        if override:
+            email = override
         return (
             host,
             cast(int, parsed.get("port") or 0),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -38,6 +38,13 @@ def _make_accounts() -> list[dict[str, Any]]:
     ]
 
 
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch) -> None:
+    """Point APPLE_MAIL_MCP_HOME at a temp dir so setup-imap's login-override
+    writes (#341) never touch the developer's real ~/.apple_mail_mcp."""
+    monkeypatch.setenv("APPLE_MAIL_MCP_HOME", str(tmp_path))
+
+
 @pytest.fixture
 def mock_connector() -> MagicMock:
     """Stand-in for AppleMailConnector — list_accounts + _resolve_imap_config."""
@@ -549,3 +556,133 @@ class TestServerMainDispatch:
 
         with pytest.raises(SystemExit):
             server_mod.main(["setup-imap"])
+
+
+# ---------------------------------------------------------------------------
+# Login override persistence (#341)
+# ---------------------------------------------------------------------------
+
+
+class TestLoginOverride:
+    """setup-imap --email must persist a login override so runtime
+    resolution uses the verified login (#341). Override writes are isolated
+    to a temp APPLE_MAIL_MCP_HOME by the autouse _isolate_home fixture."""
+
+    def test_email_persists_login_override_on_success(
+        self,
+        mock_connector: MagicMock,
+        mock_imap_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from apple_mail_mcp import cli as cli_mod
+        from apple_mail_mcp import imap_overrides
+
+        monkeypatch.setattr(cli_mod, "set_imap_password", lambda a, e, p: None)
+        # iCloud account whose Mail.app login resolves to a gmail address.
+        mock_connector._resolve_imap_config.return_value = (
+            "p42-imap.mail.me.com", 993, "someone@gmail.com",
+        )
+        rc = run_setup_imap(
+            account_name="iCloud",
+            cli_email="someone@icloud.com",
+            uninstall=False,
+            connector_factory=lambda: mock_connector,
+            getpass_fn=lambda prompt: "pw",
+            imap_factory=lambda *a, **k: mock_imap_client,
+        )
+        assert rc == 0
+        assert imap_overrides.get_login_override("iCloud") == "someone@icloud.com"
+
+    def test_no_email_does_not_persist_override(
+        self,
+        mock_connector: MagicMock,
+        mock_imap_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from apple_mail_mcp import cli as cli_mod
+        from apple_mail_mcp import imap_overrides
+
+        monkeypatch.setattr(cli_mod, "set_imap_password", lambda a, e, p: None)
+        rc = run_setup_imap(
+            account_name="iCloud",
+            cli_email=None,
+            uninstall=False,
+            connector_factory=lambda: mock_connector,
+            getpass_fn=lambda prompt: "pw",
+            imap_factory=lambda *a, **k: mock_imap_client,
+        )
+        assert rc == 0
+        assert imap_overrides.get_login_override("iCloud") is None
+
+    def test_uninstall_clears_override(
+        self,
+        mock_connector: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from apple_mail_mcp import cli as cli_mod
+        from apple_mail_mcp import imap_overrides
+
+        imap_overrides.set_login_override("iCloud", "someone@icloud.com")
+        monkeypatch.setattr(cli_mod, "delete_imap_password", lambda a, e: None)
+        rc = run_setup_imap(
+            account_name="iCloud",
+            cli_email=None,
+            uninstall=True,
+            connector_factory=lambda: mock_connector,
+        )
+        assert rc == 0
+        assert imap_overrides.get_login_override("iCloud") is None
+
+    def test_login_error_rolls_back_override(
+        self,
+        mock_connector: MagicMock,
+        mock_imap_client: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from apple_mail_mcp import cli as cli_mod
+        from apple_mail_mcp import imap_overrides
+
+        monkeypatch.setattr(cli_mod, "set_imap_password", lambda a, e, p: None)
+        monkeypatch.setattr(cli_mod, "delete_imap_password", lambda a, e: None)
+        mock_imap_client.search_messages.side_effect = LoginError("bad")
+        rc = run_setup_imap(
+            account_name="iCloud",
+            cli_email="someone@icloud.com",
+            uninstall=False,
+            connector_factory=lambda: mock_connector,
+            getpass_fn=lambda prompt: "wrong",
+            imap_factory=lambda *a, **k: mock_imap_client,
+        )
+        assert rc == 1
+        assert imap_overrides.get_login_override("iCloud") is None
+
+    def test_icloud_login_failure_hints_at_email_flag(
+        self,
+        mock_connector: MagicMock,
+        mock_imap_client: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The #341 shape: iCloud host, non-Apple login, no --email, login
+        rejected → the error suggests re-running with --email."""
+        from apple_mail_mcp import cli as cli_mod
+
+        monkeypatch.setattr(cli_mod, "set_imap_password", lambda a, e, p: None)
+        monkeypatch.setattr(cli_mod, "delete_imap_password", lambda a, e: None)
+        mock_connector._resolve_imap_config.return_value = (
+            "p42-imap.mail.me.com", 993, "someone@gmail.com",
+        )
+        mock_imap_client.search_messages.side_effect = LoginError(
+            "AUTHENTICATIONFAILED"
+        )
+        rc = run_setup_imap(
+            account_name="iCloud",
+            cli_email=None,
+            uninstall=False,
+            connector_factory=lambda: mock_connector,
+            getpass_fn=lambda prompt: "pw",
+            imap_factory=lambda *a, **k: mock_imap_client,
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "--email" in err and "icloud.com" in err.lower()

--- a/tests/unit/test_imap_overrides.py
+++ b/tests/unit/test_imap_overrides.py
@@ -1,0 +1,73 @@
+"""Unit tests for the persisted IMAP login overrides (#341)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from apple_mail_mcp import imap_overrides
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the store at a temp APPLE_MAIL_MCP_HOME for every test."""
+    monkeypatch.setenv("APPLE_MAIL_MCP_HOME", str(tmp_path))
+    return tmp_path
+
+
+class TestImapOverrides:
+    def test_home_env_honored(self, _home: Path) -> None:
+        assert imap_overrides._overrides_path() == (
+            _home / "imap_login_overrides.json"
+        )
+
+    def test_missing_file_returns_none(self) -> None:
+        assert imap_overrides.get_login_override("iCloud") is None
+
+    def test_set_get_roundtrip(self, _home: Path) -> None:
+        imap_overrides.set_login_override("iCloud", "me@icloud.com")
+        assert imap_overrides.get_login_override("iCloud") == "me@icloud.com"
+        # Persisted as JSON on disk.
+        data = json.loads(
+            (_home / "imap_login_overrides.json").read_text()
+        )
+        assert data == {"iCloud": "me@icloud.com"}
+
+    def test_set_strips_whitespace(self) -> None:
+        imap_overrides.set_login_override("iCloud", "  me@icloud.com\n")
+        assert imap_overrides.get_login_override("iCloud") == "me@icloud.com"
+
+    def test_set_merges_multiple_accounts(self) -> None:
+        imap_overrides.set_login_override("iCloud", "me@icloud.com")
+        imap_overrides.set_login_override("Work", "me@work.example")
+        assert imap_overrides.get_login_override("iCloud") == "me@icloud.com"
+        assert imap_overrides.get_login_override("Work") == "me@work.example"
+
+    def test_delete_removes_entry(self) -> None:
+        imap_overrides.set_login_override("iCloud", "me@icloud.com")
+        imap_overrides.set_login_override("Work", "me@work.example")
+        imap_overrides.delete_login_override("iCloud")
+        assert imap_overrides.get_login_override("iCloud") is None
+        assert imap_overrides.get_login_override("Work") == "me@work.example"
+
+    def test_delete_last_entry_removes_file(self, _home: Path) -> None:
+        imap_overrides.set_login_override("iCloud", "me@icloud.com")
+        imap_overrides.delete_login_override("iCloud")
+        assert not (_home / "imap_login_overrides.json").exists()
+
+    def test_delete_missing_is_noop(self) -> None:
+        imap_overrides.delete_login_override("Nope")  # must not raise
+
+    def test_corrupt_file_returns_none(self, _home: Path) -> None:
+        (_home / "imap_login_overrides.json").write_text("{not json")
+        assert imap_overrides.get_login_override("iCloud") is None
+
+    def test_non_dict_json_returns_none(self, _home: Path) -> None:
+        (_home / "imap_login_overrides.json").write_text("[1, 2, 3]")
+        assert imap_overrides.get_login_override("iCloud") is None
+
+    def test_empty_value_treated_as_absent(self, _home: Path) -> None:
+        (_home / "imap_login_overrides.json").write_text('{"iCloud": "  "}')
+        assert imap_overrides.get_login_override("iCloud") is None

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -977,6 +977,32 @@ class TestAppleMailConnector:
         assert result == ("imap.mail.me.com", 993, "apple-id@example.com")
 
     @patch.object(AppleMailConnector, "_run_applescript")
+    def test_resolve_imap_config_login_override_wins(
+        self,
+        mock_run: MagicMock,
+        connector: AppleMailConnector,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """#341: a persisted login override (setup-imap --email) wins over the
+        Mail.app-derived login — the fix for an iCloud account with a
+        third-party Apple ID and an empty `email addresses` list, where #299's
+        apple-alias rule has nothing to choose from."""
+        from apple_mail_mcp import imap_overrides
+
+        monkeypatch.setenv("APPLE_MAIL_MCP_HOME", str(tmp_path))
+        imap_overrides.set_login_override("iCloud", "s.morgan@icloud.com")
+        # The unresolvable shape: me.com host, gmail user_name, no aliases.
+        mock_run.return_value = (
+            '{"host":"p42-imap.mail.me.com",'
+            '"port":993,'
+            '"user_name":"s.morgan@gmail.com",'
+            '"email_addresses":[]}'
+        )
+        result = connector._resolve_imap_config("iCloud")
+        assert result == ("p42-imap.mail.me.com", 993, "s.morgan@icloud.com")
+
+    @patch.object(AppleMailConnector, "_run_applescript")
     def test_resolve_imap_config_non_icloud_host_not_overridden(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:


### PR DESCRIPTION
Closes #341.

## Problem
`_resolve_imap_config` derives the IMAP LOGIN from Mail.app's account properties. For an iCloud account whose Apple ID is a **third-party email** (e.g. `@gmail.com`) **and** whose Mail.app `email addresses` is **empty**, #299's apple-alias rule has nothing to pick — so it returns the Gmail address against `*.mail.me.com` → `AUTHENTICATIONFAILED`, and the IMAP fast path is unusable for that account. `setup-imap --email` could fix the login at *setup* time, but runtime re-derived it from Mail.app and **ignored the override** (the issue's core finding).

## Fix — persist the override (issue's option 1) + actionable hint (option 3)
- **`imap_overrides.py` (new):** a small `account → login email` JSON store under `~/.apple_mail_mcp/imap_login_overrides.json` (honors `APPLE_MAIL_MCP_HOME`; missing/corrupt file → no overrides, never raises).
- **`_resolve_imap_config`:** an override (when present) wins over all Mail.app-derived values — the escape hatch for any account whose correct LOGIN can't be derived from its properties.
- **`setup-imap`:** persists `--email` on success; rolls it back on `LoginError` and clears it on `--uninstall`; and on an iCloud login failure with a non-Apple login and no `--email`, prints a hint to re-run with `--email`. The hint only fires on **actual failure**, so legitimate #201 custom-domain accounts (whose non-Apple login *succeeds*) are never nagged.
- **README:** documents `--email` persistence + the iCloud quirk.

## Tests
- `test_imap_overrides.py` (new): set/get/delete, missing/corrupt/non-dict file, empty-value, `APPLE_MAIL_MCP_HOME` honored.
- `_resolve_imap_config`: override wins on the gmail/empty-`email addresses` shape; **existing #299/#201 tests unchanged** (no-override behavior preserved).
- `cli`: `--email` persists; `--uninstall` clears; `LoginError` rolls back the override; iCloud failure prints the `--email` hint. Added an autouse fixture pointing `APPLE_MAIL_MCP_HOME` at a tmp dir so override writes never touch the real home.

## Verification
- `make test` — 1368 passed. `make check-all` — lint, mypy, complexity (extracted an iCloud-hint helper to keep `run_setup_imap` ≤ CC 20), parity, doc-drift all green.
- **Manual (you):** `uv run apple-mail-fast-mcp setup-imap --account iCloud --email <your @icloud.com address>` (iCloud app password), then confirm `search_messages(account="iCloud", …)` uses the IMAP fast path (no AUTHENTICATIONFAILED). Needs your iCloud app password.

## Out of scope
Auto-synthesizing the `@icloud.com` local-part (unknowable). Overrides are keyed by the account string given at setup — addressing the same account by UUID at runtime won't match the name-keyed override (documented edge; common path passes the name).

v0.10.1 milestone: closes #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)