### PR TITLE
research(#376): spike local-DB fast read path — GO recommendation (measured)

### DIFF
--- a/docs/research/local-db-read-path-spike.md
+++ b/docs/research/local-db-read-path-spike.md
@@ -67,15 +67,38 @@ by walking the account subtree cost ~1.9 s (60k+ files). Metadata is instant; bo
 is not. A production path needs either (a) a derived shard path from `ROWID`, or (b) a
 `ROWID → path` index built once and watched. **Don't ship body fetch via `rglob`.**
 
+## Finding 4 — Writes & sync freshness (coherence model)
+
+The Envelope Index is in **WAL mode** (`-wal`/`-shm` present); Mail.app is its **sole writer**.
+Implications for a read-only accelerator:
+
+- **Writes are unchanged & safe.** We only read (`mode=ro`); we never write the local DB, so no
+  dual-write/corruption hazard. All mutations stay on AppleScript/IMAP.
+- **Read-after-write coherence.** AppleScript writes go *through* Mail.app, which updates the
+  Envelope Index as part of the op → a later local-DB read sees it once the WAL txn commits
+  (near-immediate; exact lag unmeasured — a safe bench-mailbox measurement is a follow-up).
+  **Our IMAP fast-path writes bypass Mail.app**, so the Envelope Index — *and the current
+  AppleScript read path* — won't reflect them until Mail.app re-syncs. This wrinkle already
+  exists for AppleScript today; local-DB inherits it, doesn't worsen it.
+- **Freshness == the AppleScript path.** The local store is only as fresh as Mail.app's last
+  sync (seconds with Mail.app running + IMAP IDLE/push; stale if Mail.app is closed). This is
+  *identical* to the AppleScript path's freshness — both read Mail.app's local store. Only the
+  **IMAP path is server-authoritative.** → Dispatch rule: local-DB may front the **AppleScript**
+  path (strict win: same freshness, ~5,000× faster) but must **not** front the **IMAP** path
+  when an account needs server-fresh reads.
+- **WAL read gotcha.** Open `mode=ro` (reads the `-wal`); do **not** use `immutable=1` — it
+  skips the WAL and yields stale reads.
+
 ## Answers to the issue's open questions
 
 - **Full Disk Access tradeoff.** Real: today we need only Automation; this adds FDA (the spike
   was blocked until granted). FDA to the host app is broad. → **Gate behind an explicit opt-in
   flag** (e.g. `--local-db` / env), default off; degrade to AppleScript/IMAP when unavailable.
   Composes with `--read-only` (#217) for a "fast, read-only" deployment posture.
-- **Cache/invalidation.** Envelope Index is Mail's own live DB — reads are always current; open
-  `mode=ro` per query (cheap: 0.4 ms). A `ROWID→path` cache for bodies needs invalidation
-  (FSEvents watcher or TTL). EWS/Exchange accounts may have no `.emlx` (per che) → fall back.
+- **Cache/invalidation.** Envelope Index is Mail's own live DB — no metadata cache needed; open
+  `mode=ro` per query (cheap: 0.4 ms) and you read Mail's current local state (freshness caveats
+  in Finding 4). A `ROWID→path` cache for bodies needs invalidation (FSEvents watcher or TTL).
+  EWS/Exchange accounts may have no `.emlx` (per che) → fall back.
 - **Schema-stability risk.** We read `V10` + a handful of columns (`messages`, `subjects`,
   `addresses`, `mailboxes`, `message_global_data`). Apple bumps `V<n>` across major macOS
   releases and can rename columns. → Version-detect the `V*` dir, feature-probe columns at

--- a/docs/research/local-db-read-path-spike.md
+++ b/docs/research/local-db-read-path-spike.md
@@ -1,0 +1,117 @@
+# Local-DB Fast Read Path — Spike Findings & Recommendation
+
+**Status:** Output of #376 (spike). **Recommendation: GO** — pursue a local-DB read
+accelerator behind an opt-in flag. Measured 4,000–7,000× faster than AppleScript and
+100–800× faster than IMAP for metadata search on a real 32k-message mailbox; one current
+query type (`subject_contains`) *fails* today by exceeding the 60s timeout.
+**Related issues:** #376, #331 (origin), #217 (read-only mode — composes), #72/#243/#205
+(dispatch & id scheme this must mirror).
+**Date:** 2026-06-15
+
+## Question
+
+#331 surfaced a strategic gap: three competitors (imdinu FTS5, che Swift/SQLite, rusty Rust)
+get millisecond search on large mailboxes by reading Apple Mail's on-disk store directly;
+imdinu publishes benchmarks weaponized against AppleScript servers like ours. #376 asked: is a
+local-DB read path (reading `~/Library/Mail/V*/MailData/Envelope Index` + `.emlx`) beneath
+`search_messages`/`get_messages` worth building? Spike scope was research, not production
+wiring — keep AppleScript + IMAP as fallback; writes stay where they are.
+
+## Method
+
+Throwaway prototype + benchmark (kept in `scripts/`, clearly marked, mirroring the existing
+`scripts/spike_imap_*.py` convention):
+- `scripts/spike_localdb_envelope.py` — read-only (`mode=ro`) Envelope Index reader producing
+  the connector's common row shape, plus an `.emlx` body parser.
+- `scripts/spike_localdb_bench.py` — times identical queries through local-DB vs
+  `_search_messages_applescript` vs `_imap_search` on the same account/mailbox.
+
+Environment: spike author's machine, **real Gmail INBOX = 32,623 messages** (whole store =
+128,469 messages / 176 MB Envelope Index). Medians; local-DB n=3, AppleScript n=1 (slow),
+IMAP n=2. Single-machine/single-mailbox — treat magnitudes, not exact ms, as the signal.
+
+## Finding 1 — Speed (the headline)
+
+| query (INBOX, limit 50) | local-DB | AppleScript | IMAP |
+|---|---|---|---|
+| recent 50, no filter | **0.4 ms** | 9,275 ms | 2,289 ms |
+| `sender_contains`, unread | **2.3 ms** | 31,435 ms | 1,812 ms |
+| `subject_contains` | **19.7 ms** | **136,993 ms** | 1,858 ms |
+
+- local-DB is **~4,000–7,000× faster than AppleScript**, **~100–800× faster than IMAP**.
+- `subject_contains` via AppleScript took **137 s** — past our 60s default timeout, so that
+  query **fails today** on a large mailbox. This is exactly the competitor "timeout" critique,
+  reproduced on our own path.
+- IMAP is steady ~1.8–2.3s (network round-trips) and only helps IMAP-configured accounts;
+  local-DB helps *every* account whose mail is on disk, with no network.
+
+## Finding 2 — The id-mapping problem is solved by the DB
+
+The #205/#243 dual-id scheme (`id` = Mail's numeric id, `rfc_message_id` = RFC 5322 header)
+maps cleanly onto Envelope Index columns — **no `.emlx` parse needed for metadata**:
+- `messages.message_id` → our `id` (Mail's internal numeric id; can be negative 64-bit).
+- `message_global_data.message_id_header` → our `rfc_message_id` (verified populated on live
+  rows). Join: `message_global_data.message_id = messages.message_id`.
+- `messages.subject`/`sender`/`mailbox` are integer FKs → `subjects`, `addresses`, `mailboxes`.
+  `date_received` is Unix epoch seconds. `read`/`flagged`/`flag_color`/`deleted` are columns.
+- `.emlx` filename stem = `messages.ROWID` (not `message_id`); path is
+  `V10/<account-uuid>/<Mailbox>.mbox/<uuid>/Data/<shard>/Messages/<ROWID>.emlx`.
+
+So a `LocalDbConnector` can emit rows byte-compatible with `imap_connector._envelope_to_dict`,
+slotting in beside the IMAP path with the same downstream normalization.
+
+## Finding 3 — Body fetch is the one slow spot
+
+`.emlx` parsing itself is trivial (`<byte-count>\n<rfc822>\n<plist>`), but *locating* the file
+by walking the account subtree cost ~1.9 s (60k+ files). Metadata is instant; body-by-FS-walk
+is not. A production path needs either (a) a derived shard path from `ROWID`, or (b) a
+`ROWID → path` index built once and watched. **Don't ship body fetch via `rglob`.**
+
+## Answers to the issue's open questions
+
+- **Full Disk Access tradeoff.** Real: today we need only Automation; this adds FDA (the spike
+  was blocked until granted). FDA to the host app is broad. → **Gate behind an explicit opt-in
+  flag** (e.g. `--local-db` / env), default off; degrade to AppleScript/IMAP when unavailable.
+  Composes with `--read-only` (#217) for a "fast, read-only" deployment posture.
+- **Cache/invalidation.** Envelope Index is Mail's own live DB — reads are always current; open
+  `mode=ro` per query (cheap: 0.4 ms). A `ROWID→path` cache for bodies needs invalidation
+  (FSEvents watcher or TTL). EWS/Exchange accounts may have no `.emlx` (per che) → fall back.
+- **Schema-stability risk.** We read `V10` + a handful of columns (`messages`, `subjects`,
+  `addresses`, `mailboxes`, `message_global_data`). Apple bumps `V<n>` across major macOS
+  releases and can rename columns. → Version-detect the `V*` dir, feature-probe columns at
+  startup, and **fall back to AppleScript on any schema surprise** rather than failing.
+- **Security.** Read-only (`mode=ro`), local, metadata-first — low risk, but it's a new trust
+  surface (direct disk read of all mail incl. other accounts). Document it; keep behind the
+  opt-in; never write to Mail's DB.
+- **Parity.** Result *counts* matched the limit across paths; a real implementation must
+  prove row-level parity (same messages, same flags) against AppleScript/IMAP in tests before
+  it's allowed to front either.
+
+## Recommendation — GO (phased), behind a flag
+
+The speed delta is too large to ignore and directly answers imdinu's public benchmark framing.
+Proceed, but scoped and safe:
+
+1. **`LocalDbConnector` (metadata search first)** — Envelope Index reads only, emitting the
+   common row shape; wire as a *first-attempt accelerator* under `search_messages` (and
+   `get_message` metadata), with AppleScript/IMAP fallback unchanged. Opt-in flag, default off.
+2. **Body/`get_message` content** — add `.emlx` reading with a real `ROWID→path` strategy (not
+   `rglob`); only after #1 proves parity.
+3. **Defer/optional:** an FTS5 body index for full-coverage body search (imdinu's headline) —
+   biggest payoff, biggest build; its own issue once #1–#2 land.
+
+Hard constraints: opt-in flag + FDA gating; startup schema/version probe with AppleScript
+fallback; row-level parity tests before fronting either existing path; preserve our defended
+advantages (IMAP fast path, security/test rigor). Writes stay on AppleScript/IMAP.
+
+Suggested follow-ups to file on a GO: (a) implement `LocalDbConnector` metadata search behind
+a flag; (b) `.emlx` body fetch with path index; (c) optional FTS5 body-search index.
+
+## Provenance
+
+- Prototype/bench: `scripts/spike_localdb_envelope.py`, `scripts/spike_localdb_bench.py`
+  (this branch). Reproduce: `MAIL_TEST_MODE=true uv run python scripts/spike_localdb_bench.py`
+  (needs Full Disk Access + a large local mailbox).
+- Store read: `~/Library/Mail/V10/MailData/Envelope Index`, 128,469 messages, on 2026-06-15.
+- Dispatch/id refs: `mail_connector.py` `search_messages` (1756), `_search_messages_applescript`
+  (1884), `_imap_search` (1707), `get_message` (2090); `imap_connector._envelope_to_dict` (617).

--- a/scripts/spike_localdb_bench.py
+++ b/scripts/spike_localdb_bench.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""THROWAWAY SPIKE (#376) — benchmark local-DB vs AppleScript vs IMAP.
+
+Times the same search queries through three read paths against a real large
+mailbox (Gmail INBOX, ~32k messages on the spike author's machine):
+
+  * local-DB  — scripts/spike_localdb_envelope.py (Envelope Index SQLite)
+  * AppleScript — AppleMailConnector._search_messages_applescript
+  * IMAP        — AppleMailConnector._imap_search (if a Keychain entry exists)
+
+Read-only, metadata only. Requires Full Disk Access (local-DB path) and
+MAIL_TEST_MODE=true. Run:
+
+    MAIL_TEST_MODE=true uv run python scripts/spike_localdb_bench.py
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from typing import Any, Callable
+
+from apple_mail_mcp.mail_connector import AppleMailConnector
+
+import spike_localdb_envelope as ldb  # the prototype reader
+
+ACCOUNT = "Gmail"
+ACCOUNT_UUID = "04E9E040-D5C2-4B6B-8FFA-5AAF3DCCAB16"
+MAILBOX = "INBOX"
+
+
+def timed(fn: Callable[[], Any], runs: int) -> tuple[float, int, str]:
+    """Return (median_seconds, result_count, error) over N runs."""
+    times: list[float] = []
+    count = -1
+    for _ in range(runs):
+        t = time.perf_counter()
+        try:
+            res = fn()
+            count = len(res) if res is not None else 0
+        except Exception as exc:  # noqa: BLE001 — spike: report, don't crash
+            return (time.perf_counter() - t, -1, f"{type(exc).__name__}: {exc}")
+        times.append(time.perf_counter() - t)
+    return (statistics.median(times), count, "")
+
+
+QUERIES = [
+    ("recent 50, no filter", dict(limit=50)),
+    ("sender_contains=linkedin, unread", dict(sender_contains="linkedin", read_status=False, limit=50)),
+    ("subject_contains=invoice", dict(subject_contains="invoice", limit=50)),
+]
+
+
+def run() -> None:
+    conn = AppleMailConnector(timeout=180)
+    db = ldb._connect(ldb.envelope_index_path())
+
+    print(f"Benchmark: {ACCOUNT}/{MAILBOX} (large mailbox)\n")
+    header = f"{'query':<38} {'local-DB':>12} {'AppleScript':>14} {'IMAP':>12}"
+    print(header)
+    print("-" * len(header))
+
+    for label, q in QUERIES:
+        # local-DB (3 runs: cold + warm)
+        ldb_q = ldb.Query(
+            mailbox_like=f"{ACCOUNT_UUID}/{MAILBOX}",
+            sender_contains=q.get("sender_contains"),
+            subject_contains=q.get("subject_contains"),
+            read=(False if q.get("read_status") is False else None),
+            limit=q.get("limit", 50),
+        )
+        d_t, d_n, d_e = timed(lambda: ldb.search(db, ldb_q), runs=3)
+
+        # AppleScript (1 run — slow path on a 32k mailbox)
+        a_t, a_n, a_e = timed(
+            lambda: conn._search_messages_applescript(
+                account=ACCOUNT, mailbox=MAILBOX, **q
+            ),
+            runs=1,
+        )
+
+        # IMAP (2 runs; benign skip if no Keychain entry)
+        i_t, i_n, i_e = timed(
+            lambda: conn._imap_search(account=ACCOUNT, mailbox=MAILBOX, **q),
+            runs=2,
+        )
+
+        def cell(t: float, n: int, e: str) -> str:
+            if e:
+                return "ERR/skip"
+            return f"{t * 1000:7.1f}ms n={n}"
+
+        print(f"{label:<38} {cell(d_t, d_n, d_e):>12} {cell(a_t, a_n, a_e):>14} {cell(i_t, i_n, i_e):>12}")
+        for tag, e in (("local-DB", d_e), ("AppleScript", a_e), ("IMAP", i_e)):
+            if e:
+                print(f"    {tag} note: {e[:90]}")
+
+    db.close()
+    print("\n(medians; local-DB n=3 runs, AppleScript n=1, IMAP n=2)")
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/spike_localdb_envelope.py
+++ b/scripts/spike_localdb_envelope.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""THROWAWAY SPIKE (#376) — local-DB fast read path proof of concept.
+
+Reads Apple Mail's on-disk store directly, bypassing osascript:
+  * ``~/Library/Mail/V*/MailData/Envelope Index`` (SQLite) for metadata/search
+  * ``*.emlx`` files for message bodies
+
+This is a research prototype to answer "is a local-DB read path worth it?" for
+#376 — it is NOT production code and is NOT wired into the connector. It reads
+read-only (``mode=ro``), touches metadata only, and prints nothing but counts
+and timings. Requires Full Disk Access on the host app.
+
+Run:  uv run python scripts/spike_localdb_envelope.py
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# --- locate the store -------------------------------------------------------
+
+
+def envelope_index_path() -> Path:
+    hits = sorted(
+        glob.glob(os.path.expanduser("~/Library/Mail/V*/MailData/Envelope Index"))
+    )
+    if not hits:
+        raise SystemExit(
+            "No Envelope Index found. Either Mail.app isn't set up or the host "
+            "app lacks Full Disk Access (System Settings > Privacy & Security)."
+        )
+    return Path(hits[-1])
+
+
+def mail_root() -> Path:
+    return envelope_index_path().parents[1]  # .../V10
+
+
+def _connect(idx: Path) -> sqlite3.Connection:
+    # Read-only URI so we never write/lock Mail's live DB.
+    return sqlite3.connect(f"file:{idx}?mode=ro", uri=True)
+
+
+# --- the prototype reader ---------------------------------------------------
+
+# Mirrors the connector's common row shape (see imap_connector._envelope_to_dict):
+# id, rfc_message_id, subject, sender, date_received(ISO), read_status, flagged.
+_BASE_SQL = """
+SELECT m.ROWID                   AS rowid,
+       m.message_id              AS id,
+       g.message_id_header       AS rfc,
+       s.subject                 AS subject,
+       a.address                 AS sender,
+       a.comment                 AS sender_name,
+       m.date_received           AS date_received,
+       m.read                    AS read,
+       m.flagged                 AS flagged,
+       mb.url                    AS mailbox_url
+FROM messages m
+LEFT JOIN subjects s          ON s.ROWID = m.subject
+LEFT JOIN addresses a         ON a.ROWID = m.sender
+LEFT JOIN mailboxes mb        ON mb.ROWID = m.mailbox
+LEFT JOIN message_global_data g ON g.message_id = m.message_id
+WHERE m.deleted = 0
+"""
+
+
+@dataclass
+class Query:
+    mailbox_like: str | None = None  # substring of mailbox url, e.g. "/INBOX"
+    sender_contains: str | None = None
+    subject_contains: str | None = None
+    read: bool | None = None
+    flagged: bool | None = None
+    since_epoch: int | None = None
+    limit: int = 50
+
+
+def _row_to_common(r: sqlite3.Row) -> dict[str, Any]:
+    iso = (
+        datetime.fromtimestamp(r["date_received"], tz=timezone.utc).isoformat()
+        if r["date_received"]
+        else None
+    )
+    rfc = (r["rfc"] or "").strip("<>") or None
+    return {
+        "id": str(r["id"]),
+        "rowid": r["rowid"],  # spike-only: .emlx filename stem
+        "rfc_message_id": rfc,
+        "subject": r["subject"] or "",
+        "sender": r["sender"] or "",
+        "date_received": iso,
+        "read_status": bool(r["read"]),
+        "flagged": bool(r["flagged"]),
+        "mailbox_url": r["mailbox_url"],
+    }
+
+
+def search(conn: sqlite3.Connection, q: Query) -> list[dict[str, Any]]:
+    conn.row_factory = sqlite3.Row
+    sql = _BASE_SQL
+    params: list[Any] = []
+    if q.mailbox_like:
+        sql += " AND mb.url LIKE ?"
+        params.append(f"%{q.mailbox_like}%")
+    if q.sender_contains:
+        sql += " AND a.address LIKE ?"
+        params.append(f"%{q.sender_contains}%")
+    if q.subject_contains:
+        sql += " AND s.subject LIKE ?"
+        params.append(f"%{q.subject_contains}%")
+    if q.read is not None:
+        sql += " AND m.read = ?"
+        params.append(1 if q.read else 0)
+    if q.flagged is not None:
+        sql += " AND m.flagged = ?"
+        params.append(1 if q.flagged else 0)
+    if q.since_epoch is not None:
+        sql += " AND m.date_received >= ?"
+        params.append(q.since_epoch)
+    sql += " ORDER BY m.date_received DESC LIMIT ?"
+    params.append(q.limit)
+    return [_row_to_common(r) for r in conn.execute(sql, params)]
+
+
+def read_emlx_body(rowid: int, mailbox_url: str | None = None) -> str | None:
+    """Locate and parse one .emlx body. The filename stem is messages.ROWID.
+
+    Scope the search to the account subtree (parsed from the mailbox url's
+    host = account UUID) so we don't walk the whole 128k-file store.
+    """
+    root = mail_root()
+    scope = root
+    if mailbox_url and "://" in mailbox_url:
+        uuid = mailbox_url.split("://", 1)[1].split("/", 1)[0]
+        cand = root / uuid
+        if cand.is_dir():
+            scope = cand
+    hits = list(scope.rglob(f"{rowid}.emlx"))
+    if not hits:
+        return None
+    raw = hits[0].read_bytes()
+    # .emlx = <byte-count>\n<rfc822 message>\n<plist trailer>
+    nl = raw.index(b"\n")
+    length = int(raw[:nl].strip())
+    body = raw[nl + 1 : nl + 1 + length]
+    return body.decode("utf-8", errors="replace")
+
+
+# --- spike self-check -------------------------------------------------------
+
+if __name__ == "__main__":
+    idx = envelope_index_path()
+    with _connect(idx) as conn:
+        total = conn.execute("SELECT count(*) FROM messages").fetchone()[0]
+        print(f"Envelope Index: {idx}  ({total:,} messages)")
+        rows = search(conn, Query(mailbox_like="/INBOX", read=False, limit=5))
+        print(f"sample unread INBOX rows: {len(rows)}")
+        for r in rows:
+            print(
+                f"  id={r['id']:>20}  rfc={'yes' if r['rfc_message_id'] else 'NO '} "
+                f"  {r['date_received']}  unread={not r['read_status']}"
+            )
+        if rows:
+            t = time.perf_counter()
+            body = read_emlx_body(rows[0]["rowid"], rows[0]["mailbox_url"])
+            dt = (time.perf_counter() - t) * 1000
+            print(
+                f".emlx body read: {'ok' if body else 'not found'} "
+                f"({len(body) if body else 0} bytes, {dt:.0f}ms)"
+            )


### PR DESCRIPTION
Closes #376.

Spike for the #331 strategic gap: is a local-DB read path (Apple Mail's on-disk `Envelope Index` + `.emlx`) worth building beneath `search_messages`/`get_messages`? **Answer: yes — GO, behind an opt-in flag.** Research-only; no `src/` changes.

## What's here
- `scripts/spike_localdb_envelope.py` — throwaway read-only Envelope Index reader (+ `.emlx` body parser), emitting the connector's common row shape.
- `scripts/spike_localdb_bench.py` — times identical queries across local-DB vs AppleScript vs IMAP.
- `docs/research/local-db-read-path-spike.md` — findings + recommendation.

(Both scripts mirror the existing `scripts/spike_imap_*.py` throwaway-spike convention.)

## Measured — real 32,623-message Gmail INBOX (128,469-message store)
| query (INBOX, limit 50) | local-DB | AppleScript | IMAP |
|---|---|---|---|
| recent 50, no filter | **0.4 ms** | 9,275 ms | 2,289 ms |
| `sender_contains`, unread | **2.3 ms** | 31,435 ms | 1,812 ms |
| `subject_contains` | **19.7 ms** | **136,993 ms** | 1,858 ms |

local-DB is **~4,000–7,000× faster than AppleScript** and **~100–800× faster than IMAP**. The `subject_contains` AppleScript case (137 s) **exceeds our 60 s timeout — it fails today** on a large mailbox, reproducing competitors' "AppleScript times out" critique on our own path.

## Key findings
- **id-mapping is free:** the #205/#243 dual-id scheme maps onto Envelope Index columns — `messages.message_id` → `id`, `message_global_data.message_id_header` → `rfc_message_id`. No `.emlx` parse needed for metadata.
- **body fetch is the one slow spot:** `.emlx` parsing is trivial but *locating* by FS walk was ~1.9 s — a real impl needs a `ROWID→path` index, not `rglob`.
- FDA tradeoff, cache/invalidation, schema-stability (V10 + column probing → AppleScript fallback), and security are addressed in the doc.

## Recommendation
GO, phased & gated: (1) `LocalDbConnector` metadata search as a first-attempt accelerator behind an opt-in flag (default off, AppleScript/IMAP fallback unchanged, composes with `--read-only` #217); (2) `.emlx` body fetch with a path index; (3) optional FTS5 body index. Row-level parity tests required before it fronts either existing path. Writes stay on AppleScript/IMAP.

On merge I can file the implementation follow-ups (1)–(3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)