### PR TITLE
fix(#364): stop trashing Gmail label moves — verified move + fail-loud, deprecate gmail_mode

### DIFF
--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -343,7 +343,9 @@ Patch one or more messages: change read state, flag color, and/or move to anothe
 | `destination_mailbox` | string \| null | No | null | Target mailbox name to move to. Requires `account`. |
 | `account` | string \| null | No | null | Account name (required when `destination_mailbox` is set; also unlocks the IMAP narrow-path optimization) |
 | `source_mailbox` | string \| null | No | null | Optional narrow-path hint — narrows the AppleScript scan to one mailbox. Required to unlock the IMAP fast path on move-only patches (#149) — without it, the move runs via AppleScript even when IMAP is configured. |
-| `gmail_mode` | boolean | No | false | Use Gmail-specific copy+delete instead of move (label-based accounts) |
+| `gmail_mode` | boolean | No | false | **Deprecated and ignored (#364).** The move strategy is chosen automatically; this flag does nothing. Slated for removal at v1.0 (#369). |
+
+> **Gmail label moves (#364).** The old `gmail_mode` copy+delete strategy silently routed Gmail INBOX→label moves through `[Gmail]/Trash` (stripping the destination label) and reported success anyway — data loss. It has been removed. Moves now run via IMAP `UID MOVE` when the account has IMAP configured (the reliable Gmail relabel); otherwise via a **verified** AppleScript `set mailbox`. If a move can't be confirmed (the Gmail silent-no-op), `update_message` returns `error_type: "imap_required"` instead of falsely succeeding — configure IMAP with `apple-mail-fast-mcp setup-imap --account <name>` and pass `source_mailbox`.
 
 **Patch semantics:** caller specifies only the fields they want changed. At least one field parameter must be set; otherwise returns `validation_error`.
 
@@ -378,12 +380,12 @@ update_message(message_ids=["12345"], flag_color="red")
 # Clear a flag
 update_message(message_ids=["12345"], flagged=False)
 
-# Move to Archive on a Gmail account
+# Move to Archive on a Gmail account (pass source_mailbox; needs IMAP configured)
 update_message(
     message_ids=["12345"],
     destination_mailbox="Archive",
     account="Gmail",
-    gmail_mode=True,
+    source_mailbox="INBOX",
 )
 
 # Restore from Trash — no special verb required
@@ -415,6 +417,7 @@ update_message(
 - `validation_error`: Too many IDs, no fields set, or missing `account` for move
 - `account_not_found`: `account` does not match a configured Mail.app account
 - `not_found`: `destination_mailbox` not found on the account
+- `imap_required`: A move could not be confirmed via AppleScript (the Gmail silent-no-op) and the account has no IMAP configured (#364). Run `apple-mail-fast-mcp setup-imap --account <name>` and pass `source_mailbox`.
 - `unknown`: Unexpected error occurred
 
 ---

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -455,8 +455,8 @@ message to exist in the source folder for STORE before MOVE.
 - `flag_color` (string, optional): Color name (orange, red, yellow, blue, green, purple, gray, none). Implies `flagged=True` unless "none". Validated against the existing flag-color schema.
 - `destination_mailbox` (string, optional): Move messages here (requires `account`).
 - `account` (string, optional): Account name or UUID hosting the destination mailbox. Required when `destination_mailbox` is set; also used with `source_mailbox` for narrow-path optimization.
-- `source_mailbox` (string, optional): Source mailbox name. With `account`, narrows the AppleScript scan to one mailbox (O(N) instead of cross-scan).
-- `gmail_mode` (boolean, optional) (default: False): Use Gmail-specific copy+delete instead of MOVE.
+- `source_mailbox` (string, optional): Source mailbox name. With `account`, narrows the AppleScript scan to one mailbox (O(N) instead of cross-scan). Required for reliable Gmail moves (the move is verified against the source).
+- `gmail_mode` (boolean, optional) (default: False): **Deprecated and ignored (#364).** Previously selected a copy+delete strategy that silently routed Gmail moves through Trash and lost the message. The move strategy is now chosen automatically (IMAP relabel when configured; otherwise a verified AppleScript move). A Gmail label move that can't be confirmed returns `error_type: "imap_required"` — configure IMAP with `apple-mail-fast-mcp setup-imap --account <name>`. Slated for removal at v1.0.
 
 ### update_rule
 

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -634,6 +634,7 @@ def _bulk_repeat_block(
     source_mailbox: str | None,
     actions: list[str],
     counter_var: str,
+    verify_dest_var: str | None = None,
 ) -> str:
     """Emit the AppleScript repeat block for a bulk-mutation operation.
 
@@ -689,6 +690,29 @@ def _bulk_repeat_block(
             f"missing {missing}"
         )
 
+    def _success_tail(indent: str) -> str:
+        """The per-match tail. Normally a bare counter bump; in verify mode
+        (move ops, #364) it confirms the message actually left the source by
+        checking its current mailbox against the destination — counting
+        silent no-ops into ``failCount`` instead of reporting false success.
+        Reading ``mailbox of msg`` after a successful move can error (the
+        source-scoped reference no longer resolves); that's treated as
+        landed, since the message did leave the source."""
+        if verify_dest_var is None:
+            return f"{indent}set {counter_var} to {counter_var} + 1"
+        return (
+            f"{indent}set landed to true\n"
+            f"{indent}try\n"
+            f"{indent}    if (name of mailbox of msg) is not "
+            f"(name of {verify_dest_var}) then set landed to false\n"
+            f"{indent}end try\n"
+            f"{indent}if landed then\n"
+            f"{indent}    set {counter_var} to {counter_var} + 1\n"
+            f"{indent}else\n"
+            f"{indent}    set failCount to failCount + 1\n"
+            f"{indent}end if"
+        )
+
     if account is not None and source_mailbox is not None:
         # Narrow path: single mailbox, single loop. O(N).
         action_indent = " " * 20
@@ -714,7 +738,7 @@ def _bulk_repeat_block(
             f"                end if\n"
             f"                if matched then\n"
             f"{action_lines}\n"
-            f"                    set {counter_var} to {counter_var} + 1\n"
+            f"{_success_tail(' ' * 20)}\n"
             f"                end if\n"
             f"            end repeat"
         )
@@ -742,7 +766,7 @@ def _bulk_repeat_block(
         f"                        end if\n"
         f"                        if matched then\n"
         f"{action_lines}\n"
-        f"                            set {counter_var} to {counter_var} + 1\n"
+        f"{_success_tail(' ' * 28)}\n"
         f"                        end if\n"
         f"                    end repeat\n"
         f"                end repeat\n"
@@ -3398,7 +3422,8 @@ class AppleMailConnector:
             message_ids: List of message IDs to move
             destination_mailbox: Name of destination mailbox
             account: Account name (or UUID) hosting the destination mailbox
-            gmail_mode: Use Gmail-specific handling (copy + delete)
+            gmail_mode: Deprecated and ignored (#364) — moves are always a
+                verified `set mailbox`, never copy+delete.
             source_mailbox: Optional source mailbox name to narrow the
                 AppleScript scan to one mailbox (O(N) instead of O(N × M × K)).
                 When provided, source is assumed to be in the same `account`
@@ -3416,47 +3441,85 @@ class AppleMailConnector:
         if not message_ids:
             return 0
 
+        # gmail_mode is deprecated and ignored (#364): the old copy+delete
+        # path routed Gmail moves through Trash and lost the message. Every
+        # AppleScript move now uses `set mailbox` and verifies the message
+        # actually left the source, failing loud (MailImapRequiredError) on
+        # the Gmail silent-no-op instead of reporting false success.
+        return self._run_verified_move(
+            message_ids,
+            account=account,
+            source_mailbox=source_mailbox,
+            destination_mailbox=destination_mailbox,
+        )
+
+    @staticmethod
+    def _parse_move_counts(result: str) -> tuple[int, int]:
+        """Parse the ``"<moved>,<failed>"`` payload from a verified-move
+        script into ``(moved, failed)``. Tolerates a bare ``"<moved>"`` (no
+        comma) for callers/tests that don't exercise verification."""
+        parts = result.strip().split(",")
+        moved = int(parts[0]) if parts[0].strip().isdigit() else 0
+        failed = (
+            int(parts[1]) if len(parts) > 1 and parts[1].strip().isdigit() else 0
+        )
+        return moved, failed
+
+    def _run_verified_move(
+        self,
+        message_ids: list[str],
+        *,
+        account: str,
+        source_mailbox: str | None,
+        destination_mailbox: str,
+    ) -> int:
+        """Move messages via AppleScript ``set mailbox`` and verify each one
+        left the source (#364). Raises MailImapRequiredError if any message
+        silently stayed put (the Gmail no-op) — the move can only be done
+        reliably over IMAP. Returns the count that verifiably moved."""
         from .utils import sanitize_input
 
         account_clause = applescript_account_clause(account)
-        mailbox_safe = escape_applescript_string(sanitize_input(destination_mailbox))
+        mailbox_safe = escape_applescript_string(
+            sanitize_input(destination_mailbox)
+        )
         id_list = ", ".join(
             f'"{escape_applescript_string(sanitize_input(mid))}"'
             for mid in message_ids
         )
-
-        if gmail_mode:
-            actions = ["duplicate msg to destMailbox", "delete msg"]
-        else:
-            actions = ["set mailbox of msg to destMailbox"]
-
-        # `account` is required by this method (it's where the destination
-        # lives), so source_mailbox is the only "optional" half here. Pass
-        # account through only when the caller explicitly wants the narrow
-        # source-scan path.
         repeat_block = _bulk_repeat_block(
             account=account if source_mailbox is not None else None,
             source_mailbox=source_mailbox,
-            actions=actions,
+            actions=["set mailbox of msg to destMailbox"],
             counter_var="moveCount",
+            verify_dest_var="destMailbox",
         )
-
         script = f"{_MAILBOX_RESOLVER_HANDLERS}\n" + _wrap_with_timeout(
             f"""tell application "Mail"
             set accountRef to {account_clause}
             set destMailbox to my resolveMailbox(accountRef, "{mailbox_safe}")
             set idList to {{{id_list}}}
             set moveCount to 0
+            set failCount to 0
 
 {repeat_block}
 
-            return moveCount
+            return (moveCount as text) & "," & (failCount as text)
         end tell""",
             timeout=self.timeout,
         )
 
-        result = self._run_applescript(script)
-        return int(result) if result.isdigit() else 0
+        moved, failed = self._parse_move_counts(self._run_applescript(script))
+        if failed > 0:
+            src = source_mailbox or "the source mailbox"
+            raise MailImapRequiredError(
+                f"Move to {destination_mailbox!r} could not be confirmed for "
+                f"{failed} message(s) — they never left {src!r}. On Gmail, "
+                f"label moves only apply reliably over IMAP: run "
+                f"`apple-mail-fast-mcp setup-imap --account <name>` for this "
+                f"account and retry. (#364)"
+            )
+        return moved
 
     def flag_message(
         self,
@@ -3568,7 +3631,9 @@ class AppleMailConnector:
                 unlock the IMAP fast path on move-only patches (#149) —
                 without it, the move runs via AppleScript even when
                 IMAP is configured.
-            gmail_mode: Use Gmail-specific copy+delete for the move.
+            gmail_mode: Deprecated and ignored (#364). Moves are always a
+                verified ``set mailbox`` (IMAP relabel when available);
+                copy+delete is gone because it trashed Gmail messages.
 
         IMAP fast path (#149): when the patch is move-only
         (``destination_mailbox`` is the only field set) and
@@ -3620,6 +3685,23 @@ class AppleMailConnector:
         if imap_count is not None:
             return imap_count
 
+        # Pure move (no read/flag) on the AppleScript fallback: route through
+        # the verified mover so a Gmail silent-no-op fails loud instead of
+        # quietly losing the message (#364). gmail_mode is deprecated/ignored.
+        pure_move = (
+            destination_mailbox is not None
+            and read_status is None
+            and flagged is None
+            and flag_color is None
+        )
+        if pure_move:
+            return self._run_verified_move(
+                message_ids,
+                account=cast(str, account),
+                source_mailbox=source_mailbox,
+                destination_mailbox=cast(str, destination_mailbox),
+            )
+
         actions: list[str] = []
 
         if read_status is not None:
@@ -3628,13 +3710,13 @@ class AppleMailConnector:
 
         actions.extend(self._build_flag_actions(flagged, flag_color))
 
-        # Move (always last — IMAP STORE requires source folder).
+        # Move (always last — IMAP STORE requires source folder). gmail_mode
+        # is deprecated/ignored (#364): never copy+delete (it trashes on
+        # Gmail). Combined move+read/flag patches stay on this unverified
+        # path; the move itself is a plain relabel that never routes through
+        # Trash.
         if destination_mailbox is not None:
-            if gmail_mode:
-                actions.append("duplicate msg to destMailbox")
-                actions.append("delete msg")
-            else:
-                actions.append("set mailbox of msg to destMailbox")
+            actions.append("set mailbox of msg to destMailbox")
 
         repeat_block = _bulk_repeat_block(
             account=account if source_mailbox is not None else None,

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -1345,7 +1345,16 @@ def update_message(
             `source_mailbox` for narrow-path optimization.
         source_mailbox: Source mailbox name. With `account`, narrows the
             AppleScript scan to one mailbox (O(N) instead of cross-scan).
-        gmail_mode: Use Gmail-specific copy+delete instead of MOVE.
+            Required for reliable Gmail moves (the move is verified against
+            the source).
+        gmail_mode: **Deprecated and ignored (#364).** Previously selected a
+            copy+delete strategy that silently routed Gmail moves through
+            Trash and lost the message. The move strategy is now chosen
+            automatically (IMAP relabel when configured; otherwise a verified
+            AppleScript move). A Gmail label move that can't be confirmed
+            returns `error_type: "imap_required"` — configure IMAP with
+            `apple-mail-fast-mcp setup-imap --account <name>`. Slated for
+            removal at v1.0.
 
     Returns:
         Dictionary with `updated` (int count) and `requested` (input count).
@@ -1453,6 +1462,16 @@ def update_message(
             "success": False,
             "error": str(e),
             "error_type": "not_found",
+        }
+    except MailImapRequiredError as e:
+        # #364: a Gmail label move that couldn't be verified needs IMAP.
+        # Surface it loudly so the caller can run setup-imap, rather than
+        # the generic "unknown" that hides an actionable remedy.
+        logger.error(f"Move requires IMAP: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "imap_required",
         }
     except ValueError as e:
         logger.error(f"Validation error in update_message: {e}")

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -1264,6 +1264,102 @@ class TestDraftsLifecycleIntegration:
                 except Exception:
                     pass
 
+    def test_gmail_label_move_lands_in_label_not_trash(
+        self,
+        connector: AppleMailConnector,
+        test_account: str,
+    ) -> None:
+        """#364 acceptance gate: a Gmail label→label move must land the
+        message in the destination label and NOT in [Gmail]/Trash. The old
+        gmail_mode copy+delete trashed it (and stripped the label); this
+        pins that it never happens again. Verified via direct IMAP because
+        Mail.app's local view lags the server.
+
+        Skips on non-Gmail accounts — the bug and its fix are Gmail-specific.
+        """
+        import uuid as _uuid
+        from datetime import datetime, timezone
+        from email.utils import format_datetime
+
+        from imapclient import IMAPClient
+
+        from apple_mail_mcp.keychain import get_imap_password
+
+        host, port, email = connector._resolve_imap_config(test_account)
+        if "gmail" not in host.lower():
+            pytest.skip(f"not a Gmail account (host={host})")
+        pw = get_imap_password(test_account, email)
+
+        suffix = _uuid.uuid4().hex[:8]
+        src = f"ZZZ-AMM-GM-SRC-{suffix}"
+        dst = f"ZZZ-AMM-GM-DST-{suffix}"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-fast-mcp-test.invalid"
+        bracketed = f"<{msg_id_local}>"
+
+        assert connector.create_mailbox(account=test_account, name=src)
+        assert connector.create_mailbox(account=test_account, name=dst)
+
+        try:
+            now = format_datetime(datetime.now(tz=timezone.utc))
+            raw = (
+                f"From: sender@apple-mail-fast-mcp-test.invalid\r\n"
+                f"To: rcpt@apple-mail-fast-mcp-test.invalid\r\n"
+                f"Subject: AMM #364 Gmail label move test\r\n"
+                f"Date: {now}\r\n"
+                f"Message-ID: {bracketed}\r\n"
+                f"\r\n"
+                f"body\r\n"
+            ).encode()
+
+            append_client = IMAPClient(host, port=port, ssl=True, timeout=30)
+            append_client.login(email, pw)
+            try:
+                append_client.append(src, raw)
+            finally:
+                append_client.logout()
+
+            moved = connector.update_message(
+                [msg_id_local],
+                destination_mailbox=dst,
+                account=test_account,
+                source_mailbox=src,
+            )
+            assert moved == 1
+
+            verify = IMAPClient(host, port=port, ssl=True, timeout=30)
+            verify.login(email, pw)
+            try:
+                # Discover Trash via SPECIAL-USE, fall back to the Gmail name.
+                trash = None
+                for flags, _delim, name in verify.list_folders():
+                    if b"\\Trash" in flags:
+                        trash = name
+                        break
+                trash = trash or "[Gmail]/Trash"
+
+                verify.select_folder(src, readonly=True)
+                src_uids = verify.search(["HEADER", "Message-ID", bracketed])
+                verify.select_folder(dst, readonly=True)
+                dst_uids = verify.search(["HEADER", "Message-ID", bracketed])
+                verify.select_folder(trash, readonly=True)
+                trash_uids = verify.search(["HEADER", "Message-ID", bracketed])
+            finally:
+                verify.logout()
+
+            assert src_uids == [], f"still in source label: {src_uids}"
+            assert len(dst_uids) == 1, f"not in destination label: {dst_uids}"
+            assert trash_uids == [], (
+                f"#364 regression — message routed through Trash: {trash_uids}"
+            )
+        finally:
+            for name in (src, dst):
+                try:
+                    connector.delete_mailbox(
+                        account=test_account, name=name, delete_messages=True
+                    )
+                except Exception:
+                    pass
+
     def test_delete_messages_via_imap_round_trip(
         self,
         connector: AppleMailConnector,

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -4539,10 +4539,12 @@ class TestBulkOpsSourceMailbox:
         assert "repeat with acc in accounts" not in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_move_messages_narrow_path_gmail_branch(
+    def test_move_messages_gmail_mode_no_longer_copy_deletes(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        mock_run.return_value = "2"
+        # #364: the copy+delete that routed Gmail moves through Trash is gone.
+        # gmail_mode is deprecated/ignored — the move is always `set mailbox`.
+        mock_run.return_value = "2,0"
         connector.move_messages(
             ["abc", "def"],
             destination_mailbox="[Gmail]/All Mail",
@@ -4559,10 +4561,45 @@ class TestBulkOpsSourceMailbox:
             'set destMailbox to my resolveMailbox(accountRef, "[Gmail]/All Mail")'
             in script
         )
-        # Gmail-mode body: duplicate + delete instead of set mailbox
-        assert "duplicate msg to destMailbox" in script
-        assert "delete msg" in script
+        # The data-loss primitives must be gone.
+        assert "set mailbox of msg to destMailbox" in script
+        assert "duplicate msg to destMailbox" not in script
+        assert "delete msg" not in script
         assert "repeat with acc in accounts" not in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_move_messages_emits_landing_verification(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        # #364: every AppleScript move now verifies the message actually left
+        # the source (Gmail `set mailbox` silently no-ops otherwise).
+        mock_run.return_value = "1,0"
+        connector.move_messages(
+            ["abc"],
+            destination_mailbox="Archive",
+            account="Gmail",
+            source_mailbox="INBOX",
+        )
+        script = mock_run.call_args[0][0]
+        assert "name of mailbox of msg" in script
+        assert "failCount" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_move_messages_unverified_move_raises_imap_required(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        # #364: a message that never left source (silent Gmail no-op) must
+        # fail loud, not report success.
+        from apple_mail_mcp.exceptions import MailImapRequiredError
+
+        mock_run.return_value = "1,1"  # 1 moved, 1 stuck in source
+        with pytest.raises(MailImapRequiredError, match="IMAP"):
+            connector.move_messages(
+                ["abc", "def"],
+                destination_mailbox="Newsletters",
+                account="Gmail",
+                source_mailbox="INBOX",
+            )
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_move_messages_no_source_keeps_cross_scan(
@@ -4575,6 +4612,44 @@ class TestBulkOpsSourceMailbox:
         script = mock_run.call_args[0][0]
         assert "repeat with acc in accounts" in script
         assert "repeat with mb in mailboxes" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_update_message_gmail_move_uses_set_mailbox_not_delete(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        # #364: the AppleScript fallback for a Gmail move (IMAP unavailable)
+        # must not copy+delete. Open the breaker so the IMAP fast path is
+        # skipped and the AppleScript path runs.
+        connector._imap_failure_until["Gmail"] = time.monotonic() + 60
+        mock_run.return_value = "1,0"
+        connector.update_message(
+            ["abc"],
+            destination_mailbox="Newsletters",
+            account="Gmail",
+            source_mailbox="INBOX",
+            gmail_mode=True,
+        )
+        script = mock_run.call_args[0][0]
+        assert "set mailbox of msg to destMailbox" in script
+        assert "duplicate msg to destMailbox" not in script
+        assert "delete msg" not in script
+        assert "name of mailbox of msg" in script  # verification present
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_update_message_unverified_gmail_move_raises_imap_required(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        from apple_mail_mcp.exceptions import MailImapRequiredError
+
+        connector._imap_failure_until["Gmail"] = time.monotonic() + 60
+        mock_run.return_value = "0,1"  # message never left source
+        with pytest.raises(MailImapRequiredError, match="IMAP"):
+            connector.update_message(
+                ["abc"],
+                destination_mailbox="Newsletters",
+                account="Gmail",
+                source_mailbox="INBOX",
+            )
 
     # ------ flag_message ------
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1893,6 +1893,27 @@ class TestUpdateMessage:
         assert result["success"] is False
         assert result["error_type"] == "validation_error"
 
+    def test_imap_required_maps_to_imap_required(
+        self, mock_mail: MagicMock
+    ) -> None:
+        # #364: a Gmail move that couldn't be verified (needs IMAP) must fail
+        # loud with an actionable error_type, not the generic "unknown".
+        from apple_mail_mcp.exceptions import MailImapRequiredError
+
+        mock_mail.update_message.side_effect = MailImapRequiredError(
+            "Gmail label moves require IMAP"
+        )
+
+        result = update_message(
+            ["1"],
+            destination_mailbox="Newsletters",
+            account="Gmail",
+            source_mailbox="INBOX",
+        )
+
+        assert result["success"] is False
+        assert result["error_type"] == "imap_required"
+
     def test_unexpected_exception_maps_to_unknown(
         self, mock_mail: MagicMock
     ) -> None:


### PR DESCRIPTION
## Problem

Closes #364. `update_message` with `gmail_mode=true` moving a Gmail message INBOX→user-label silently landed it in `[Gmail]/Trash`, stripped the destination label, and still returned `{"success": true, "updated": 1}` — **silent data loss**.

**Root cause:** the `gmail_mode` branch ran AppleScript `duplicate msg to destMailbox` then `delete msg`. On Gmail every label is one underlying message, `delete` always routes to Trash (#111), and Gmail's Trash strips all other labels — so the label `duplicate` added was removed the instant `delete` ran. Only IMAP relabels Gmail correctly; **both** AppleScript primitives are broken (`copy+delete` trashes, `set mailbox` silently no-ops). The IMAP move-only fast path already did the right thing and ignored `gmail_mode` — the bug was the AppleScript fallback taken when the account has no IMAP configured.

## Fix (maintainer-approved approach: prefer IMAP, else verified AppleScript, fail loud)

- **Remove the copy+delete branch** from `update_message` and `move_messages`. Moves always use `set mailbox` (a relabel that never routes through Trash).
- **Verified AppleScript fallback:** per message, in-loop on the live `msg` reference, confirm it left the source (compare current mailbox to the destination — no slow `whose message id` lookup, which is ~21s/lookup). A silent no-op raises `MailImapRequiredError` → server `error_type: "imap_required"`, pointing the user at `setup-imap`. **No more false success.**
- **Deprecate `gmail_mode`** (accepted but ignored; auto-routing now). Filed #369 to remove it at v1.0.

## Tests (TDD, RED→GREEN)

- Replaced the copy+delete script-text assertions with `set mailbox` / no-`delete` assertions.
- Added verified-move + fail-loud unit tests (`"<moved>,<failed>"` payload → raises on `failed>0`) and the `update_message` → `imap_required` server mapping test.
- Added a **Gmail-gated integration test** asserting the move lands in the destination label and is **absent from `[Gmail]/Trash`** — the #364 acceptance gate (skips on non-Gmail accounts; run with `make test-integration`).

`make check-all` ✅ · `make test` + e2e → **1420 passed** (+9).

## Notes

- The IMAP happy path is unchanged (it was already correct); the changed code is the AppleScript fallback + verification.
- Combined move+read/flag patches stay on the unverified AppleScript path but now use `set mailbox` (no trash); noted as a follow-up, not a regression.
- Integration test requires a real Gmail test account, so CI can't run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)