### PR TITLE
fix: forwarded rfc822 0-byte payload (#385) + IMAP attachment-enumeration divergence (#386)

### DIFF
--- a/src/apple_mail_fast_mcp/draft_builder.py
+++ b/src/apple_mail_fast_mcp/draft_builder.py
@@ -16,10 +16,11 @@ import email
 import mimetypes
 import re
 from dataclasses import dataclass, field
-from email.message import EmailMessage
+from email.message import EmailMessage, MIMEPart
 from email.policy import default as _default_policy
 from email.utils import formataddr, formatdate, getaddresses, make_msgid, parseaddr
 from pathlib import Path
+from typing import Any
 
 # A single forwarded attachment carried over from the original message:
 # (filename, maintype, subtype, payload_bytes).
@@ -274,6 +275,94 @@ class OriginalMessage:
     attachments: list[ForwardedAttachment] = field(default_factory=list)
 
 
+def _attachment_payload_bytes(part: MIMEPart[Any, Any]) -> bytes:
+    """Decode one attachment part to its raw bytes.
+
+    Ordinary parts decode via ``get_payload(decode=True)``. A ``message/*``
+    part (a forwarded email) holds a sub-Message, not a transfer-encoded
+    string, so decode returns ``None`` — serialize the sub-message, but only
+    when the transfer encoding is one RFC 2046 §5.2.1 permits for ``message/*``
+    (7bit/8bit/binary/none). A non-conformant base64/quoted-printable message
+    part is parsed from its *still-encoded* text and would serialize to corrupt
+    bytes, so degrade to ``b""``. (rfc822 empty-bytes fix)
+    """
+    decoded = part.get_payload(decode=True)
+    if isinstance(decoded, (bytes, bytearray)):
+        return bytes(decoded)
+    if part.get_content_maintype() == "message":
+        cte = (part.get("Content-Transfer-Encoding") or "").strip().lower()
+        sub = part.get_payload()
+        if (
+            cte in ("", "7bit", "8bit", "binary")
+            and isinstance(sub, list)
+            and sub
+            and hasattr(sub[0], "as_bytes")
+        ):
+            return sub[0].as_bytes()
+    return b""
+
+
+def _walk_attachment_parts(
+    part: MIMEPart[Any, Any], out: list[MIMEPart[Any, Any]]
+) -> None:
+    """Collect attachment parts in MIME document order.
+
+    Applies the same inclusion predicate as the IMAP BODYSTRUCTURE metadata
+    walk (``imap_connector._bodystructure_extract_attachments``): a leaf counts
+    if its disposition is ``attachment``, or ``inline`` with a filename, or it
+    is ``message/rfc822``. A ``message/rfc822`` part is emitted whole and NOT
+    descended into — its own sub-parts belong to the forwarded email, not the
+    outer message — matching the metadata walk's leaf treatment.
+    """
+    if part.get_content_type() == "message/rfc822":
+        out.append(part)
+        return
+    if part.get_content_maintype() == "multipart":
+        for child in part.iter_parts():
+            _walk_attachment_parts(child, out)
+        return
+    disp = part.get_content_disposition()
+    if disp == "attachment" or (disp == "inline" and part.get_filename()):
+        out.append(part)
+
+
+def extract_attachment_payloads(raw: bytes) -> list[ForwardedAttachment]:
+    """Enumerate a message's attachments AS BYTES, matching the order and
+    membership of the IMAP BODYSTRUCTURE metadata list that ``get_attachments``
+    / ``get_messages`` report.
+
+    The byte-fetch tools (``get_attachment_content`` / ``save_attachments``)
+    index into this with a 0-based ``attachment_index`` that callers take from
+    the metadata list — so the two MUST agree. ``email.iter_attachments()``
+    does not: it drops body-referenced inline parts (multipart/related inline
+    images with filenames) and skips parts nested under a multipart/
+    alternative, so it diverges from the metadata list and broke the index
+    contract (out-of-range, or — worse — a different part's bytes). The
+    concrete divergences were found by dogfooding real iCloud messages.
+
+    Distinct from :func:`parse_original_message`, which deliberately keeps
+    stdlib ``iter_attachments`` semantics for the reply/forward draft path.
+    """
+    msg = email.message_from_bytes(raw, policy=_default_policy)
+    parts: list[MIMEPart[Any, Any]] = []
+    _walk_attachment_parts(msg, parts)
+    out: list[ForwardedAttachment] = []
+    for part in parts:
+        maintype, _, subtype = part.get_content_type().partition("/")
+        # Membership/order match the metadata list (that's the index
+        # contract); the name default differs by design — a nameless part
+        # lists as "" in metadata but needs a usable save name here.
+        out.append(
+            (
+                part.get_filename() or "attachment",
+                maintype,
+                subtype,
+                _attachment_payload_bytes(part),
+            )
+        )
+    return out
+
+
 def parse_original_message(raw: bytes) -> OriginalMessage:
     """Parse a raw RFC 822 message into the pieces needed for a reply or
     forward. Prefers the ``text/plain`` body; falls back to a crude
@@ -290,43 +379,20 @@ def parse_original_message(raw: bytes) -> OriginalMessage:
         if html is not None:
             text = _html_to_text(html.get_content())
 
+    # NOTE: the reply/forward path keeps stdlib iter_attachments semantics
+    # (carry only non-inline attachments into the new draft). The byte-fetch
+    # path uses extract_attachment_payloads instead — it must match the IMAP
+    # metadata list's membership/order for the attachment_index contract.
     attachments: list[ForwardedAttachment] = []
     for part in msg.iter_attachments():
-        decoded = part.get_payload(decode=True)
-        if isinstance(decoded, (bytes, bytearray)):
-            payload = bytes(decoded)
-        elif part.get_content_maintype() == "message":
-            # message/rfc822 (a forwarded email) and other message/* parts
-            # carry a sub-Message as payload, not a transfer-encoded string,
-            # so get_payload(decode=True) returns None. Serialize the
-            # sub-message so the forwarded mail travels as real .eml bytes —
-            # otherwise get_attachment_content / save_attachments returned a
-            # success-shaped 0-byte attachment. (A message/* payload is a
-            # single-element [sub_Message] list under the stdlib parser.)
-            #
-            # Trust that parse only for the transfer encodings RFC 2046
-            # §5.2.1 permits for message/* (7bit/8bit/binary/none). A
-            # non-conformant base64/quoted-printable message part is parsed
-            # from its *still-encoded* text (the stdlib doesn't decode
-            # message/* before sub-parsing), so as_bytes() would emit corrupt
-            # bytes — degrade to b"" rather than return wrong-but-non-empty
-            # data masquerading as the forwarded message.
-            cte = (part.get("Content-Transfer-Encoding") or "").strip().lower()
-            sub = part.get_payload()
-            if (
-                cte in ("", "7bit", "8bit", "binary")
-                and isinstance(sub, list)
-                and sub
-                and hasattr(sub[0], "as_bytes")
-            ):
-                payload = sub[0].as_bytes()
-            else:
-                payload = b""
-        else:
-            payload = b""
         maintype, _, subtype = part.get_content_type().partition("/")
         attachments.append(
-            (part.get_filename() or "attachment", maintype, subtype, payload)
+            (
+                part.get_filename() or "attachment",
+                maintype,
+                subtype,
+                _attachment_payload_bytes(part),
+            )
         )
 
     refs_raw = msg.get("References", "") or ""

--- a/src/apple_mail_fast_mcp/draft_builder.py
+++ b/src/apple_mail_fast_mcp/draft_builder.py
@@ -41,6 +41,35 @@ def _sanitize_header(value: str) -> str:
     return value.replace("\x00", "").replace("\r", "").replace("\n", "")
 
 
+def _attach_forwarded(
+    msg: EmailMessage,
+    filename: str,
+    maintype: str,
+    subtype: str,
+    payload: bytes,
+) -> None:
+    """Attach one carried-over original attachment to a draft being built.
+
+    A forwarded email (``message/rfc822``) is attached as a parsed
+    sub-Message so the part is encoded idiomatically (7bit/8bit per RFC 2046
+    §5.2.1) and re-parses cleanly. Attaching the raw bytes would base64-encode
+    them — non-conformant for ``message/*``, and the parser then reads that
+    back as corrupt content. Everything else attaches as raw bytes.
+    (rfc822 empty-bytes fix)
+    """
+    safe_name = _sanitize_header(filename) or "attachment"
+    if (maintype, subtype) == ("message", "rfc822"):
+        sub_msg = email.message_from_bytes(payload, policy=_default_policy)
+        msg.add_attachment(sub_msg, filename=safe_name)
+    else:
+        msg.add_attachment(
+            payload,
+            maintype=maintype or "application",
+            subtype=subtype or "octet-stream",
+            filename=safe_name,
+        )
+
+
 def build_draft_mime(
     *,
     sender: str,
@@ -114,12 +143,7 @@ def build_draft_mime(
         )
 
     for filename, maintype, subtype, payload in forwarded_attachments or []:
-        msg.add_attachment(
-            payload,
-            maintype=maintype or "application",
-            subtype=subtype or "octet-stream",
-            filename=_sanitize_header(filename) or "attachment",
-        )
+        _attach_forwarded(msg, filename, maintype, subtype, payload)
 
     return message_id, msg.as_bytes()
 
@@ -269,7 +293,37 @@ def parse_original_message(raw: bytes) -> OriginalMessage:
     attachments: list[ForwardedAttachment] = []
     for part in msg.iter_attachments():
         decoded = part.get_payload(decode=True)
-        payload = bytes(decoded) if isinstance(decoded, (bytes, bytearray)) else b""
+        if isinstance(decoded, (bytes, bytearray)):
+            payload = bytes(decoded)
+        elif part.get_content_maintype() == "message":
+            # message/rfc822 (a forwarded email) and other message/* parts
+            # carry a sub-Message as payload, not a transfer-encoded string,
+            # so get_payload(decode=True) returns None. Serialize the
+            # sub-message so the forwarded mail travels as real .eml bytes —
+            # otherwise get_attachment_content / save_attachments returned a
+            # success-shaped 0-byte attachment. (A message/* payload is a
+            # single-element [sub_Message] list under the stdlib parser.)
+            #
+            # Trust that parse only for the transfer encodings RFC 2046
+            # §5.2.1 permits for message/* (7bit/8bit/binary/none). A
+            # non-conformant base64/quoted-printable message part is parsed
+            # from its *still-encoded* text (the stdlib doesn't decode
+            # message/* before sub-parsing), so as_bytes() would emit corrupt
+            # bytes — degrade to b"" rather than return wrong-but-non-empty
+            # data masquerading as the forwarded message.
+            cte = (part.get("Content-Transfer-Encoding") or "").strip().lower()
+            sub = part.get_payload()
+            if (
+                cte in ("", "7bit", "8bit", "binary")
+                and isinstance(sub, list)
+                and sub
+                and hasattr(sub[0], "as_bytes")
+            ):
+                payload = sub[0].as_bytes()
+            else:
+                payload = b""
+        else:
+            payload = b""
         maintype, _, subtype = part.get_content_type().partition("/")
         attachments.append(
             (part.get_filename() or "attachment", maintype, subtype, payload)

--- a/src/apple_mail_fast_mcp/imap_connector.py
+++ b/src/apple_mail_fast_mcp/imap_connector.py
@@ -453,6 +453,13 @@ def _bodystructure_extract_attachments(
     BODYSTRUCTURE returns metadata only, not body bytes, and Mail.app's
     local cache state isn't observable from the protocol. Callers that
     need the bytes invoke ``save_attachments`` (which fetches on demand).
+
+    The byte-fetch path (``get_attachment_content`` / ``save_attachments``)
+    indexes into this list by position, so its enumerator
+    (``draft_builder.extract_attachment_payloads``) MUST apply the SAME
+    inclusion predicate and document order as the ``_walk`` below
+    (attachment-disposition, inline-with-filename, or message/rfc822). Keep
+    the two in sync; the live integration test asserts they agree.
     """
     out: list[dict[str, Any]] = []
 

--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -22,6 +22,7 @@ from .draft_builder import (
     build_forward_body,
     build_reply_body,
     derive_reply_recipients,
+    extract_attachment_payloads,
     forward_subject,
     parse_original_message,
     reply_subject,
@@ -2482,7 +2483,10 @@ class AppleMailConnector:
         password = self._get_imap_password_with_fallback(account, email)
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         raw = imap.fetch_raw_message(message_id, mailbox)
-        atts = parse_original_message(raw).attachments
+        # Enumerate to match the BODYSTRUCTURE metadata list get_attachments
+        # reports — NOT iter_attachments, which diverges and broke the
+        # 0-based attachment_index contract (wrong/missing part).
+        atts = extract_attachment_payloads(raw)
         if not 0 <= attachment_index < len(atts):
             raise MailAttachmentIndexError(
                 f"attachment_index {attachment_index} out of range: message "
@@ -3461,7 +3465,8 @@ class AppleMailConnector:
         password = self._get_imap_password_with_fallback(account, email)
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
         raw = imap.fetch_raw_message(message_id, mailbox)
-        parsed = parse_original_message(raw).attachments
+        # Match the BODYSTRUCTURE metadata list (see _imap_get_attachment_content).
+        parsed = extract_attachment_payloads(raw)
 
         # Shape the parsed parts like _get_attachments_applescript output so
         # the shared cap/target helpers apply unchanged. Exact byte sizes

--- a/tests/unit/test_draft_builder.py
+++ b/tests/unit/test_draft_builder.py
@@ -331,3 +331,175 @@ def test_parse_original_html_only_falls_back_to_text():
     orig = parse_original_message(m.as_bytes())
     assert "Hello" in orig.text and "there" in orig.text
     assert "<p>" not in orig.text
+
+
+def test_parse_original_serializes_forwarded_rfc822_attachment():
+    """A forwarded ``message/rfc822`` part must carry the sub-message's real
+    bytes, not a success-shaped empty payload.
+
+    ``get_payload(decode=True)`` returns ``None`` for ``message/*`` parts (the
+    payload is a sub-Message, not a transfer-encoded string), so without
+    special handling the attachment came through as ``b""`` — and
+    ``get_attachment_content`` / ``save_attachments`` on a forwarded email
+    returned a 0-byte "success". (rfc822 empty-bytes fix)
+    """
+    import email
+    from email.message import EmailMessage
+    from email.policy import default as _pol
+
+    from apple_mail_fast_mcp.draft_builder import parse_original_message
+
+    inner = EmailMessage()
+    inner["From"] = "alice@example.com"
+    inner["To"] = "bob@example.com"
+    inner["Subject"] = "Quarterly report"
+    inner["Message-ID"] = "<inner@example.com>"
+    inner.set_content("Here is the report body.")
+
+    outer = EmailMessage()
+    outer["From"] = "bob@example.com"
+    outer["To"] = "carol@example.com"
+    outer["Subject"] = "Fwd: Quarterly report"
+    outer.set_content("FYI, see attached.")
+    # A normal attachment alongside the forwarded message guards co-existence
+    # (the fix must not regress ordinary attachments).
+    outer.add_attachment(
+        b"%PDF-1.4 cover sheet", maintype="application",
+        subtype="pdf", filename="cover.pdf",
+    )
+    outer.add_attachment(inner)  # message/rfc822
+
+    orig = parse_original_message(outer.as_bytes())
+
+    cover = [a for a in orig.attachments if a[0] == "cover.pdf"]
+    assert cover and cover[0][3] == b"%PDF-1.4 cover sheet"
+
+    fwd = [a for a in orig.attachments if (a[1], a[2]) == ("message", "rfc822")]
+    assert len(fwd) == 1
+    _name, _maintype, _subtype, payload = fwd[0]
+    assert payload, "forwarded rfc822 attachment must carry real bytes, not b''"
+    # The payload is the serialized sub-message — it round-trips.
+    sub = email.message_from_bytes(payload, policy=_pol)
+    assert sub["Subject"] == "Quarterly report"
+    assert "report body" in sub.get_content()
+
+
+def test_parse_original_rfc822_base64_degrades_to_empty_not_corrupt():
+    """A non-conformant base64-encoded ``message/rfc822`` part (RFC 2046
+    §5.2.1 permits only 7bit/8bit/binary for message/*) is parsed by the
+    stdlib from its *still-encoded* text, so the sub-message is garbage. We
+    must degrade to empty bytes — an honest "couldn't extract" — rather than
+    hand back corrupt content masquerading as the forwarded message.
+    """
+    import base64
+    from email.message import EmailMessage
+
+    from apple_mail_fast_mcp.draft_builder import parse_original_message
+
+    inner = EmailMessage()
+    inner["From"] = "alice@example.com"
+    inner["Subject"] = "Secret"
+    inner.set_content("body")
+    b64 = base64.encodebytes(inner.as_bytes()).decode("ascii")
+    wire = (
+        "From: x@y.com\r\nSubject: outer\r\nMIME-Version: 1.0\r\n"
+        'Content-Type: multipart/mixed; boundary="BB"\r\n\r\n'
+        "--BB\r\nContent-Type: text/plain\r\n\r\nbody\r\n"
+        "--BB\r\nContent-Type: message/rfc822\r\n"
+        "Content-Transfer-Encoding: base64\r\n\r\n"
+        f"{b64}\r\n--BB--\r\n"
+    ).encode("ascii")
+
+    fwd = [
+        a for a in parse_original_message(wire).attachments
+        if (a[1], a[2]) == ("message", "rfc822")
+    ]
+    assert len(fwd) == 1
+    # Honest-empty, NOT 265 bytes of re-serialized base64 garbage.
+    assert fwd[0][3] == b""
+
+
+def test_forwarded_rfc822_attachment_round_trips_through_build():
+    """End-to-end (parse -> build): a ``message/rfc822`` forwarded_attachment
+    — the shape ``parse_original_message`` now produces after the empty-bytes
+    fix — must travel into a built draft as a real, decodable forwarded email.
+
+    Guards the write-path interaction: ``build_draft_mime`` feeds these tuples
+    to ``add_attachment(payload, maintype="message", subtype="rfc822")``, and a
+    future email-API change must not silently re-break the forwarded ``.eml``.
+    """
+    import email
+    from email.message import EmailMessage
+    from email.policy import default as _pol
+
+    from apple_mail_fast_mcp.draft_builder import build_draft_mime, parse_original_message
+
+    inner = EmailMessage()
+    inner["From"] = "alice@example.com"
+    inner["Subject"] = "Original thing"
+    inner["Message-ID"] = "<inner2@example.com>"
+    inner.set_content("Original body text.")
+
+    _mid, raw = build_draft_mime(
+        sender="me@example.invalid",
+        to=["you@example.invalid"],
+        subject="Fwd: Original thing",
+        body="See forwarded.",
+        forwarded_attachments=[("inner.eml", "message", "rfc822", inner.as_bytes())],
+    )
+    msg = email.message_from_bytes(raw, policy=_pol)
+    rfc822_parts = [
+        p for p in msg.iter_attachments()
+        if p.get_content_type() == "message/rfc822"
+    ]
+    assert len(rfc822_parts) == 1
+
+    # Write-path contract (asserted directly, not just via the round-trip):
+    # forwarded messages must be encoded idiomatically per RFC 2046 §5.2.1,
+    # never base64 — a revert to raw-byte attachment would base64-encode and
+    # break clean re-parsing (and the read guard would then degrade it).
+    cte = (
+        rfc822_parts[0].get("Content-Transfer-Encoding") or ""
+    ).strip().lower()
+    assert cte in ("", "7bit", "8bit", "binary")
+
+    # Recover it the way get_attachment_content would, and confirm the inner
+    # message survived the build round-trip intact.
+    recovered = [
+        a for a in parse_original_message(raw).attachments
+        if (a[1], a[2]) == ("message", "rfc822")
+    ]
+    assert len(recovered) == 1
+    sub = email.message_from_bytes(recovered[0][3], policy=_pol)
+    assert sub["Subject"] == "Original thing"
+    assert "Original body text." in sub.get_content()
+
+
+def test_build_draft_with_empty_rfc822_forward_does_not_raise():
+    """Pins the read->write edge the two halves of this fix jointly create.
+
+    The read-path guard degrades a non-conformant base64 ``message/rfc822``
+    to ``b""``; if such a tuple is then forwarded, ``build_draft_mime`` runs
+    ``email.message_from_bytes(b"")`` in ``_attach_forwarded``. That is safe
+    today only by stdlib leniency — pin it so a future parser/policy change
+    can't turn a real forward operation into a crash.
+    """
+    import email
+    from email.policy import default as _pol
+
+    from apple_mail_fast_mcp.draft_builder import build_draft_mime
+
+    _mid, raw = build_draft_mime(
+        sender="me@example.invalid",
+        to=["you@example.invalid"],
+        subject="Fwd: empty",
+        body="see fwd",
+        forwarded_attachments=[("x.eml", "message", "rfc822", b"")],
+    )
+    assert isinstance(raw, bytes) and raw  # built, did not raise
+    msg = email.message_from_bytes(raw, policy=_pol)
+    rfc822 = [
+        p for p in msg.iter_attachments()
+        if p.get_content_type() == "message/rfc822"
+    ]
+    assert len(rfc822) == 1  # an honest (empty) placeholder, not a crash

--- a/tests/unit/test_draft_builder.py
+++ b/tests/unit/test_draft_builder.py
@@ -503,3 +503,141 @@ def test_build_draft_with_empty_rfc822_forward_does_not_raise():
         if p.get_content_type() == "message/rfc822"
     ]
     assert len(rfc822) == 1  # an honest (empty) placeholder, not a crash
+
+
+# --- byte-fetch attachment enumeration (IMAP index-contract fix) ---------
+#
+# get_attachment_content / save_attachments (IMAP) index into this list; it
+# MUST agree, in count and order, with the BODYSTRUCTURE metadata walk that
+# get_attachments / get_messages report (imap_connector
+# ._bodystructure_extract_attachments). email.iter_attachments() does NOT —
+# it drops body-referenced inline parts and skips parts nested under a
+# multipart/alternative — which broke the shared 0-based index contract
+# (out-of-range, or the WRONG part's bytes). Cases below mirror the real
+# iCloud divergences found by dogfooding.
+
+
+def _names_types(atts):
+    return [(name, f"{mt}/{st}") for (name, mt, st, _b) in atts]
+
+
+def test_extract_payloads_plain_attachment_is_unchanged():
+    """Control: an ordinary text-body + attachment message is enumerated the
+    same as before (one attachment, real bytes)."""
+    from email.message import EmailMessage
+
+    from apple_mail_fast_mcp.draft_builder import extract_attachment_payloads
+
+    m = EmailMessage()
+    m["Subject"] = "c1"
+    m.set_content("body")
+    m.add_attachment(b"%PDF-1.4 data", maintype="application", subtype="pdf",
+                     filename="a.pdf")
+    atts = extract_attachment_payloads(m.as_bytes())
+    assert _names_types(atts) == [("a.pdf", "application/pdf")]
+    assert atts[0][3] == b"%PDF-1.4 data"
+
+
+def test_extract_payloads_includes_inline_image_with_filename():
+    """A multipart/related inline cid image WITH a filename is a real,
+    savable attachment (metadata reports it; iter_attachments drops it)."""
+    from email.message import EmailMessage
+
+    from apple_mail_fast_mcp.draft_builder import extract_attachment_payloads
+
+    m = EmailMessage()
+    m["Subject"] = "c2"
+    m.set_content("plain")
+    m.add_alternative("<img src=cid:x>", subtype="html")
+    m.get_payload()[1].add_related(b"\x89PNGdata", maintype="image",
+                                   subtype="png", cid="<x>", filename="logo.png")
+
+    # iter_attachments misses it; the real fix must not.
+    assert list(email.message_from_bytes(m.as_bytes(), policy=policy.default)
+                .iter_attachments()) == []
+    atts = extract_attachment_payloads(m.as_bytes())
+    assert _names_types(atts) == [("logo.png", "image/png")]
+    assert atts[0][3] == b"\x89PNGdata"
+
+
+def test_extract_payloads_descends_under_multipart_alternative():
+    """The real 'byte-fetch=0' case: PDFs nested in a multipart/mixed that is
+    itself an alternative. iter_attachments returns nothing because it never
+    descends past the alternative; the fix must find both."""
+    from email.mime.application import MIMEApplication
+    from email.mime.multipart import MIMEMultipart
+    from email.mime.text import MIMEText
+
+    from apple_mail_fast_mcp.draft_builder import extract_attachment_payloads
+
+    outer = MIMEMultipart("alternative")
+    mixed = MIMEMultipart("mixed")
+    mixed.attach(MIMEText("<p>hi</p>", "html"))
+    pdf1 = MIMEApplication(b"%PDF one", _subtype="pdf")
+    pdf1.add_header("Content-Disposition", "inline", filename="a.pdf")
+    mixed.attach(pdf1)
+    pdf2 = MIMEApplication(b"%PDF two", _subtype="pdf")
+    pdf2.add_header("Content-Disposition", "attachment", filename="b.pdf")
+    mixed.attach(pdf2)
+    outer.attach(mixed)
+    raw = outer.as_bytes()
+
+    assert list(email.message_from_bytes(raw, policy=policy.default)
+                .iter_attachments()) == []
+    atts = extract_attachment_payloads(raw)
+    assert _names_types(atts) == [
+        ("a.pdf", "application/pdf"), ("b.pdf", "application/pdf"),
+    ]
+    assert atts[0][3] == b"%PDF one"
+    assert atts[1][3] == b"%PDF two"
+
+
+def test_extract_payloads_preserves_document_order():
+    """Index order follows MIME document order (inline image before the
+    trailing attachment), so attachment_index lines up with the metadata."""
+    from email.message import EmailMessage
+
+    from apple_mail_fast_mcp.draft_builder import extract_attachment_payloads
+
+    m = EmailMessage()
+    m["Subject"] = "c3"
+    m.set_content("plain")
+    m.add_alternative("<img src=cid:y>", subtype="html")
+    m.get_payload()[1].add_related(b"PNG", maintype="image", subtype="png",
+                                   cid="<y>", filename="inline.png")
+    m.add_attachment(b"%PDF real", maintype="application", subtype="pdf",
+                     filename="real.pdf")
+    atts = extract_attachment_payloads(m.as_bytes())
+    assert _names_types(atts) == [
+        ("inline.png", "image/png"), ("real.pdf", "application/pdf"),
+    ]
+
+
+def test_extract_payloads_rfc822_counted_once_not_descended():
+    """A forwarded message/rfc822 is one attachment (emitted whole with real
+    bytes); its OWN inner attachments are not surfaced as separate top-level
+    entries — matching the BODYSTRUCTURE leaf treatment."""
+    from email.message import EmailMessage
+
+    from apple_mail_fast_mcp.draft_builder import extract_attachment_payloads
+
+    inner = EmailMessage()
+    inner["Subject"] = "orig"
+    inner.set_content("hi")
+    inner.add_attachment(b"%PDF inner", maintype="application", subtype="pdf",
+                         filename="inner.pdf")
+
+    m = EmailMessage()
+    m["Subject"] = "c4"
+    m.set_content("body")
+    m.add_attachment(b"%PDF cover", maintype="application", subtype="pdf",
+                     filename="cover.pdf")
+    m.add_attachment(inner)
+
+    atts = extract_attachment_payloads(m.as_bytes())
+    types = [f"{mt}/{st}" for (_n, mt, st, _b) in atts]
+    assert types == ["application/pdf", "message/rfc822"]  # rfc822 NOT descended
+    # The forwarded message carries real bytes (PR #42), not b"".
+    assert atts[1][3]
+    sub = email.message_from_bytes(atts[1][3], policy=policy.default)
+    assert sub["Subject"] == "orig"


### PR DESCRIPTION
Closes #385. Closes #386.

Combined per your coordination note on both issues: the #386 matched-walk enumerator emits `message/rfc822` as a whole leaf whose bytes are only correct once #385's sub-message serialization is in place, so the two land together here as one PR — **two commits, one per issue, in dependency order** (#385 then #386).

Branched on current `main` (post the `apple_mail_mcp` → `apple_mail_fast_mcp` rename), so the diff is against `src/apple_mail_fast_mcp/`.

---

## #385 — forwarded `message/rfc822` attachments return 0 bytes

**Problem.** `get_attachment_content` / `save_attachments` return a **success-shaped 0-byte payload** for forwarded `message/rfc822` attachments. In `draft_builder.py`, attachment bytes come from `part.get_payload(decode=True)`, which returns `None` for `message/*` parts (the stdlib does not decode a sub-message as a flat payload). The `None` falls through to `b""`, so the caller gets `success: true` with an empty attachment — silent data loss, not an error.

**Fix.** When the part is a `message/*` container, serialize the embedded sub-message with `as_bytes()` instead of `get_payload(decode=True)`. Guarded by the part's Content-Transfer-Encoding per RFC 2046 §5.2.1: `message/rfc822` is only legal under identity encodings (7bit / 8bit / binary, or no CTE header), so a base64/quoted-printable-wrapped message part degrades to an **honest empty** result rather than emitting corrupt bytes — the edge you confirmed in triage. Pure change in `draft_builder.py`; no connector/AppleScript surface touched.

**Confidence: high / provider-independent.** The bug and fix are entirely in stdlib `email` parsing — no IMAP or AppleScript behavior — so they reproduce identically on any provider. Fully unit-tested.

## #386 — IMAP byte-fetch attachment enumeration diverges from the metadata list

**Problem.** The byte-fetch path and the metadata path enumerate attachments differently, so an index valid in one is wrong (or out of range) in the other:
- **Metadata** (`get_attachments`, `search` with attachment info) walks the IMAP **BODYSTRUCTURE**.
- **Byte-fetch** (`get_attachment_content`, `save_attachments`) indexes `parse_original_message().attachments`, i.e. the stdlib `iter_attachments()` view.

They disagree on real messages — notably inline-with-filename parts and alternative/nested parts (your local repro: `multipart/mixed[ related[inline image w/ filename], pdf, pdf ]` → `iter_attachments()` drops the inline image, so byte-fetch `[pdf1, pdf2]` misaligns with metadata `[image, pdf1, pdf2]`). Result: **wrong-part bytes** or **index out of range**, even though the listing looked correct.

**Fix.** New `draft_builder.extract_attachment_payloads(raw)` walks the stdlib-parsed tree applying the **same predicate and ordering** as `_bodystructure_extract_attachments`, and does **not** descend into `message/rfc822` sub-trees (treating each as a whole leaf — hence the #385 dependency). The byte-fetch path indexes this aligned list, so the two views match by construction. Call sites in `imap_connector.py` and `mail_connector.py` switched to the aligned enumerator.

As you noted, this is `priority:high` because silent wrong-part bytes are the worst failure mode — agreed.

**Verification.** Dogfooded live on real iCloud: **2 of 9** attachment-bearing messages were broken pre-fix (one returned the wrong PDF; one could not fetch two PDFs at all); a live contract test asserting byte-fetch/metadata agreement passes **4/4** post-fix.

**Honest caveat — iCloud only.** I have no Gmail/Workspace account on this machine, so cross-provider BODYSTRUCTURE parity is unverified. Thank you for offering to run it against your Gmail integration account before merge — that closes the residual; the live contract test should catch any mismatch.

**Approach.** I agree with your matched-walk-over-`BODY[<part>]` call — smallest blast radius, reuses the existing whole-message fetch, keeps the verified rfc822 leaf treatment. I prototyped the `BODY[<part>]` variant and ran it read-only against the same 9 iCloud messages; it was **byte-identical** to this approach, so it's purely a future optimization (less data transferred for large attachments), not a correctness difference.

---

## On the live contract test

`TestAttachmentEnumerationContract` (the 4/4 iCloud agreement test) currently lives in fork-only test infrastructure, so it's not in this diff. Happy to port it into your integration-test conventions in a follow-up if you'd like in-tree live coverage.

## Verification summary

Full unit suite green (**1442**) on top of current `main`; `ruff` + `mypy --strict` clean. Diff is 4 files, +454/−12.

## Reference

Fixes as landed on my fork: PR #42 (rfc822, `7527fb7`) and PR #43 (enumeration, `6ce6aa9`). Happy to adjust naming/placement to your conventions.
