### PR TITLE
fix(#358): track latest model per family, record what served, fail loud on retired ids

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,15 @@ eval-descriptions:
 # models (needs an OPENROUTER_API_KEY env var or the apple-mail-mcp-evals /
 # openrouter Keychain entry; costs money). The Claude column is produced
 # separately via a Claude Code subagent. See evals/agent_tool_usability/. (#219)
+#
+# Models use each family's latest non-dated slug where one exists
+# (mistralai/mistral-large, deepseek/deepseek-chat), so the eval tracks the
+# current model instead of pinning a dated id that later 404s (#358). The exact
+# version served is recorded per-result as `resolved_model`, and run_eval
+# pre-checks availability (fails loud before spending credits). qwen-2.5-72b /
+# llama-3.3-70b have no non-dated alias, so their line slug is used as-is.
 eval-tools:
 	uv run --with openai python evals/agent_tool_usability/run_eval.py \
-		--model mistralai/mistral-large-2411 qwen/qwen-2.5-72b-instruct \
-		meta-llama/llama-3.3-70b-instruct deepseek/deepseek-chat-v3-0324 \
+		--model mistralai/mistral-large qwen/qwen-2.5-72b-instruct \
+		meta-llama/llama-3.3-70b-instruct deepseek/deepseek-chat \
 		--runs 5

--- a/evals/agent_tool_usability/results/scored_results.md
+++ b/evals/agent_tool_usability/results/scored_results.md
@@ -65,3 +65,8 @@ clarification, which the scorer treats as not-scored.
 - Re-run anytime: `make eval-descriptions` (refresh inputs) then `make eval-tools` (open-weight
   models via OpenRouter; needs the `apple-mail-mcp-evals` / `openrouter` Keychain key). The Claude
   column is produced separately via subagent.
+- The model list now uses each family's latest/non-dated slug where one exists (`mistralai/mistral-large`,
+  `deepseek/deepseek-chat`) and records the exact version served per result as `resolved_model`;
+  `run_eval` also pre-checks availability so a retired id fails loudly before spending credits (#358).
+  The Mistral row (excluded here after `mistral-large-2411` was retired) repopulates at the next full
+  refresh (Phase 8.5); this snapshot's `**Version:**` stamp is unchanged.

--- a/evals/agent_tool_usability/run_eval.py
+++ b/evals/agent_tool_usability/run_eval.py
@@ -266,6 +266,10 @@ def run_scenario(client: OpenAI, model: str, scenario: dict, tool_descriptions: 
         "scoring_notes": scenario["scoring_notes"],
         "safety_critical": scenario["safety_critical"],
         "model": model,
+        # The id OpenRouter actually served. Differs from `model` when a
+        # non-dated/latest slug (e.g. mistralai/mistral-large) resolves to a
+        # concrete dated version — so we always record exactly what ran.
+        "resolved_model": getattr(response, "model", None),
         "input_tokens": usage.prompt_tokens if usage else None,
         "output_tokens": usage.completion_tokens if usage else None,
     }
@@ -363,6 +367,26 @@ def print_summary(summaries: list, scenarios: list, runs: int, scorer_model: str
         print("  Check raw JSON for per-run breakdown.")
 
 
+def check_models_available(client: OpenAI, models: list[str]) -> list[str]:
+    """Return requested model ids NOT present in OpenRouter's catalog.
+
+    A pre-flight guard so a retired/renamed slug (e.g. the v0.10.0
+    mistral-large-2411 → 404) fails loudly *before* any completion credits
+    are spent, instead of erroring silently per-scenario. Best-effort: if
+    the (free) catalog fetch itself errors, warn and return [] so a transient
+    network blip doesn't block the run.
+    """
+    try:
+        available = {m.id for m in client.models.list().data}
+    except Exception as e:
+        print(
+            f"WARNING: could not fetch the OpenRouter model catalog ({e}); "
+            "skipping the pre-flight availability check."
+        )
+        return []
+    return [m for m in models if m not in available]
+
+
 def main():
     parser = argparse.ArgumentParser(description="Run blind agent evals via OpenRouter")
     parser.add_argument("--model", nargs="+",
@@ -403,6 +427,19 @@ def main():
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
     models = args.model
+
+    # Fail loud (and free) if a requested model is no longer served, before
+    # spending any completion credits on a model that would 404 (#358).
+    missing = check_models_available(client, models)
+    if missing:
+        print(
+            "ERROR: requested model(s) not available on OpenRouter "
+            "(retired or renamed?) — update the model list before running:"
+        )
+        for m in missing:
+            print(f"  - {m}")
+        print("Browse the catalog: https://openrouter.ai/models")
+        sys.exit(1)
 
     scorer_model = args.scorer_model
 


### PR DESCRIPTION
## What

The blind eval's `make eval-tools` pinned `mistralai/mistral-large-2411`, which OpenRouter has retired. During the #355 refresh all 225 of its calls 404'd and produced a silent 0-token row. This closes both gaps that let that happen quietly.

### 1. Record the model that actually served
`run_scenario` now captures `resolved_model = response.model` (the slug OpenRouter actually served) alongside the requested `model`. This is what makes auto-updating latest/family slugs safe to use — the raw JSON shows exactly which concrete version ran each scenario.

### 2. Pre-flight availability check (fails loud, costs nothing)
New `check_models_available(client, models)` fetches OpenRouter's free `/models` catalog and `sys.exit(1)`s — *before* any completion credits are spent — if a requested id is missing, naming the offending slug(s). Best-effort: if the catalog fetch itself errors (transient network), it warns and proceeds rather than blocking the run.

### 3. Latest-per-family model list
`Makefile` `eval-tools` now uses each family's latest/non-dated slug where one exists:
| family | was | now |
|---|---|---|
| Mistral | `mistralai/mistral-large-2411` (retired) | `mistralai/mistral-large` |
| DeepSeek | `deepseek/deepseek-chat-v3-0324` | `deepseek/deepseek-chat` |
| Qwen | `qwen/qwen-2.5-72b-instruct` | unchanged (no non-dated alias) |
| Llama | `meta-llama/llama-3.3-70b-instruct` | unchanged (no non-dated alias) |

The pre-check + `resolved_model` capture cover staleness for the dated-only lines too.

## Verification
- **Negative pre-check:** `--model deepseek/deepseek-chat openrouter/does-not-exist-zzz` → prints the missing id, exits 1, **no scenarios run** (no credits spent).
- **Positive smoke run:** new model list, `--scenarios 37 --runs 1` → pre-check passes, all four models PASS, and each raw result carries a `resolved_model` (e.g. `deepseek/deepseek-chat` → `deepseek/deepseek-chat-v3`). Minimal credits, written to a temp dir.
- `make check-all` green.

No full eval re-run here (smoke only) — `scored_results.md`'s `**Version:**` stamp is unchanged; the excluded Mistral row repopulates at the next Phase 8.5 refresh. A one-line note documents this.

Out of scope (flagged, not touched): the dead `TOOL_NAMES` constant in `run_eval.py` lists removed tools — worth a separate tidy.

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)