### PR TITLE
fix(#337): rebrand Keychain service prefixes with read-through fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ eval-descriptions:
 	uv run python evals/agent_tool_usability/generate_descriptions.py
 
 # Run the blind agent tool-usability eval against the open-weight OpenRouter
-# models (needs an OPENROUTER_API_KEY env var or the apple-mail-mcp-evals /
+# models (needs an OPENROUTER_API_KEY env var or the apple-mail-fast-mcp-evals /
 # openrouter Keychain entry; costs money). The Claude column is produced
 # separately via a Claude Code subagent. See evals/agent_tool_usability/. (#219)
 #

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ On first run, macOS will prompt for Automation access. Grant permission in:
    Substitute the Mail.app account name exactly — whatever it's labeled in Mail.app (e.g. `iCloud`, `Gmail`, `"Yahoo!"`). The CLI:
    - looks up the account's primary email from Mail.app (override with `--email`, which is **persisted** so runtime uses the same login — see the iCloud quirk below),
    - prompts via `getpass` so the password never lands in shell history,
-   - writes to Keychain at `apple-mail-mcp.imap.<account>` (idempotent — re-running with a new password updates the existing entry),
+   - writes to Keychain at `apple-mail-fast-mcp.imap.<account>` (idempotent — re-running with a new password updates the existing entry; pre-rename `apple-mail-mcp.imap.` entries still resolve via a read-through fallback removed at 1.0.0),
    - opens an IMAP connection and runs a real LOGIN to confirm the password works. On rejection it rolls back the Keychain entry so you can retry without leaving a broken item behind.
 
 3. If you see a one-time "security wants to use the 'login' keychain" prompt on the next IMAP-backed call, click **Always Allow**.

--- a/evals/agent_tool_usability/README.md
+++ b/evals/agent_tool_usability/README.md
@@ -35,8 +35,11 @@ pip install openai
 Store your OpenRouter key in the macOS Keychain:
 
 ```bash
-security add-generic-password -a "openrouter" -s "apple-mail-mcp-evals" -w "YOUR_KEY"
+security add-generic-password -a "openrouter" -s "apple-mail-fast-mcp-evals" -w "YOUR_KEY"
 ```
+
+(Keys stored under the old `apple-mail-mcp-evals` service still resolve via a
+read-through fallback, removed at 1.0.0.)
 
 Then run:
 

--- a/evals/agent_tool_usability/run_eval.py
+++ b/evals/agent_tool_usability/run_eval.py
@@ -18,7 +18,7 @@ Usage:
     python run_eval.py --model meta-llama/llama-3.3-70b-instruct --scenarios 1,2,3
 
 Requires OPENROUTER_API_KEY in macOS Keychain or environment variable.
-Store in Keychain: security add-generic-password -a "openrouter" -s "apple-mail-mcp-evals" -w "KEY"
+Store in Keychain: security add-generic-password -a "openrouter" -s "apple-mail-fast-mcp-evals" -w "KEY"
 """
 
 import argparse
@@ -62,8 +62,24 @@ TOOL_NAMES = [
     "reply_to_message", "forward_message",
 ]
 
-KEYCHAIN_SERVICE = "apple-mail-mcp-evals"
+KEYCHAIN_SERVICE = "apple-mail-fast-mcp-evals"
+# Read-through fallback for keys stored before the #335/#337 rebrand. Drop at 1.0.0.
+_LEGACY_KEYCHAIN_SERVICE = "apple-mail-mcp-evals"
 KEYCHAIN_ACCOUNT = "openrouter"
+
+
+def _keychain_lookup(service: str) -> str:
+    """Return the stored key for a service, or "" if absent/unavailable."""
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-a", KEYCHAIN_ACCOUNT, "-s", service, "-w"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass  # Not on macOS or security command unavailable
+    return ""
 
 
 def get_api_key() -> str:
@@ -71,27 +87,22 @@ def get_api_key() -> str:
 
     Lookup order:
         1. OPENROUTER_API_KEY environment variable
-        2. macOS Keychain (service: apple-mail-mcp-evals, account: openrouter)
+        2. macOS Keychain (service: apple-mail-fast-mcp-evals, account: openrouter;
+           falls back to the old apple-mail-mcp-evals service — #337)
         3. .env file at project root (deprecated — prints warning)
 
     To store your key in Keychain:
-        security add-generic-password -a "openrouter" -s "apple-mail-mcp-evals" -w "YOUR_KEY"
+        security add-generic-password -a "openrouter" -s "apple-mail-fast-mcp-evals" -w "YOUR_KEY"
     """
     # 1. Environment variable
     api_key = os.environ.get("OPENROUTER_API_KEY")
     if api_key:
         return api_key
 
-    # 2. macOS Keychain
-    try:
-        result = subprocess.run(
-            ["security", "find-generic-password", "-a", KEYCHAIN_ACCOUNT, "-s", KEYCHAIN_SERVICE, "-w"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass  # Not on macOS or security command unavailable
+    # 2. macOS Keychain — prefer the new service, fall back to the legacy one.
+    api_key = _keychain_lookup(KEYCHAIN_SERVICE) or _keychain_lookup(_LEGACY_KEYCHAIN_SERVICE)
+    if api_key:
+        return api_key
 
     # 3. .env file (deprecated fallback)
     env_path = SCRIPT_DIR.parent.parent / ".env"
@@ -407,7 +418,7 @@ def main():
     if not api_key:
         print("Error: OPENROUTER_API_KEY not found.")
         print("Store it in macOS Keychain:")
-        print('  security add-generic-password -a "openrouter" -s "apple-mail-mcp-evals" -w "YOUR_KEY"')
+        print('  security add-generic-password -a "openrouter" -s "apple-mail-fast-mcp-evals" -w "YOUR_KEY"')
         print("Or set OPENROUTER_API_KEY as an environment variable.")
         sys.exit(1)
 

--- a/src/apple_mail_mcp/cli.py
+++ b/src/apple_mail_mcp/cli.py
@@ -160,7 +160,7 @@ def run_setup_imap(
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
     print(
-        f"Stored in Keychain as 'apple-mail-mcp.imap.{account_name}'."
+        f"Stored in Keychain as 'apple-mail-fast-mcp.imap.{account_name}'."
     )
     # Persist an explicit --email as a login override so runtime resolution
     # (_resolve_imap_config) uses the same login this setup verifies — without

--- a/src/apple_mail_mcp/keychain.py
+++ b/src/apple_mail_mcp/keychain.py
@@ -1,11 +1,18 @@
 """macOS Keychain password storage / retrieval for IMAP credentials.
 
 Entries live under service name
-``apple-mail-mcp.imap.<mail_app_account_name>`` keyed by the account's
+``apple-mail-fast-mcp.imap.<mail_app_account_name>`` keyed by the account's
 email. The ``apple-mail-fast-mcp setup-imap`` CLI is the supported way to
 write entries; this module also exposes set/delete helpers that the
 CLI uses, plus the read helper used by the IMAP fallback path at
 runtime.
+
+Read-through fallback (#337): the brand was renamed in #335. Reads and
+deletes prefer the new ``apple-mail-fast-mcp.imap.`` prefix and fall back to
+the pre-rename ``apple-mail-mcp.imap.`` prefix on a NotFound miss, so existing
+entries keep working with zero user action. Writes go to the new prefix only.
+The fallback is dropped at 1.0.0 (documented breaking change — re-run
+``setup-imap``).
 
 See ``docs/research/imap-auth-options-decision.md`` for the chosen
 auth path and the service-name convention, and
@@ -19,6 +26,7 @@ import logging
 import os
 import re
 import subprocess
+from typing import NoReturn
 
 from apple_mail_mcp.exceptions import (
     MailKeychainAccessDeniedError,
@@ -28,7 +36,11 @@ from apple_mail_mcp.exceptions import (
 
 logger = logging.getLogger(__name__)
 
-SERVICE_NAME_PREFIX = "apple-mail-mcp.imap."
+SERVICE_NAME_PREFIX = "apple-mail-fast-mcp.imap."
+
+# Read/delete fallback for entries written before the #335 rebrand.
+# Drop at 1.0.0 (the breaking-change follow-up to #337).
+_LEGACY_SERVICE_NAME_PREFIX = "apple-mail-mcp.imap."
 
 # Env-var fallback for the IMAP password (#248). Convention:
 # APPLE_MAIL_MCP_IMAP_PASSWORD_<SUFFIX>, where <SUFFIX> is the account name
@@ -56,6 +68,91 @@ def _env_var_name(mail_app_account: str) -> str | None:
     if not suffix:
         return None
     return IMAP_PASSWORD_ENV_PREFIX + suffix
+
+
+def _run_security(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Invoke ``security`` capturing output; map a missing binary to
+    ``MailKeychainError`` (the only failure not signalled via exit code)."""
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise MailKeychainError(f"`security` binary not found: {exc}") from exc
+
+
+def _raise_security_failure(
+    result: subprocess.CompletedProcess[str],
+    service: str,
+    email: str,
+    action: str,
+) -> NoReturn:
+    """Map a non-zero ``security`` exit to the right exception. NotFound is
+    handled by callers (it drives the legacy-prefix fallback); this raises
+    AccessDenied vs. a generic Keychain error for everything else."""
+    stderr = result.stderr or ""
+    if result.returncode == _EXIT_INTERACTION_NOT_ALLOWED or any(
+        marker in stderr for marker in _ACCESS_DENIED_MARKERS
+    ):
+        raise MailKeychainAccessDeniedError(
+            f"Keychain access denied for service={service!r}, account={email!r}: "
+            f"{stderr.strip()}"
+        )
+    raise MailKeychainError(
+        f"security {action} failed (exit {result.returncode}): "
+        f"{stderr.strip()}"
+    )
+
+
+def _find_password(service: str, email: str) -> str:
+    """Read one Keychain entry for an exact service name. Raises
+    ``MailKeychainEntryNotFoundError`` on a miss (lets the caller fall back to
+    the legacy prefix), or AccessDenied / generic errors via
+    ``_raise_security_failure``."""
+    result = _run_security(
+        [
+            "security",
+            "find-generic-password",
+            "-w",
+            "-s",
+            service,
+            "-a",
+            email,
+        ]
+    )
+    if result.returncode == 0:
+        return result.stdout.rstrip("\n")
+    if result.returncode == _EXIT_ITEM_NOT_FOUND:
+        raise MailKeychainEntryNotFoundError(
+            f"No Keychain entry for service={service!r}, account={email!r}."
+        )
+    _raise_security_failure(result, service, email, "find-generic-password")
+
+
+def _delete_password(service: str, email: str) -> None:
+    """Delete one Keychain entry for an exact service name. Raises
+    ``MailKeychainEntryNotFoundError`` on a miss (lets the caller fall back to
+    the legacy prefix), or AccessDenied / generic errors."""
+    result = _run_security(
+        [
+            "security",
+            "delete-generic-password",
+            "-s",
+            service,
+            "-a",
+            email,
+        ]
+    )
+    if result.returncode == 0:
+        return
+    if result.returncode == _EXIT_ITEM_NOT_FOUND:
+        raise MailKeychainEntryNotFoundError(
+            f"No Keychain entry for service={service!r}, account={email!r}."
+        )
+    _raise_security_failure(result, service, email, "delete-generic-password")
 
 
 def get_imap_password(mail_app_account: str, email: str) -> str:
@@ -93,47 +190,15 @@ def get_imap_password(mail_app_account: str, email: str) -> str:
             # the password fails LOGIN. Mirrors the Keychain path's rstrip.
             # (#349)
             return env_pw.strip()
-    service = SERVICE_NAME_PREFIX + mail_app_account
+    # Read-through fallback (#337): prefer the new prefix, retry the legacy one
+    # only on a NotFound miss. AccessDenied / generic errors propagate from the
+    # first attempt — they're explicit macOS signals, not "wrong prefix".
     try:
-        result = subprocess.run(
-            [
-                "security",
-                "find-generic-password",
-                "-w",
-                "-s",
-                service,
-                "-a",
-                email,
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
+        return _find_password(SERVICE_NAME_PREFIX + mail_app_account, email)
+    except MailKeychainEntryNotFoundError:
+        return _find_password(
+            _LEGACY_SERVICE_NAME_PREFIX + mail_app_account, email
         )
-    except FileNotFoundError as exc:
-        raise MailKeychainError(f"`security` binary not found: {exc}") from exc
-
-    if result.returncode == 0:
-        return result.stdout.rstrip("\n")
-
-    stderr = result.stderr or ""
-
-    if result.returncode == _EXIT_ITEM_NOT_FOUND:
-        raise MailKeychainEntryNotFoundError(
-            f"No Keychain entry for service={service!r}, account={email!r}."
-        )
-
-    if result.returncode == _EXIT_INTERACTION_NOT_ALLOWED or any(
-        marker in stderr for marker in _ACCESS_DENIED_MARKERS
-    ):
-        raise MailKeychainAccessDeniedError(
-            f"Keychain access denied for service={service!r}, account={email!r}: "
-            f"{stderr.strip()}"
-        )
-
-    raise MailKeychainError(
-        f"security find-generic-password failed (exit {result.returncode}): "
-        f"{stderr.strip()}"
-    )
 
 
 def set_imap_password(
@@ -156,43 +221,24 @@ def set_imap_password(
         MailKeychainAccessDeniedError: ACL or user denial.
         MailKeychainError: Any other ``security(1)`` failure.
     """
+    # Writes go to the new prefix only (#337); no legacy fallback on writes.
     service = SERVICE_NAME_PREFIX + mail_app_account
-    try:
-        result = subprocess.run(
-            [
-                "security",
-                "add-generic-password",
-                "-s",
-                service,
-                "-a",
-                email,
-                "-w",
-                password,
-                "-U",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except FileNotFoundError as exc:
-        raise MailKeychainError(f"`security` binary not found: {exc}") from exc
-
+    result = _run_security(
+        [
+            "security",
+            "add-generic-password",
+            "-s",
+            service,
+            "-a",
+            email,
+            "-w",
+            password,
+            "-U",
+        ]
+    )
     if result.returncode == 0:
         return
-
-    stderr = result.stderr or ""
-    if result.returncode == _EXIT_INTERACTION_NOT_ALLOWED or any(
-        marker in stderr for marker in _ACCESS_DENIED_MARKERS
-    ):
-        raise MailKeychainAccessDeniedError(
-            f"Keychain access denied for service={service!r}, account={email!r}: "
-            f"{stderr.strip()}"
-        )
-
-    raise MailKeychainError(
-        f"security add-generic-password failed (exit {result.returncode}): "
-        f"{stderr.strip()}"
-    )
+    _raise_security_failure(result, service, email, "add-generic-password")
 
 
 def delete_imap_password(mail_app_account: str, email: str) -> None:
@@ -207,41 +253,9 @@ def delete_imap_password(mail_app_account: str, email: str) -> None:
         MailKeychainAccessDeniedError: ACL or user denial.
         MailKeychainError: Any other ``security(1)`` failure.
     """
-    service = SERVICE_NAME_PREFIX + mail_app_account
+    # Delete-through fallback (#337): try the new prefix, then the legacy one
+    # on a NotFound miss, so a pre-rename entry can still be removed.
     try:
-        result = subprocess.run(
-            [
-                "security",
-                "delete-generic-password",
-                "-s",
-                service,
-                "-a",
-                email,
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except FileNotFoundError as exc:
-        raise MailKeychainError(f"`security` binary not found: {exc}") from exc
-
-    if result.returncode == 0:
-        return
-
-    stderr = result.stderr or ""
-    if result.returncode == _EXIT_ITEM_NOT_FOUND:
-        raise MailKeychainEntryNotFoundError(
-            f"No Keychain entry for service={service!r}, account={email!r}."
-        )
-    if result.returncode == _EXIT_INTERACTION_NOT_ALLOWED or any(
-        marker in stderr for marker in _ACCESS_DENIED_MARKERS
-    ):
-        raise MailKeychainAccessDeniedError(
-            f"Keychain access denied for service={service!r}, account={email!r}: "
-            f"{stderr.strip()}"
-        )
-
-    raise MailKeychainError(
-        f"security delete-generic-password failed (exit {result.returncode}): "
-        f"{stderr.strip()}"
-    )
+        _delete_password(SERVICE_NAME_PREFIX + mail_app_account, email)
+    except MailKeychainEntryNotFoundError:
+        _delete_password(_LEGACY_SERVICE_NAME_PREFIX + mail_app_account, email)

--- a/tests/integration/test_imap_connector.py
+++ b/tests/integration/test_imap_connector.py
@@ -3,9 +3,12 @@
 Guarded by ``MAIL_TEST_MODE=true``. Requires a Keychain entry:
 
     security add-generic-password \\
-        -s "apple-mail-mcp.imap.iCloud" \\
+        -s "apple-mail-fast-mcp.imap.iCloud" \\
         -a "s.morgan.jeffries@icloud.com" \\
         -w "<APP_PASSWORD>" -T "" -U
+
+(Pre-rename ``apple-mail-mcp.imap.`` entries still resolve via the #337
+read-through fallback.)
 
 Run:
 

--- a/tests/integration/test_imap_delegation.py
+++ b/tests/integration/test_imap_delegation.py
@@ -5,10 +5,13 @@ entry keyed to the Apple ID email (what Mail.app returns for `user name`),
 not an @icloud.com alias::
 
     security add-generic-password \\
-        -s "apple-mail-mcp.imap.iCloud" \\
+        -s "apple-mail-fast-mcp.imap.iCloud" \\
         -a "<apple-id-email>" \\
         -w "<APP_PASSWORD>" \\
         -T "" -U
+
+(Pre-rename ``apple-mail-mcp.imap.`` entries still resolve via the #337
+read-through fallback, so an existing entry works without re-creation.)
 
 Run:
 
@@ -34,13 +37,17 @@ def _test_mode_enabled() -> bool:
 
 
 def _keychain_entry_exists(account_name: str, email: str) -> bool:
-    service = f"apple-mail-mcp.imap.{account_name}"
-    result = subprocess.run(
-        ["security", "find-generic-password", "-s", service, "-a", email],
-        capture_output=True,
-        check=False,
-    )
-    return result.returncode == 0
+    # Mirror the runtime read-through fallback (#337): an entry under either
+    # the new or the legacy prefix means IMAP is set up for this account.
+    for prefix in ("apple-mail-fast-mcp.imap.", "apple-mail-mcp.imap."):
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", prefix + account_name, "-a", email],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return True
+    return False
 
 
 @pytest.fixture
@@ -64,7 +71,7 @@ class TestIMAPDelegation:
         if not _keychain_entry_exists(ICLOUD_ACCOUNT_NAME, email):
             pytest.skip(
                 f"No Keychain entry under "
-                f"apple-mail-mcp.imap.{ICLOUD_ACCOUNT_NAME} for {email}. "
+                f"apple-mail-fast-mcp.imap.{ICLOUD_ACCOUNT_NAME} for {email}. "
                 f"See the test file's module docstring for setup."
             )
 
@@ -156,7 +163,7 @@ class TestIMAPDelegation:
         if not _keychain_entry_exists(ICLOUD_ACCOUNT_NAME, email):
             pytest.skip(
                 f"No Keychain entry under "
-                f"apple-mail-mcp.imap.{ICLOUD_ACCOUNT_NAME} for {email}."
+                f"apple-mail-fast-mcp.imap.{ICLOUD_ACCOUNT_NAME} for {email}."
             )
 
         # Find any iCloud message to use as anchor.

--- a/tests/unit/test_keychain.py
+++ b/tests/unit/test_keychain.py
@@ -10,6 +10,7 @@ from apple_mail_mcp.exceptions import (
     MailKeychainError,
 )
 from apple_mail_mcp.keychain import (
+    _LEGACY_SERVICE_NAME_PREFIX,
     IMAP_PASSWORD_ENV_PREFIX,
     SERVICE_NAME_PREFIX,
     _env_var_name,
@@ -41,8 +42,12 @@ def _clear_imap_password_env(monkeypatch):
 
 
 class TestServiceNamePrefix:
-    def test_prefix_matches_decision_doc(self):
-        assert SERVICE_NAME_PREFIX == "apple-mail-mcp.imap."
+    def test_prefix_uses_new_brand(self):
+        assert SERVICE_NAME_PREFIX == "apple-mail-fast-mcp.imap."
+
+    def test_legacy_prefix_is_old_brand(self):
+        # Read-through fallback target for pre-#335 entries. Drop at 1.0.0.
+        assert _LEGACY_SERVICE_NAME_PREFIX == "apple-mail-mcp.imap."
 
 
 class TestHappyPath:
@@ -62,7 +67,7 @@ class TestHappyPath:
             "find-generic-password",
             "-w",
             "-s",
-            "apple-mail-mcp.imap.iCloud",
+            "apple-mail-fast-mcp.imap.iCloud",
             "-a",
             "user@icloud.com",
         ]
@@ -125,6 +130,66 @@ class TestOtherFailure:
             get_imap_password("iCloud", "u@i.com")
 
 
+def _service_of(call) -> str:
+    """Extract the service string (value after '-s') from a security call."""
+    cmd = call[0][0]
+    return cmd[cmd.index("-s") + 1]
+
+
+class TestReadThroughFallback:
+    """#337: get_imap_password prefers the new prefix, falls back to the old
+    one on a NotFound miss so pre-#335 entries keep resolving."""
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_new_prefix_hit_does_not_touch_legacy(self, mock_run):
+        mock_run.return_value = _mock_security(0, stdout="newpw\n")
+        assert get_imap_password("iCloud", "u@i.com") == "newpw"
+        mock_run.assert_called_once()
+        assert _service_of(mock_run.call_args) == "apple-mail-fast-mcp.imap.iCloud"
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_new_miss_falls_back_to_legacy_prefix(self, mock_run):
+        mock_run.side_effect = [
+            _mock_security(44, stderr="not found"),
+            _mock_security(0, stdout="legacypw\n"),
+        ]
+        assert get_imap_password("iCloud", "u@i.com") == "legacypw"
+        assert mock_run.call_count == 2
+        services = [_service_of(c) for c in mock_run.call_args_list]
+        assert services == [
+            "apple-mail-fast-mcp.imap.iCloud",
+            "apple-mail-mcp.imap.iCloud",
+        ]
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_both_miss_raises_entry_not_found(self, mock_run):
+        mock_run.side_effect = [
+            _mock_security(44, stderr="not found"),
+            _mock_security(44, stderr="not found"),
+        ]
+        with pytest.raises(MailKeychainEntryNotFoundError):
+            get_imap_password("iCloud", "u@i.com")
+        assert mock_run.call_count == 2
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_access_denied_does_not_fall_back(self, mock_run):
+        # AccessDenied is an explicit macOS signal — surface it, don't mask
+        # it by probing the legacy prefix.
+        mock_run.return_value = _mock_security(
+            128, stderr="User interaction is not allowed."
+        )
+        with pytest.raises(MailKeychainAccessDeniedError):
+            get_imap_password("iCloud", "u@i.com")
+        mock_run.assert_called_once()
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_generic_error_does_not_fall_back(self, mock_run):
+        mock_run.return_value = _mock_security(2, stderr="some other failure")
+        with pytest.raises(MailKeychainError):
+            get_imap_password("iCloud", "u@i.com")
+        mock_run.assert_called_once()
+
+
 class TestSetImapPassword:
     @patch("apple_mail_mcp.keychain.subprocess.run")
     def test_writes_via_security_with_update_flag(self, mock_run):
@@ -136,7 +201,7 @@ class TestSetImapPassword:
             "security",
             "add-generic-password",
             "-s",
-            "apple-mail-mcp.imap.iCloud",
+            "apple-mail-fast-mcp.imap.iCloud",
             "-a",
             "user@icloud.com",
             "-w",
@@ -185,7 +250,7 @@ class TestDeleteImapPassword:
             "security",
             "delete-generic-password",
             "-s",
-            "apple-mail-mcp.imap.iCloud",
+            "apple-mail-fast-mcp.imap.iCloud",
             "-a",
             "user@icloud.com",
         ]
@@ -217,6 +282,52 @@ class TestDeleteImapPassword:
         with pytest.raises(MailKeychainError) as exc_info:
             delete_imap_password("iCloud", "u@i.com")
         assert type(exc_info.value) is MailKeychainError
+
+
+class TestDeleteThroughFallback:
+    """#337: delete_imap_password tries the new prefix, then the old on a
+    NotFound miss, so a legacy user's setup-imap delete can still remove
+    their real (old-prefix) entry."""
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_new_prefix_hit_does_not_touch_legacy(self, mock_run):
+        mock_run.return_value = _mock_security(0)
+        delete_imap_password("iCloud", "u@i.com")
+        mock_run.assert_called_once()
+        assert _service_of(mock_run.call_args) == "apple-mail-fast-mcp.imap.iCloud"
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_new_miss_falls_back_to_legacy_prefix(self, mock_run):
+        mock_run.side_effect = [
+            _mock_security(44, stderr="not found"),
+            _mock_security(0),
+        ]
+        delete_imap_password("iCloud", "u@i.com")
+        assert mock_run.call_count == 2
+        services = [_service_of(c) for c in mock_run.call_args_list]
+        assert services == [
+            "apple-mail-fast-mcp.imap.iCloud",
+            "apple-mail-mcp.imap.iCloud",
+        ]
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_both_miss_raises_entry_not_found(self, mock_run):
+        mock_run.side_effect = [
+            _mock_security(44, stderr="not found"),
+            _mock_security(44, stderr="not found"),
+        ]
+        with pytest.raises(MailKeychainEntryNotFoundError):
+            delete_imap_password("iCloud", "u@i.com")
+        assert mock_run.call_count == 2
+
+    @patch("apple_mail_mcp.keychain.subprocess.run")
+    def test_access_denied_does_not_fall_back(self, mock_run):
+        mock_run.return_value = _mock_security(
+            128, stderr="User interaction is not allowed."
+        )
+        with pytest.raises(MailKeychainAccessDeniedError):
+            delete_imap_password("iCloud", "u@i.com")
+        mock_run.assert_called_once()
 
 
 class TestEnvVarName:

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -7290,9 +7290,14 @@ class TestKeychainDualFormLookup:
         )
         assert result == "ENV-PW"
         # Only the UUID form shelled out to `security`; the name form was
-        # satisfied by the env var without a Keychain call.
-        assert len(run_calls) == 1
-        assert "apple-mail-mcp.imap.04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16" in run_calls[0]
+        # satisfied by the env var without a Keychain call. The UUID form
+        # probes both prefixes (new, then legacy on the NotFound miss — #337).
+        assert len(run_calls) == 2
+        services = [cmd[cmd.index("-s") + 1] for cmd in run_calls]
+        assert services == [
+            "apple-mail-fast-mcp.imap.04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16",
+            "apple-mail-mcp.imap.04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16",
+        ]
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #337.

Completes the #335 rebrand for the two Keychain identifiers deliberately left on the old brand (renaming them outright would orphan stored credentials).

## What changed
**0.11.0 plan (decided in #337):** switch the *preferred* name to the new brand with a **NotFound-only read-through fallback** to the old name, so existing entries keep resolving with zero user action.

- **IMAP prefix** (`keychain.py`): preferred `apple-mail-fast-mcp.imap.`, falls back to `apple-mail-mcp.imap.` on a miss.
  - **read** prefers new, falls back to legacy
  - **write** → new prefix only (passive read-through; no migrate-on-write)
  - **delete** falls back to legacy, so a pre-rename entry can still be removed via `setup-imap`
  - AccessDenied / generic errors propagate from the first attempt — never retried (matches the #243 fallback rationale). Composes with the existing name↔UUID `_get_imap_password_with_fallback`.
  - Refactored the three near-duplicate `security` blocks into shared helpers (`_run_security`, `_raise_security_failure`, `_find_password`, `_delete_password`).
- **Eval key** (`run_eval.py`): prefers `apple-mail-fast-mcp-evals`, falls back to the old service.
- **Doc/string sweep**: README, `setup-imap` confirmation message, Makefile, evals README, integration-test docstrings; the integration presence-check now mirrors the runtime fallback (resolves under either prefix).

## Out of scope
- Env vars (`APPLE_MAIL_MCP_IMAP_PASSWORD_*`, `APPLE_MAIL_MCP_HOME`) — not Keychain entries; renaming is a separate breaking change.
- **1.0.0**: drop the fallback (documented breaking change — "re-run `setup-imap`"). Separate follow-up.
- **CHANGELOG**: deferred to the release branch per project convention.

## Tests
11 new unit tests (read + delete fallback: new-hit, miss→legacy, both-miss→NotFound, AccessDenied-not-retried), updated existing prefix assertions, and updated the composed name/UUID + prefix test in `test_mail_connector.py`.

`make check-all` green: 1406 unit tests, lint, typecheck, complexity, version-sync, parity.

> Note: `run_eval.py` imports `openai` (eval-only, not a project dep), so it can't be imported in the unit-test env — its fallback is maintainer-verified, not unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)