### PR TITLE
fix: search limit bounds matching results, not the candidate window

### DIFF
--- a/src/apple_mail_mcp/imap_connector.py
+++ b/src/apple_mail_mcp/imap_connector.py
@@ -81,6 +81,12 @@ that while still amortizing connect cost across realistic interactive
 bursts (a series of search → get_message → get_attachments calls within
 a couple minutes of each other reuses one connection)."""
 
+_FILTER_FETCH_CHUNK: int = 100
+"""FETCH batch size when a limited search needs post-FETCH filtering
+(has_attachment). Newest chunks are fetched first and the scan stops at
+`limit` matches, so this bounds the per-round-trip cost, not the total
+scan depth."""
+
 _FLAG_SEEN = b"\\Seen"
 _FLAG_FLAGGED = b"\\Flagged"
 
@@ -713,7 +719,16 @@ class ImapConnector:
             client.select_folder(mailbox, readonly=True)
 
             uids = client.search(criteria)
-            if limit is not None:
+            # `limit` bounds MATCHING results. With no post-filter, every
+            # candidate matches, so truncating the window up front is both
+            # correct and the cheapest possible FETCH. With has_attachment
+            # (only expressible by inspecting BODYSTRUCTURE after FETCH),
+            # pre-truncating would change limit's meaning to "whichever of
+            # the newest N happen to match" — silently dropping matches the
+            # AppleScript path (per-match limit) would return. There the
+            # walk below scans newest-first in bounded chunks instead.
+            post_filter = has_attachment is not None
+            if limit is not None and not post_filter:
                 uids = uids[-limit:]
 
             if not uids:
@@ -723,15 +738,45 @@ class ImapConnector:
             # BODYSTRUCTURE bundles into the same FETCH (no extra round-trip)
             # whether we need it for has_attachment filtering or for the
             # include_attachments output field — only fetch once.
-            need_bodystructure = (
-                has_attachment is not None or include_attachments
-            )
+            need_bodystructure = post_filter or include_attachments
             if need_bodystructure:
                 fetch_keys.append(b"BODYSTRUCTURE")
-            fetched = client.fetch(uids, fetch_keys)
 
-            results: list[dict[str, Any]] = []
-            for uid in uids:
+            return self._collect_search_rows(
+                client,
+                uids,
+                fetch_keys,
+                has_attachment=has_attachment,
+                include_attachments=include_attachments,
+                limit=limit if post_filter else None,
+            )
+
+    def _collect_search_rows(
+        self,
+        client: Any,
+        uids: list[int],
+        fetch_keys: list[bytes],
+        *,
+        has_attachment: bool | None,
+        include_attachments: bool,
+        limit: int | None,
+    ) -> list[dict[str, Any]]:
+        """FETCH candidate UIDs and build result rows, newest first.
+
+        When ``limit`` is set (only passed for post-filtered searches),
+        candidates are fetched in chunks of ``_FILTER_FETCH_CHUNK`` from
+        the newest end and the walk stops as soon as ``limit`` rows match
+        — so a mailbox where the newest messages match never pays for
+        fetching the old ones. Results are returned oldest-first to match
+        every other search path. ``limit=None`` degenerates to a single
+        FETCH of all candidates (the pre-existing fast path).
+        """
+        chunk_size = _FILTER_FETCH_CHUNK if limit is not None else len(uids)
+        newest_first: list[dict[str, Any]] = []
+        for end in range(len(uids), 0, -chunk_size):
+            chunk = uids[max(0, end - chunk_size) : end]
+            fetched = client.fetch(chunk, fetch_keys)
+            for uid in reversed(chunk):
                 entry = fetched.get(uid)
                 # A message can vanish between SEARCH and FETCH (expunged or
                 # moved by a concurrent change — another client, a rule, or
@@ -755,8 +800,10 @@ class ImapConnector:
                     row["attachments"] = _bodystructure_extract_attachments(
                         entry.get(b"BODYSTRUCTURE")
                     )
-                results.append(row)
-            return results
+                newest_first.append(row)
+                if limit is not None and len(newest_first) >= limit:
+                    return list(reversed(newest_first))
+        return list(reversed(newest_first))
 
     def get_message(
         self,

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -315,6 +315,144 @@ class TestLimit:
         assert fetch_uids == list(range(1, 11))
 
 
+_BS_PLAIN_TEXT_LEAF = (
+    b"text", b"plain", (b"CHARSET", b"UTF-8"), None, None,
+    b"7bit", 100, 5, None, None, None, None,
+)
+
+
+class TestLimitWithHasAttachmentFilter:
+    """`limit` must bound MATCHING results, not the candidate window.
+
+    The old `uids[-limit:]` pre-truncation made `limit=5,
+    has_attachment=True` mean "whichever of the 5 newest messages happen
+    to have attachments" — observed live as 1/2/6 results for the same
+    mailbox depending on what was in the window, silently missing
+    attachment-bearing messages. The AppleScript path collects matches
+    until limit; the IMAP path must agree.
+    """
+
+    def _setup(self, mock_cls, *, uids, attachment_uids):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.search.return_value = list(uids)
+        full = {
+            uid: {
+                b"ENVELOPE": _fake_envelope(
+                    message_id=f"<msg-{uid}@example.com>".encode(),
+                    subject=f"Subject {uid}".encode(),
+                ),
+                b"FLAGS": (b"\\Seen",),
+                b"BODYSTRUCTURE": (
+                    _BS_REAL_ICLOUD_MIXED_PDF
+                    if uid in attachment_uids
+                    else _BS_PLAIN_TEXT_LEAF
+                ),
+            }
+            for uid in uids
+        }
+        mock_client.fetch.side_effect = lambda chunk, keys: {
+            uid: full[uid] for uid in chunk
+        }
+        return mock_client
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_limit_counts_matches_not_candidates(self, mock_cls):
+        """Attachments only on the two OLDEST messages; limit=2 must still
+        find both (old behavior: scan newest 2, return [])."""
+        self._setup(mock_cls, uids=range(1, 11), attachment_uids={1, 2})
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        result = conn.search_messages(has_attachment=True, limit=2)
+        assert [r["subject"] for r in result] == ["Subject 1", "Subject 2"]
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_limit_returns_newest_matches_when_more_exist(self, mock_cls):
+        """More matches than limit → keep the newest `limit` matches,
+        returned oldest-first like every other search result."""
+        self._setup(
+            mock_cls, uids=range(1, 11), attachment_uids={2, 5, 8, 9}
+        )
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        result = conn.search_messages(has_attachment=True, limit=2)
+        assert [r["subject"] for r in result] == ["Subject 8", "Subject 9"]
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_filter_scan_short_circuits_in_chunks(self, mock_cls):
+        """250 candidates, the newest 5 all match, limit=5 → only the
+        newest chunk is fetched; older chunks are never paid for."""
+        client = self._setup(
+            mock_cls,
+            uids=range(1, 251),
+            attachment_uids={246, 247, 248, 249, 250},
+        )
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        result = conn.search_messages(has_attachment=True, limit=5)
+        assert len(result) == 5
+        assert client.fetch.call_count == 1
+        fetched_uids = client.fetch.call_args[0][0]
+        assert len(fetched_uids) <= 100  # bounded chunk, not all 250
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_matches_collected_across_multiple_chunks(self, mock_cls):
+        """Matches deep in the mailbox force the walk through ALL chunks:
+        250 candidates, matches at uids 10 and 120 only, limit=2 → three
+        chunked FETCHes that partition 1..250, both matches found,
+        returned oldest-first."""
+        client = self._setup(
+            mock_cls, uids=range(1, 251), attachment_uids={10, 120}
+        )
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        result = conn.search_messages(has_attachment=True, limit=2)
+        assert [r["subject"] for r in result] == ["Subject 10", "Subject 120"]
+        assert client.fetch.call_count == 3
+        fetched_uids = sorted(
+            uid
+            for call in client.fetch.call_args_list
+            for uid in call[0][0]
+        )
+        assert fetched_uids == list(range(1, 251))  # complete, no overlap
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_has_attachment_false_symmetric(self, mock_cls):
+        """has_attachment=False with limit collects non-attachment
+        matches across the whole candidate set."""
+        self._setup(
+            mock_cls, uids=range(1, 11), attachment_uids=set(range(3, 11))
+        )
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        result = conn.search_messages(has_attachment=False, limit=2)
+        assert [r["subject"] for r in result] == ["Subject 1", "Subject 2"]
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_uid_expunged_between_search_and_fetch_is_skipped(self, mock_cls):
+        """A UID the server omits from the FETCH response (expunged by
+        another session, RFC 3501 / #314) is skipped within the chunked
+        walk, not a KeyError aborting the whole search."""
+        client = self._setup(
+            mock_cls, uids=range(1, 11), attachment_uids={3, 7}
+        )
+        inner = client.fetch.side_effect
+        client.fetch.side_effect = lambda chunk, keys: {
+            uid: entry
+            for uid, entry in inner(chunk, keys).items()
+            if uid != 7
+        }
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        result = conn.search_messages(has_attachment=True, limit=5)
+        assert [r["subject"] for r in result] == ["Subject 3"]
+
+    @patch("apple_mail_mcp.imap_connector.IMAPClient")
+    def test_no_limit_with_filter_fetches_all_once(self, mock_cls):
+        """Filter without limit keeps the single-FETCH fast path."""
+        client = self._setup(
+            mock_cls, uids=range(1, 11), attachment_uids={3, 7}
+        )
+        conn = ImapConnector("h", 993, "u@e.com", "pw")
+        result = conn.search_messages(has_attachment=True)
+        assert [r["subject"] for r in result] == ["Subject 3", "Subject 7"]
+        assert client.fetch.call_count == 1
+
+
 # BODYSTRUCTURE shapes below match what IMAPClient returns: either a flat
 # leaf tuple (type, subtype, params, id, desc, encoding, size, [type-specific], [disposition])
 # or a multipart tuple ((child1,), (child2,), ..., subtype).


### PR DESCRIPTION
## Bug

`ImapConnector.search_messages` applies `uids[-limit:]` **before** the `has_attachment` post-filter (attachment presence is only knowable from BODYSTRUCTURE after FETCH). So `limit=5, has_attachment=True` means "whichever of the 5 newest messages happen to have attachments" rather than "up to 5 matching messages."

**Observed live** on a real iCloud INBOX (same mailbox, same second): the identical `has_attachment=True` search returned **2** results with `limit=5` and **6** with `limit=20` — i.e., the limited search silently missed 4 attachment-bearing messages.

The AppleScript path collects matches *until* limit (the per-match `matchCount` short-circuit in `mail_connector.py`), so the two backends disagree on what `limit` means and can return different result sets for the same query.

## Fix

- When a post-filter is active, walk candidate UIDs newest-first in chunks of `_FILTER_FETCH_CHUNK` (100), filter, and short-circuit once `limit` rows match. Results are returned oldest-first, as before. The common case (newest messages match) stays one FETCH round trip.
- No-filter searches keep the pre-truncation single-FETCH fast path byte-for-byte; the existing `TestLimit` tests pin that.
- The #314 expunged-UID skip is preserved inside the chunked walk and now has a regression test.

Trade-off, stated plainly: a limited filtered search over a mailbox where few candidates match scans candidates in 100-UID chunks rather than one bounded FETCH. That is the cost of `limit` meaning what callers expect; the short-circuit bounds it in the common case.

## Confidence

- **Live-verified** end-to-end on a real iCloud account running this exact patch: `limit=2` → 2, `limit=5` → 5 (was 2), `limit=20` → 6, unlimited → 6.
- 7 new unit tests, including a multi-chunk partition test (250 UIDs → 3 FETCHes, complete coverage, no overlap) and the expunged-UID regression.
- Against this branch: `tests/unit` = 1374 passed; ruff and mypy clean. One pre-existing failure (`test_attachments.py::TestSaveAttachments::test_save_validates_path_traversal`) fails identically on clean `main` in my environment and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)