### PR TITLE
ci(#356): release-artifact freshness gate (no more silent Phase 8.5 skips)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -58,6 +58,13 @@ release commit so a stale snapshot can't ship:
 3. Re-run the blind agent eval (#219) and refresh its scored snapshot (needs
    `OPENROUTER_API_KEY`); commit.
 
+Steps 2 and 3 are **enforced** by `./scripts/check_release_artifacts.sh` (Phase 9):
+the benchmark baseline and the eval snapshot are version-stamped, and the gate
+fails the release if a stamp is stale. If an artifact genuinely can't be
+refreshed for this release (e.g. a CI/docs-only release), don't skip silently —
+record a waiver line (with a tracking issue) in `release_artifact_waivers.txt`.
+See [docs/guides/RELEASE_ARTIFACTS.md](../../../docs/guides/RELEASE_ARTIFACTS.md). (#356)
+
 ## Phase 9: Validation
 Run ALL checks (stop on failure):
 1. `./scripts/check_version_sync.sh`
@@ -68,6 +75,7 @@ Run ALL checks (stop on failure):
 6. `./scripts/check_dependencies.sh` — hard-fails only on advisories in **direct** deps (`fastmcp`/`imapclient`); transitive advisories are warnings (exit 0), surfaced continuously off the release path by `.github/workflows/dependency-audit.yml` so they don't block a release (#296). A direct-dep advisory still blocks — bump the pin and re-run.
 7. `./scripts/check_applescript_safety.sh`
 8. `./scripts/check_docs.sh` — doc/artifact drift gate (tool-set coverage, removed-name, cross-refs, eval-description sync) (#288)
+9. `./scripts/check_release_artifacts.sh` — fails if the benchmark baseline or eval snapshot isn't version-stamped for this release (Phase 8.5 #2/#3) and isn't waived in `release_artifact_waivers.txt` (#356)
 
 ## Phase 10: Commit, Push, PR
 - Commit: `"release: vX.Y.Z"`

--- a/docs/guides/RELEASE_ARTIFACTS.md
+++ b/docs/guides/RELEASE_ARTIFACTS.md
@@ -1,0 +1,44 @@
+# Release Artifacts
+
+This project ships two **derived artifacts** that must be refreshed each release (Phase 8.5 of the [release skill](../../.claude/skills/release/SKILL.md), #288) but can't be regenerated in CI — they need resources the release driver may not have:
+
+| Artifact | Needs | Refresh |
+|---|---|---|
+| `tests/benchmarks/baseline.json` | a real Mail.app account (`MAIL_TEST_ACCOUNT`) | `make benchmark-baseline` |
+| `evals/agent_tool_usability/results/scored_results.md` | an `OPENROUTER_API_KEY` | `make eval-tools` (+ refresh the Claude row) |
+
+Because they're resource-gated, they're easy to defer "just this once" — and at v0.10.0 they were, silently: the eval snapshot shipped stamped `v0.9.0`, and the benchmark baseline predated the release. [`scripts/check_release_artifacts.sh`](../../scripts/check_release_artifacts.sh) (#356) closes that gap.
+
+## The gate
+
+Each artifact carries the **release version it was produced for**:
+
+- `baseline.json` — a `"_version"` key, written by `--capture-baseline` (from `apple_mail_mcp.__version__`).
+- `scored_results.md` — its `**Version:** vX.Y.Z` line (hand-authored when the snapshot is written).
+
+`check_release_artifacts.sh` (run in release Phase 9; `./scripts/check_release_artifacts.sh [version]`, default version from `pyproject.toml`) **fails** when a stamp doesn't match the release being cut — so a stale artifact can't ship unnoticed.
+
+## Resolving a failure
+
+When the gate flags a stale artifact, do one of:
+
+1. **Refresh it** — run the command above and commit the result (this re-stamps it). The normal path.
+2. **Re-stamp** — if it's genuinely unchanged for this release (re-running would reproduce the same numbers/scores), re-run the capture, or update `scored_results.md`'s `**Version:**` line, asserting it still represents the release.
+3. **Waive** — if it genuinely can't be refreshed for this release (e.g. a CI/docs-only release with no perf or tool-surface change), add a line to [`release_artifact_waivers.txt`](../../release_artifact_waivers.txt):
+   ```
+   v<version> <benchmark|eval> #<issue> <reason>
+   ```
+   The `#<issue>` is required — a waiver records a *deliberate, tracked* skip, never a silent one. Prune old entries freely.
+
+If you can't justify a waiver with a one-line reason and an issue, the artifact probably should be refreshed.
+
+## Why a gate (vs. a checklist)
+
+Phase 8.5 was already marked "mandatory", but only `eval-descriptions` (#1) was enforced (by `check_docs.sh`); the benchmark baseline and eval snapshot had no freshness check, so the "mandatory" step quietly became optional. A warning that's ignored is how the v0.10.0 snapshot went stale — hence a hard gate with an explicit, tracked waiver rather than another advisory note. Same philosophy as the complexity and client/server-parity gates ([COMPLEXITY.md](COMPLEXITY.md), [CLIENT_SERVER_PARITY.md](CLIENT_SERVER_PARITY.md)).
+
+## Checking locally
+
+```bash
+./scripts/check_release_artifacts.sh          # against pyproject's version
+./scripts/check_release_artifacts.sh 0.11.0   # against an explicit version
+```

--- a/release_artifact_waivers.txt
+++ b/release_artifact_waivers.txt
@@ -1,0 +1,15 @@
+# Release-artifact waivers (#356) — read by scripts/check_release_artifacts.sh.
+#
+# The release gate fails when a version-stamped derived artifact (the benchmark
+# baseline or the blind-eval snapshot) isn't stamped for the release being cut.
+# If an artifact genuinely can't be refreshed for a release (e.g. a CI/docs-only
+# release with no perf or tool-surface change), record a waiver here instead of
+# refreshing — so the skip is deliberate and tracked, never silent.
+#
+# Format (one per waived artifact):
+#   v<version> <benchmark|eval> #<issue> <reason>
+# Example:
+#   v0.10.2 benchmark #999 CI-only release; no perf-relevant change
+#
+# Entries are per-release; prune old ones freely. See
+# docs/guides/RELEASE_ARTIFACTS.md.

--- a/scripts/check_release_artifacts.sh
+++ b/scripts/check_release_artifacts.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Release-artifact freshness gate (#356).
+#
+# Phase 8.5 of the release refreshes derived artifacts that need real resources
+# (a Mail.app account for the benchmark baseline; an OpenRouter key for the
+# blind-eval snapshot). Those steps used to be skippable silently — at v0.10.0
+# the eval snapshot shipped stamped "v0.9.0". This gate makes a skip impossible
+# to do silently: each artifact carries the release version it was produced for,
+# and this check FAILS when that stamp doesn't match the release being cut —
+# unless an explicit waiver (with a tracking issue) is recorded.
+#
+# Resolutions when this fails:
+#   1. Refresh the artifact (`make benchmark-baseline` / `make eval-tools`), OR
+#   2. If it's genuinely unchanged for this release, re-stamp it (re-run the
+#      capture, or update scored_results.md's `**Version:**` line), OR
+#   3. Waive: add a line to release_artifact_waivers.txt naming the release,
+#      the artifact, and a tracking issue. See docs/guides/RELEASE_ARTIFACTS.md.
+set -euo pipefail
+
+# Release version: explicit arg, else pyproject.toml (authoritative).
+if [ "$#" -ge 1 ]; then
+    VERSION="$1"
+else
+    VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+fi
+if [ -z "$VERSION" ]; then
+    echo "ERROR: could not determine the release version."
+    exit 1
+fi
+
+echo "Checking release artifacts are stamped for v$VERSION..."
+
+VERSION="$VERSION" python3 - <<'PY'
+from __future__ import annotations  # 3.9-safe: keep `X | None` annotations lazy
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+version = os.environ["VERSION"]
+waivers_path = Path("release_artifact_waivers.txt")
+
+# Parse waivers: lines `v<version> <artifact> #<issue> <reason>`. A matching
+# (version, artifact) line lets a stale artifact pass with a warning.
+waived: set[tuple[str, str]] = set()
+if waivers_path.exists():
+    for line in waivers_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) >= 3 and parts[0].startswith("v") and "#" in parts[2]:
+            waived.add((parts[0].lstrip("v"), parts[1]))
+
+
+def baseline_version() -> str | None:
+    try:
+        data = json.loads(
+            Path("tests/benchmarks/baseline.json").read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError):
+        return None
+    v = data.get("_version") if isinstance(data, dict) else None
+    return str(v) if v else None
+
+
+def eval_version() -> str | None:
+    try:
+        text = Path(
+            "evals/agent_tool_usability/results/scored_results.md"
+        ).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = re.search(r"(?m)^\*\*Version:\*\*\s*v?([0-9]+\.[0-9]+\.[0-9]+)", text)
+    return m.group(1) if m else None
+
+
+# (artifact key, human label, found stamp, refresh command)
+checks = [
+    ("benchmark", "tests/benchmarks/baseline.json",
+     baseline_version(), "make benchmark-baseline"),
+    ("eval", "evals/agent_tool_usability/results/scored_results.md",
+     eval_version(), "make eval-tools (+ refresh the Claude row)"),
+]
+
+problems = False
+for key, path, found, refresh in checks:
+    if found == version:
+        print(f"  OK: {path} stamped for v{version}.")
+    elif (version, key) in waived:
+        print(
+            f"  WAIVED: {path} is stamped {found!r} (expected v{version}) "
+            f"but waived for this release in release_artifact_waivers.txt."
+        )
+    else:
+        problems = True
+        print(
+            f"  STALE: {path} is stamped {found!r}, expected v{version}.\n"
+            f"         Refresh it (`{refresh}`), or record a waiver line\n"
+            f"         `v{version} {key} #<issue> <reason>` in "
+            f"release_artifact_waivers.txt."
+        )
+
+if problems:
+    print("")
+    print("FAIL: one or more release artifacts are stale and unwaived.")
+    print("See docs/guides/RELEASE_ARTIFACTS.md.")
+    sys.exit(1)
+
+print(f"Release artifacts OK for v{version}.")
+PY

--- a/tests/benchmarks/baseline.json
+++ b/tests/benchmarks/baseline.json
@@ -1,4 +1,5 @@
 {
+  "_version": "0.10.0",
   "imap_repeat_5_calls_no_pool": 8.075,
   "imap_repeat_5_calls_pooled": 5.234,
   "mark_as_read_50_msgs": 1.426,

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -27,6 +27,7 @@ from typing import Any
 
 import pytest
 
+from apple_mail_mcp import __version__
 from apple_mail_mcp.exceptions import MailAppleScriptError
 from apple_mail_mcp.mail_connector import AppleMailConnector
 
@@ -129,22 +130,25 @@ def measure_median(
 # Baseline I/O + assertion
 # ---------------------------------------------------------------------------
 
-def _load_baselines() -> dict[str, float]:
+# baseline.json holds benchmark name -> median seconds (float), plus a
+# `_version` string stamp recording the release the timings were captured for
+# (the release-artifact gate, #356, checks it). Hence dict[str, Any].
+def _load_baselines() -> dict[str, Any]:
     if not BASELINE_PATH.exists():
         return {}
     with BASELINE_PATH.open() as f:
         return json.load(f)
 
 
-def _save_baselines(baselines: dict[str, float]) -> None:
+def _save_baselines(baselines: dict[str, Any]) -> None:
     BASELINE_PATH.write_text(
         json.dumps(baselines, indent=2, sort_keys=True) + "\n"
     )
 
 
 @pytest.fixture(scope="session")
-def baselines() -> dict[str, float]:
-    """Loaded baseline timings, keyed by benchmark name."""
+def baselines() -> dict[str, Any]:
+    """Loaded baseline timings, keyed by benchmark name (plus `_version`)."""
     return _load_baselines()
 
 
@@ -162,7 +166,7 @@ def capture_mode(request: pytest.FixtureRequest) -> bool:
 def assert_within_baseline(
     name: str,
     result: BenchmarkResult,
-    baselines: dict[str, float],
+    baselines: dict[str, Any],
     capture_mode: bool,
     *,
     ratio: float = REGRESSION_RATIO,
@@ -198,10 +202,13 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     # bulk_ops baselines).
     merged = _load_baselines()
     merged.update(_captured)
+    # Stamp the release this baseline was captured for, so the release-artifact
+    # gate (#356) can tell a fresh baseline from a stale one.
+    merged["_version"] = __version__
     _save_baselines(merged)
     print(
-        f"\nbaseline.json updated with {len(_captured)} entries: "
-        f"{sorted(_captured.keys())}"
+        f"\nbaseline.json updated with {len(_captured)} entries "
+        f"(_version={__version__}): {sorted(_captured.keys())}"
     )
 
 


### PR DESCRIPTION
Closes #356.

## Problem
Phase 8.5 of the release marks the **benchmark baseline** and **blind-eval snapshot** refresh "mandatory" (#288), but only `eval-descriptions` was actually enforced (`check_docs.sh`). The other two need real resources (Mail.app account; OpenRouter key) the release driver may not have, so at v0.10.0 they were deferred **silently** — the eval snapshot even shipped stamped `v0.9.0`. Nothing caught it.

## Fix — a version-stamp gate (Phase-9 script enforcement, per your call)
Each derived artifact carries the release version it was produced for; a gate fails the release when a stamp is stale, with a **recorded-waiver** escape hatch for the legitimate "can't refresh this release" case (so a skip is deliberate + tracked, never silent).

- **`baseline.json`** gets a `"_version"` stamp, written by `--capture-baseline` (`conftest.py`, from `apple_mail_mcp.__version__`); the current file is hand-stamped `0.10.0` (#354 captured it then). Compare-mode is unaffected (it only looks baselines up by name). `scored_results.md` already carries its `**Version:**` line.
- **`scripts/check_release_artifacts.sh`** — fails when an artifact's stamp ≠ the release version (from `pyproject`, or an explicit arg), printing the refresh command — unless a line `v<version> <benchmark|eval> #<issue> <reason>` exists in **`release_artifact_waivers.txt`**. The `#<issue>` is required.
- Wired into the release skill **Phase 9** (step 9) + a **Phase 8.5** note; new **`docs/guides/RELEASE_ARTIFACTS.md`** (mirrors the COMPLEXITY / parity guides).

## Verification
- **Positive:** `./scripts/check_release_artifacts.sh` (v0.10.0) → both stamps match → pass.
- **Stale:** `./scripts/check_release_artifacts.sh 0.11.0` → both stale → exit 1 with refresh commands + waiver hint.
- **Waiver:** add `v0.11.0 benchmark #354` / `v0.11.0 eval #355` → pass with WARNINGs.
- Benchmark collection still works (`_version` ignored by compare-mode); `make test` 1368 passed; `make check-all` green. The gate is **release-only** (not in `check-all`), like `check_dependencies.sh`.

## Notes
- No CI job (your choice). Could later be added as a release-PR CI check if desired — noted, not built.
- Makes per-release artifact refresh the default; a no-op (CI/docs-only) release records a one-line waiver instead of re-running a Mail.app/OpenRouter job.

This is the root-cause fix for why #354/#355 existed. v0.10.1 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)