### PR TITLE
fix(#371): give save_attachments an account/mailbox IMAP fast path

### DIFF
--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -547,6 +547,10 @@ Save attachments from a message to a directory.
 | `message_id` | string | Yes | - | Message ID to save attachments from |
 | `save_directory` | string | Yes | - | Directory path to save attachments |
 | `attachment_indices` | list[int] | No | None | Specific attachment indices (None = all) |
+| `account` | string | No | None | Mail.app account name or UUID. With `mailbox`, takes the IMAP fast path (one fetch). Pass the same values you read the message with so attachment ordering matches. |
+| `mailbox` | string | No | None | Folder the message lives in (e.g. "INBOX"), used with `account` for the IMAP fast path. |
+
+**Performance (#371):** pass `account` + `mailbox` to fetch the message once over IMAP and write the bytes straight to disk. Without them, `save_attachments` falls back to an O(accounts × mailboxes) AppleScript scan whose unindexed `message id` lookup is ~20s/mailbox — on Gmail (dozens of labels) that can run for minutes and time out. Mirrors `get_attachment_content`'s fast path.
 
 **Returns:**
 

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -316,6 +316,8 @@ Save attachments from a message to a directory.
 - `message_id` (string, required): Message ID from search results
 - `save_directory` (string, required): Directory path to save attachments to
 - `attachment_indices` (list[integer], optional): Specific attachment indices to save (0-based), None for all
+- `account` (string, optional): Mail.app account name or UUID. Supply it (with ``mailbox``) to take the faster IMAP path — one fetch instead of an account×mailbox AppleScript scan. Pass the same values you read the message with so attachment ordering matches (#371). Strongly recommended on Gmail, where the AppleScript fallback's unindexed cross-scan can take minutes and time out.
+- `mailbox` (string, optional): Folder the message lives in (e.g. "INBOX"), used with ``account`` for the IMAP fast path.
 
 ### save_template
 

--- a/src/apple_mail_mcp/mail_connector.py
+++ b/src/apple_mail_mcp/mail_connector.py
@@ -3286,6 +3286,9 @@ class AppleMailConnector:
         message_id: str,
         save_directory: Path,
         attachment_indices: list[int] | None = None,
+        *,
+        account: str | None = None,
+        mailbox: str | None = None,
     ) -> dict[str, Any]:
         """
         Save attachments from a message to a directory.
@@ -3296,6 +3299,14 @@ class AppleMailConnector:
         pre-checked out before saving, and a post-write net deletes any file
         that still lands over the cap (covering sizes Mail under-reports for
         not-yet-downloaded attachments).
+
+        IMAP fast path (#371): when ``account`` + ``mailbox`` are supplied,
+        the message is fetched once over IMAP and its attachment bytes are
+        written straight to disk — avoiding the O(accounts × mailboxes)
+        AppleScript cross-scan (whose unindexed ``message id`` lookup is
+        ~20s/mailbox and times out on Gmail's many labels). Falls back to
+        AppleScript transparently when IMAP isn't configured. Attachment
+        ordering matches ``get_attachment_content`` (same fetch+parse path).
 
         Args:
             message_id: Message ID
@@ -3336,6 +3347,27 @@ class AppleMailConnector:
         # selected attachment by index to a precomputed, contained POSIX
         # path. (Concatenating `name of att` into the path inside AppleScript
         # was a path-traversal → arbitrary-file-write vector.)
+        # IMAP fast path (#371): one fetch instead of the AppleScript
+        # cross-scan. Mirrors get_attachment_content's dispatch.
+        if (
+            account is not None
+            and mailbox is not None
+            and not self._imap_breaker_open(account)
+        ):
+            try:
+                imap_result = self._imap_save_attachments(
+                    account=account,
+                    mailbox=mailbox,
+                    message_id=message_id,
+                    save_directory=save_directory,
+                    attachment_indices=attachment_indices,
+                )
+                self._imap_clear_breaker(account)
+                return imap_result
+            except _IMAP_FALLBACK_EXCS as exc:
+                self._log_imap_fallback(account, exc)
+                # fall through to AppleScript
+
         attachments = self._get_attachments_applescript(message_id)
 
         # Pre-check byte caps (#236): drop oversized attachments before saving.
@@ -3398,6 +3430,72 @@ class AppleMailConnector:
 
         # Post-write net (#236): delete any file that landed over the cap
         # (e.g. Mail under-reported size pre-download) and report it.
+        removed, post_rejected = _prune_oversized_written(
+            targets,
+            per_cap=self.max_attachment_bytes,
+            total_cap=self.max_total_attachment_bytes,
+        )
+        rejected.extend(post_rejected)
+        return {"saved": max(0, saved - removed), "rejected": rejected}
+
+    def _imap_save_attachments(
+        self,
+        *,
+        account: str,
+        mailbox: str,
+        message_id: str,
+        save_directory: Path,
+        attachment_indices: list[int] | None,
+    ) -> dict[str, Any]:
+        """IMAP path for save_attachments (#371): fetch the raw message once
+        and write the selected attachment bytes to disk. Reuses
+        ``fetch_raw_message`` + ``parse_original_message`` (same machinery as
+        ``_imap_get_attachment_content``) and the same #236 byte-cap /
+        path-safety helpers as the AppleScript path — the only new step is
+        the direct ``write_bytes``.
+
+        Propagates ``_IMAP_FALLBACK_EXCS`` unchanged for the caller's
+        fallback.
+        """
+        host, port, email = self._resolve_imap_config(account)
+        password = self._get_imap_password_with_fallback(account, email)
+        imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
+        raw = imap.fetch_raw_message(message_id, mailbox)
+        parsed = parse_original_message(raw).attachments
+
+        # Shape the parsed parts like _get_attachments_applescript output so
+        # the shared cap/target helpers apply unchanged. Exact byte sizes
+        # here (not Mail's pre-download estimate) make the pre-check precise.
+        attachments: list[dict[str, Any]] = [
+            {
+                "name": filename,
+                "mime_type": f"{maintype}/{subtype}",
+                "size": len(payload),
+                "downloaded": True,
+            }
+            for (filename, maintype, subtype, payload) in parsed
+        ]
+
+        allowed, rejected = _select_attachments_within_caps(
+            attachments,
+            attachment_indices,
+            per_cap=self.max_attachment_bytes,
+            total_cap=self.max_total_attachment_bytes,
+        )
+        if not allowed:
+            return {"saved": 0, "rejected": rejected}
+
+        targets = _compute_attachment_save_targets(
+            [a["name"] for a in attachments], save_directory, allowed
+        )
+        saved = 0
+        for as_idx, path in targets:
+            # _compute_attachment_save_targets returns 1-based indices.
+            path.write_bytes(parsed[as_idx - 1][3])
+            saved += 1
+
+        # Post-write net for symmetry with the AppleScript path (inert here —
+        # IMAP sizes are exact, so nothing should exceed the pre-check).
         removed, post_rejected = _prune_oversized_written(
             targets,
             per_cap=self.max_attachment_bytes,

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -1564,6 +1564,8 @@ def save_attachments(
     message_id: str,
     save_directory: str,
     attachment_indices: IntList | None = None,
+    account: str | None = None,
+    mailbox: str | None = None,
 ) -> dict[str, Any]:
     """
     Save attachments from a message to a directory.
@@ -1572,6 +1574,14 @@ def save_attachments(
         message_id: Message ID from search results
         save_directory: Directory path to save attachments to
         attachment_indices: Specific attachment indices to save (0-based), None for all
+        account: Mail.app account name or UUID. Supply it (with ``mailbox``)
+            to take the faster IMAP path — one fetch instead of an
+            account×mailbox AppleScript scan. Pass the same values you read
+            the message with so attachment ordering matches (#371). Strongly
+            recommended on Gmail, where the AppleScript fallback's unindexed
+            cross-scan can take minutes and time out.
+        mailbox: Folder the message lives in (e.g. "INBOX"), used with
+            ``account`` for the IMAP fast path.
 
     Returns:
         Dict with ``success``, ``saved`` (count written), ``directory``, and
@@ -1620,6 +1630,8 @@ def save_attachments(
             message_id=message_id,
             save_directory=save_path,
             attachment_indices=attachment_indices,
+            account=account,
+            mailbox=mailbox,
         )
 
         operation_logger.log_operation(

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -509,6 +509,73 @@ class TestMailIntegration:
             # Documented divergence — IMAP path always reports False.
             assert att["downloaded"] is False
 
+    def test_save_attachments_via_imap_fast_path(
+        self, connector: AppleMailConnector, test_account: str, tmp_path: Path
+    ) -> None:
+        """#371: save_attachments(account, mailbox) writes attachment bytes
+        via the IMAP fast path (one fetch, no AppleScript cross-scan).
+        APPENDs a synthetic message with a known attachment, saves it, and
+        verifies the file bytes match exactly. Skips without IMAP.
+        """
+        import uuid as _uuid
+        from datetime import datetime, timezone
+        from email.message import EmailMessage
+        from email.utils import format_datetime
+
+        from imapclient import IMAPClient
+
+        from apple_mail_mcp.exceptions import (
+            MailKeychainAccessDeniedError,
+            MailKeychainEntryNotFoundError,
+        )
+        from apple_mail_mcp.keychain import get_imap_password
+
+        host, port, email = connector._resolve_imap_config(test_account)
+        try:
+            pw = get_imap_password(test_account, email)
+        except (MailKeychainEntryNotFoundError, MailKeychainAccessDeniedError):
+            pytest.skip(
+                f"No Keychain entry for {test_account!r} — run setup-imap."
+            )
+
+        suffix = _uuid.uuid4().hex[:8]
+        box = f"ZZZ-AMM-ATT-{suffix}"
+        msg_id_local = f"{_uuid.uuid4().hex}@apple-mail-fast-mcp-test.invalid"
+        payload = b"%PDF-1.4 fake pdf " + _uuid.uuid4().hex.encode()
+
+        assert connector.create_mailbox(account=test_account, name=box)
+        try:
+            m = EmailMessage()
+            m["From"] = "sender@apple-mail-fast-mcp-test.invalid"
+            m["To"] = "rcpt@apple-mail-fast-mcp-test.invalid"
+            m["Subject"] = "AMM #371 save_attachments fast path"
+            m["Date"] = format_datetime(datetime.now(tz=timezone.utc))
+            m["Message-ID"] = f"<{msg_id_local}>"
+            m.set_content("body")
+            m.add_attachment(
+                payload, maintype="application", subtype="pdf", filename="doc.pdf"
+            )
+
+            ac = IMAPClient(host, port=port, ssl=True, timeout=30)
+            ac.login(email, pw)
+            try:
+                ac.append(box, m.as_bytes())
+            finally:
+                ac.logout()
+
+            result = connector.save_attachments(
+                msg_id_local, tmp_path, account=test_account, mailbox=box
+            )
+            assert result["saved"] == 1
+            assert (tmp_path / "doc.pdf").read_bytes() == payload
+        finally:
+            try:
+                connector.delete_mailbox(
+                    account=test_account, name=box, delete_messages=True
+                )
+            except Exception:
+                pass
+
 
 class TestDraftsLifecycleIntegration:
     """Integration tests for the drafts lifecycle (#134).

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -5135,6 +5135,155 @@ class TestNonJsonPathsThreadTimeout:
         assert "with timeout of 127 seconds" in self._script_from(mock_run)
 
 
+def _raw_with_attachments(atts: list[tuple[str, str, bytes]]) -> bytes:
+    """Build raw RFC 822 bytes with the given attachments.
+
+    ``atts`` is a list of ``(filename, subtype, payload_bytes)``.
+    """
+    from email.message import EmailMessage
+
+    m = EmailMessage()
+    m["From"] = "s@example.com"
+    m["To"] = "r@example.com"
+    m["Subject"] = "with attachments"
+    m["Message-ID"] = "<att-test@example.com>"
+    m.set_content("body")
+    for filename, subtype, data in atts:
+        m.add_attachment(
+            data, maintype="application", subtype=subtype, filename=filename
+        )
+    return m.as_bytes()
+
+
+class TestSaveAttachmentsImapFastPath:
+    """#371: save_attachments(account, mailbox) uses the IMAP fast path
+    (one fetch_raw_message) instead of the O(accounts × mailboxes)
+    AppleScript cross-scan that hangs on Gmail."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    def _imap_patches(self, mock_imap: MagicMock) -> list:
+        return [
+            patch(
+                "apple_mail_mcp.mail_connector.ImapConnector",
+                return_value=mock_imap,
+            ),
+            patch.object(
+                AppleMailConnector,
+                "_get_imap_password_with_fallback",
+                return_value="pw",
+            ),
+            patch.object(
+                AppleMailConnector,
+                "_resolve_imap_config",
+                return_value=("h", 993, "e@x.com"),
+            ),
+        ]
+
+    def test_imap_path_writes_bytes_without_applescript(
+        self, connector: AppleMailConnector, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        raw = _raw_with_attachments(
+            [("offer.pdf", "pdf", b"PDF-OFFER"), ("agreement.pdf", "pdf", b"PDF-AGREE")]
+        )
+        mock_imap = MagicMock()
+        mock_imap.fetch_raw_message.return_value = raw
+        with contextlib.ExitStack() as stack:
+            for p in self._imap_patches(mock_imap):
+                stack.enter_context(p)
+            with patch.object(
+                AppleMailConnector, "_run_applescript"
+            ) as mock_as:
+                result = connector.save_attachments(
+                    "att-test@example.com",
+                    tmp_path,
+                    account="Gmail",
+                    mailbox="INBOX",
+                )
+            mock_as.assert_not_called()  # no AppleScript cross-scan
+
+        assert result["saved"] == 2
+        assert (tmp_path / "offer.pdf").read_bytes() == b"PDF-OFFER"
+        assert (tmp_path / "agreement.pdf").read_bytes() == b"PDF-AGREE"
+        mock_imap.fetch_raw_message.assert_called_once_with(
+            "att-test@example.com", "INBOX"
+        )
+
+    def test_imap_path_respects_attachment_indices(
+        self, connector: AppleMailConnector, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        raw = _raw_with_attachments([("a.pdf", "pdf", b"AAA"), ("b.pdf", "pdf", b"BBB")])
+        mock_imap = MagicMock()
+        mock_imap.fetch_raw_message.return_value = raw
+        with contextlib.ExitStack() as stack:
+            for p in self._imap_patches(mock_imap):
+                stack.enter_context(p)
+            with patch.object(AppleMailConnector, "_run_applescript"):
+                result = connector.save_attachments(
+                    "att-test@example.com",
+                    tmp_path,
+                    attachment_indices=[1],
+                    account="Gmail",
+                    mailbox="INBOX",
+                )
+        assert result["saved"] == 1
+        assert not (tmp_path / "a.pdf").exists()
+        assert (tmp_path / "b.pdf").read_bytes() == b"BBB"
+
+    def test_imap_failure_falls_back_to_applescript(
+        self, connector: AppleMailConnector, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        mock_imap = MagicMock()
+        mock_imap.fetch_raw_message.side_effect = OSError("conn reset")
+        with contextlib.ExitStack() as stack:
+            for p in self._imap_patches(mock_imap):
+                stack.enter_context(p)
+            with patch.object(
+                AppleMailConnector,
+                "_get_attachments_applescript",
+                return_value=[],
+            ) as mock_get_as:
+                result = connector.save_attachments(
+                    "att-test@example.com",
+                    tmp_path,
+                    account="Gmail",
+                    mailbox="INBOX",
+                )
+            mock_get_as.assert_called_once()  # fell through to AppleScript
+        assert result["saved"] == 0
+
+    def test_imap_path_enforces_per_attachment_cap(
+        self, connector: AppleMailConnector, tmp_path: Path
+    ) -> None:
+        import contextlib
+
+        raw = _raw_with_attachments([("big.bin", "octet-stream", b"x" * 100)])
+        mock_imap = MagicMock()
+        mock_imap.fetch_raw_message.return_value = raw
+        connector.max_attachment_bytes = 10  # tiny cap
+        with contextlib.ExitStack() as stack:
+            for p in self._imap_patches(mock_imap):
+                stack.enter_context(p)
+            with patch.object(AppleMailConnector, "_run_applescript"):
+                result = connector.save_attachments(
+                    "att-test@example.com",
+                    tmp_path,
+                    account="Gmail",
+                    mailbox="INBOX",
+                )
+        assert result["saved"] == 0
+        assert result["rejected"][0]["reason"] == "per_attachment_cap"
+        assert not (tmp_path / "big.bin").exists()
+
+
 class TestAutoTemplateVars:
     """auto_template_vars() builds the auto-fill dict for render_template."""
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2062,6 +2062,20 @@ class TestSaveAttachments:
         assert result["rejected"] == []
         mock_logger.log_operation.assert_called_once()
 
+    def test_account_mailbox_pass_through_for_imap_fast_path(
+        self, mock_mail: MagicMock, mock_logger: MagicMock, tmp_path: Any
+    ) -> None:
+        # #371: account/mailbox unlock the IMAP fast path in the connector.
+        mock_mail.save_attachments.return_value = {"saved": 1, "rejected": []}
+
+        save_attachments(
+            "1", str(tmp_path), account="Gmail", mailbox="INBOX"
+        )
+
+        kwargs = mock_mail.save_attachments.call_args.kwargs
+        assert kwargs["account"] == "Gmail"
+        assert kwargs["mailbox"] == "INBOX"
+
     def test_surfaces_rejected_attachments(
         self, mock_mail: MagicMock, mock_logger: MagicMock, tmp_path: Any
     ) -> None:


### PR DESCRIPTION
## Problem

Closes #371. `save_attachments` has no `account`/`mailbox` params, so it always locates the message via the O(accounts × mailboxes) AppleScript cross-scan. With an RFC 5322 Message-ID (what the IMAP read tools return) the numeric-`id` arm misses and it falls back to the **unindexed** `whose message id` (~20s/mailbox). On Gmail (dozens of labels) one call ran for minutes and timed out — the "hang" reported in #371. Its sibling `get_attachment_content` (#250) already had an IMAP fast path; `save_attachments` simply never got one.

## Fix

Add `account` + `mailbox` to the `save_attachments` tool and connector method. When both are supplied, dispatch (mirroring `get_attachment_content`) to a new `_imap_save_attachments` that:
- fetches the raw message **once** via `fetch_raw_message` and parses it with `parse_original_message` (same machinery and attachment ordering as `get_attachment_content`), then
- writes the selected attachment bytes straight to disk, reusing the existing #236 byte-cap (`_select_attachments_within_caps` / `_prune_oversized_written`) and path-traversal-safe target helper (`_compute_attachment_save_targets`).

The only genuinely new line is `Path.write_bytes(...)`. Without `account`/`mailbox`, the AppleScript fallback is unchanged (backward compatible).

## Tests (TDD, RED→GREEN)

- Connector unit: writes bytes & does **not** call `_run_applescript`; falls back to AppleScript on an `_IMAP_FALLBACK_EXCS` error; respects `attachment_indices`; enforces the per-attachment cap.
- Server unit: `account`/`mailbox` pass through.
- Integration: APPENDs a synthetic message with a known attachment to a throwaway mailbox and asserts the saved file is **byte-for-byte** (self-cleaning; skips without IMAP).

`make check-all` ✅ · unit + e2e → **1425 passed** (+5).

## Notes

- Pure-Python change (no AppleScript modified); the slow AppleScript path is retained as the fallback.
- Still-open follow-up from the #371 triage: `get_attachment_content` has no "save to a path" option (separate enhancement, not filed yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)