### PR TITLE
release: v0.10.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Mail via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.10.0 | **Tests:** 1351 unit / 29 e2e / 59 integration | **Coverage:** 92%
+**Version:** v0.10.1 | **Tests:** 1368 unit / 29 e2e / 59 integration | **Coverage:** 92%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-06-08
+
+A maintenance release. The one user-facing fix lets an iCloud account whose Apple ID is a third-party address (e.g. a Gmail sign-in) resolve its IMAP login. The rest is release-engineering hardening: a gate that makes the Phase 8.5 derived-artifact refresh impossible to skip silently — the gap that shipped a stale eval snapshot at v0.10.0 — and a more robust blind-eval model list that tracks each family's latest model and fails loud on retired ids.
+
+### Added
+
+**Release-artifact freshness gate (#356):** [`scripts/check_release_artifacts.sh`](scripts/check_release_artifacts.sh) fails the release validation when a derived artifact (`tests/benchmarks/baseline.json`, `evals/agent_tool_usability/results/scored_results.md`) isn't stamped for the release being cut — unless an explicit, issue-tracked waiver is recorded in [`release_artifact_waivers.txt`](release_artifact_waivers.txt). The v0.10.0 release silently shipped an eval snapshot stamped `v0.9.0` because Phase 8.5 was skippable without a check; this closes that gap. See [docs/guides/RELEASE_ARTIFACTS.md](docs/guides/RELEASE_ARTIFACTS.md).
+
+### Changed
+
+**Blind-eval model list tracks latest-per-family and fails loud on retired ids (#358):** `make eval-tools` had pinned `mistralai/mistral-large-2411`, which OpenRouter retired — its calls 404'd and produced a silent zero-token row. The model list now uses each family's latest non-dated slug where one exists (`mistralai/mistral-large`, `deepseek/deepseek-chat`), each run records the exact version OpenRouter served (`resolved_model`), and `run_eval` pre-checks model availability against the catalog, exiting before any credits are spent if a requested id is missing.
+
+### Fixed
+
+**iCloud IMAP login resolution for third-party Apple IDs (#341):** `_resolve_imap_config` couldn't determine the login for an iCloud/MobileMe account whose Apple ID is a non-iCloud address (e.g. a Gmail sign-in) and whose AppleScript `email addresses` list is empty — the #299 apple-alias rule had nothing to resolve from, so the connection failed. A persisted per-account login override (`~/.apple_mail_mcp/imap_login_overrides.json`, set via the IMAP setup CLI) is now consulted first, letting these accounts connect.
+
 ## [0.10.0] - 2026-06-05
 
 First release under the new name **`apple-mail-fast-mcp`** (#335) — the PyPI distribution, CLI command, and repo were renamed, and publishing now goes through PyPI OIDC trusted publishing. Feature-wise the theme is **richer composition and inspection**: drafts can carry an HTML body, a new tool reads an attachment's content inline without writing to disk, and IMAP credentials can come from an environment variable for uvx/headless/CI contexts. Alongside: a confirmation-prompt fix for current FastMCP, and CI/release hardening so parity drift and dependency advisories can't slip through (or hard-block a release) unnoticed.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server that provides programmatic access to Apple Mail, enabling AI assistants like Claude to read, send, search, and manage emails on macOS.
 
-> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-fast-mcp==0.10.0`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
+> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-fast-mcp==0.10.1`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
 
 ## Tools (24)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-mail-fast-mcp"
-version = "0.10.0"
+version = "0.10.1"
 description = "MCP server for Apple Mail integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/release_artifact_waivers.txt
+++ b/release_artifact_waivers.txt
@@ -13,3 +13,6 @@
 #
 # Entries are per-release; prune old ones freely. See
 # docs/guides/RELEASE_ARTIFACTS.md.
+
+v0.10.1 benchmark #354 maintenance release; only runtime change (#341 IMAP login resolution) touches no benchmarked hot path, so numbers would reproduce
+v0.10.1 eval #355 maintenance release; tool surface unchanged (still 24 tools), so blind-eval scores would reproduce

--- a/src/apple_mail_mcp/__init__.py
+++ b/src/apple_mail_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Mail MCP Server
 A Model Context Protocol server for Apple Mail integration.
 """
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-fast-mcp"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## v0.10.1 — maintenance release

One user-facing fix plus release-engineering hardening. No tool-surface change (still 24 tools).

### Fixed
- **iCloud IMAP login resolution for third-party Apple IDs (#341):** a persisted per-account login override (`~/.apple_mail_mcp/imap_login_overrides.json`, set via `setup-imap --email`) is now consulted first, so an iCloud/MobileMe account whose Apple ID is a non-iCloud address (e.g. a Gmail sign-in) with an empty AppleScript `email addresses` list can connect.

### Added
- **Release-artifact freshness gate (#356):** `scripts/check_release_artifacts.sh` fails the release when `baseline.json` / `scored_results.md` aren't stamped for the release being cut, unless an issue-tracked waiver is recorded. Closes the gap that silently shipped a `v0.9.0`-stamped eval snapshot at v0.10.0.

### Changed
- **Blind-eval model list robustness (#358):** tracks each family's latest non-dated slug (`mistralai/mistral-large`, `deepseek/deepseek-chat`), records the `resolved_model` OpenRouter served, and pre-checks availability before spending credits (the retired `mistral-large-2411` had been 404'ing silently).

## Release process
- All 12 release phases run. Gates green: version-sync, client/server parity, complexity, **1368 unit** + **29 e2e** tests, dependencies (transitive-only advisory #348, non-blocking), AppleScript safety, doc-drift, **release-artifacts**, lint, typecheck. Coverage **92.37%** (≥90).
- Code review of the cumulative `v0.10.0..HEAD` diff: no release-blocking issues.
- **Derived artifacts waived** (recorded in `release_artifact_waivers.txt`): benchmark baseline (#354) and eval snapshot (#355) — no perf-meaningful or tool-surface change this release, so numbers/scores would reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)