### PR TITLE
release: v0.10.2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and Apple Mail via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.10.1 | **Tests:** 1368 unit / 29 e2e / 59 integration | **Coverage:** 92%
+**Version:** v0.10.2 | **Tests:** 1396 unit / 29 e2e / 62 integration | **Coverage:** 92%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-06-13
+
+A bug-fix patch release for four reliability and data-integrity issues surfaced from real Claude Desktop usage on Gmail and iCloud: a full-body read that could crash the whole server, a Gmail label move that silently trashed the message, an IMAP search that silently dropped matching results, and an attachment save that hung for minutes on Gmail. No new tools (still 24).
+
+### Added
+
+**`save_attachments` IMAP fast path (#371):** `save_attachments` gains optional `account` + `mailbox` parameters. When supplied, the message is fetched once over IMAP and its attachment bytes are written straight to disk — avoiding the O(accounts × mailboxes) AppleScript cross-scan whose unindexed `whose message id` lookup (~20s/mailbox) ran for minutes and timed out on Gmail's many labels. Mirrors `get_attachment_content`'s fast path; without the parameters the AppleScript fallback is unchanged.
+
+**Truncation signal on `get_messages` (#365):** a bounded body carries `content_truncated: true` and `content_original_bytes: <int>` so callers can tell when a body was clipped.
+
+### Changed
+
+**`get_messages` bounds and scrubs message bodies (#365):** each `content` is now capped at 1 MB of UTF-8 text (override via `APPLE_MAIL_MCP_MAX_BODY_BYTES`) and stripped of transport-hostile characters before it leaves the tool, so a single large or non-UTF8-encodable body can't blow the JSON-RPC frame.
+
+### Deprecated
+
+**`gmail_mode` on `update_message` (#364):** the parameter is now accepted but ignored — the move strategy is chosen automatically (IMAP relabel when configured, otherwise a verified AppleScript move). Removal is tracked for v1.0 in #369.
+
+### Fixed
+
+**`get_messages` full-body fetch could crash the entire server (#365):** retrieving full bodies on iCloud returned `-32000: Connection closed` and took the whole stdio server down (every tool unavailable until relaunch). An unbounded, un-scrubbed body produced a JSON-RPC frame the client rejected — outside the tool's `try/except`. Bodies are now bounded and scrubbed at the single resolve chokepoint (covers the IMAP, AppleScript, and `SELECTED` paths).
+
+**Gmail INBOX→label move silently trashed the message (#364):** `update_message` with `gmail_mode=true` ran an AppleScript copy+delete; on Gmail `delete` always routes to Trash and Trash strips all other labels, so the destination label was lost and the message landed in `[Gmail]/Trash` only — while the tool still reported success. Moves now use a relabel (`set mailbox`) and verify the message left the source; an unconfirmed move fails loud with `error_type: "imap_required"` instead of losing mail.
+
+**IMAP `search_messages` `limit` bounded the candidate window, not the matches (#366, #368):** with `has_attachment` set, `limit` was applied before the post-FETCH filter, so a limited search silently missed attachment-bearing messages (observed live: 2 results at `limit=5` vs 6 at `limit=20` on the same mailbox). The IMAP path now walks candidates newest-first in bounded chunks and short-circuits once `limit` *matching* rows are found. (Contributed by @jason21wc.)
+
+**`save_attachments` hung and timed out on Gmail (#371):** see the IMAP fast path under Added — the cross-scan that caused the hang is now bypassed when `account`+`mailbox` are supplied.
+
 ## [0.10.1] - 2026-06-08
 
 A maintenance release. The one user-facing fix lets an iCloud account whose Apple ID is a third-party address (e.g. a Gmail sign-in) resolve its IMAP login. The rest is release-engineering hardening: a gate that makes the Phase 8.5 derived-artifact refresh impossible to skip silently — the gap that shipped a stale eval snapshot at v0.10.0 — and a more robust blind-eval model list that tracks each family's latest model and fails loud on retired ids.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An MCP server that provides programmatic access to Apple Mail, enabling AI assistants like Claude to read, send, search, and manage emails on macOS.
 
-> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-fast-mcp==0.10.1`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
+> ⚠️ **Pre-1.0 — expect breaking changes.** The MCP tool surface (tool names, parameters, return shapes) is still evolving as the project matures. Pin to a specific version (for example, `apple-mail-fast-mcp==0.10.2`) and review the [CHANGELOG](CHANGELOG.md) before upgrading.
 
 ## Tools (24)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apple-mail-fast-mcp"
-version = "0.10.1"
+version = "0.10.2"
 description = "MCP server for Apple Mail integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/release_artifact_waivers.txt
+++ b/release_artifact_waivers.txt
@@ -14,5 +14,4 @@
 # Entries are per-release; prune old ones freely. See
 # docs/guides/RELEASE_ARTIFACTS.md.
 
-v0.10.1 benchmark #354 maintenance release; only runtime change (#341 IMAP login resolution) touches no benchmarked hot path, so numbers would reproduce
-v0.10.1 eval #355 maintenance release; tool surface unchanged (still 24 tools), so blind-eval scores would reproduce
+v0.10.2 eval #373 additive tool-surface change (still 24 tools: added optional account/mailbox to save_attachments, content_truncated to get_messages, deprecated gmail_mode); OPENROUTER_API_KEY unavailable on the release runner, scores expected to reproduce, re-run tracked. (Benchmark baseline IS refreshed this release — #364 changed move_messages timing.)

--- a/src/apple_mail_mcp/__init__.py
+++ b/src/apple_mail_mcp/__init__.py
@@ -4,4 +4,4 @@ Apple Mail MCP Server
 A Model Context Protocol server for Apple Mail integration.
 """
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/tests/benchmarks/baseline.json
+++ b/tests/benchmarks/baseline.json
@@ -1,16 +1,16 @@
 {
-  "_version": "0.10.0",
-  "imap_repeat_5_calls_no_pool": 8.075,
-  "imap_repeat_5_calls_pooled": 5.234,
-  "mark_as_read_50_msgs": 1.426,
-  "move_messages_50_msgs": 3.698,
+  "_version": "0.10.2",
+  "imap_repeat_5_calls_no_pool": 9.424,
+  "imap_repeat_5_calls_pooled": 5.756,
+  "mark_as_read_50_msgs": 0.698,
+  "move_messages_50_msgs": 5.309,
   "move_messages_50_msgs_gmail": 2.94,
   "save_attachments_one_file": 0.432,
-  "search_messages_no_filter": 1.647,
+  "search_messages_no_filter": 2.117,
   "search_messages_no_filter_gmail": 1.537,
-  "search_messages_with_sender_filter": 1.474,
+  "search_messages_with_sender_filter": 1.66,
   "search_messages_with_sender_filter_gmail": 1.371,
-  "search_messages_with_zero_matches": 1.435,
+  "search_messages_with_zero_matches": 1.688,
   "search_messages_with_zero_matches_gmail": 1.355,
-  "update_message_move_50_msgs_imap": 4.42
+  "update_message_move_50_msgs_imap": 20.546
 }

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-fast-mcp"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Patch release bundling four reliability / data-integrity fixes surfaced from real Claude Desktop usage on Gmail and iCloud. See [CHANGELOG](CHANGELOG.md) for the full entry.

## Included
- **#365** — `get_messages` bounds (1 MB) + scrubs message bodies so an oversized/non-UTF8 body can't crash the stdio server.
- **#366** — IMAP `search_messages` `limit` bounds *matching* results (not the candidate window) when `has_attachment` is set. (Contributed by @jason21wc.)
- **#364** — Gmail INBOX→label move no longer trashes the message; verified `set mailbox` move that fails loud (`imap_required`); `gmail_mode` deprecated (removal tracked #369).
- **#371** — `save_attachments` gains an `account`/`mailbox` IMAP fast path, avoiding the cross-scan that hung on Gmail.

## Release checklist
- ✅ Milestone v0.10.2: 0 open issues
- ✅ Version bumped (pyproject, `__init__`, CLAUDE.md, README); CHANGELOG written
- ✅ Coverage 92.4% (≥90); `make test` 1396; `make test-e2e` 29
- ✅ Cumulative code review — no blockers
- ✅ All gates: version-sync, parity, complexity, applescript-safety, dependencies, docs
- ✅ Benchmark baseline refreshed and stamped v0.10.2 (recaptured `move_messages` timing changed by #364)
- ⚠️ Blind-eval snapshot refresh **waived** (additive surface change, still 24 tools; `OPENROUTER_API_KEY` unavailable on the release runner) — tracked in **#373**

🤖 Generated with [Claude Code](https://claude.com/claude-code)