### PR TITLE
feat(#332): Claude Desktop .mcpb bundle (uv-type, install-from-file)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -24,6 +24,7 @@ Update ALL files (pyproject.toml is authoritative):
 2. `src/apple_mail_fast_mcp/__init__.py` — `__version__ = "X.Y.Z"`
 3. `.claude/CLAUDE.md` — `**Version:** vX.Y.Z`
 4. `README.md` — all version references
+5. `mcpb/manifest.json` — `"version": "X.Y.Z"` (the .mcpb bundle; `check_version_sync.sh` enforces it)
 
 ## Phase 5: Generate CHANGELOG
 - Commits since last tag: `git log v{prev}..HEAD --oneline`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
@@ -40,6 +44,15 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             --title "Release $GITHUB_REF_NAME" \
             --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # Build the Claude Desktop .mcpb bundle (uv-type; no compiled artifacts to
+      # bundle, so it builds fine on Linux) and attach it to the release (#332).
+      - name: Build and attach .mcpb bundle
+        run: |
+          ./scripts/build-mcpb.sh
+          gh release upload "$GITHUB_REF_NAME" dist/*.mcpb --clobber
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,28 @@ Destructive operations (`delete_*`, `create_rule` with move/forward/delete actio
 
 ## Installation
 
+### Claude Desktop — install from file (`.mcpb`)
+
+The lowest-friction path for Claude Desktop: grab the `apple-mail-fast-mcp-<version>.mcpb`
+bundle from the [Releases](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/releases)
+page and open it (or drag it into **Settings → Extensions**). Claude Desktop manages Python
+and dependencies for you via `uv` — no manual venv, no config JSON to hand-edit. macOS only.
+
+To build the bundle yourself: `./scripts/build-mcpb.sh` → `dist/apple-mail-fast-mcp-<version>.mcpb`
+(requires Node for the `mcpb` packer).
+
+### From source (development)
+
 ```bash
-# From source (recommended for development)
 git clone https://github.com/s-morgan-jeffries/apple-mail-fast-mcp.git
 cd apple-mail-fast-mcp
 uv sync --dev
 ```
 
 ## Configuration
+
+> Skip this section if you installed the `.mcpb` bundle — it wires up Claude Desktop for you.
+> The manual config below is for source installs.
 
 Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`). `uv sync` installs a console script at `.venv/bin/apple-mail-fast-mcp`; point Claude Desktop at its **absolute path** — it's the most reliable form under Claude Desktop's restricted spawn environment (no reliance on `uv` being on `PATH`):
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,34 @@
+{
+  "manifest_version": "0.4",
+  "name": "apple-mail-fast-mcp",
+  "display_name": "Apple Mail (Fast MCP)",
+  "version": "0.10.2",
+  "description": "MCP server for Apple Mail — search, read, organize, draft, templates, rules, and inbox stats, with an IMAP fast path and a security-first design.",
+  "long_description": "A local, security-first MCP server for Apple Mail on macOS. Reads and organizes mail via AppleScript with an optional IMAP fast path for large mailboxes. 25 tools across search/read, drafts, mailbox & rule CRUD, attachments, templates, and inbox statistics. No telemetry; destructive operations are gated; a --read-only mode is available. See the README for IMAP setup and the read/write server split.",
+  "author": {
+    "name": "Morgan Jeffries"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/s-morgan-jeffries/apple-mail-fast-mcp",
+  "documentation": "https://github.com/s-morgan-jeffries/apple-mail-fast-mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/s-morgan-jeffries/apple-mail-fast-mcp.git"
+  },
+  "keywords": ["mcp", "apple-mail", "email", "macos", "imap", "automation"],
+  "server": {
+    "type": "uv",
+    "entry_point": "src/apple_mail_fast_mcp/server.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": ["run", "--directory", "${__dirname}", "apple-mail-fast-mcp"]
+    }
+  },
+  "tools_generated": true,
+  "compatibility": {
+    "platforms": ["darwin"],
+    "runtimes": {
+      "python": ">=3.10"
+    }
+  }
+}

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build the Claude Desktop .mcpb bundle (#332).
+#
+# Produces dist/apple-mail-fast-mcp-<version>.mcpb — a uv-type MCP bundle
+# (manifest_version 0.4). Claude Desktop manages Python + uv and resolves
+# dependencies from the bundled pyproject.toml/uv.lock at install time, so we
+# never bundle compiled wheels (the spec warns those aren't portable).
+#
+# Requires Node (for `npx @anthropic-ai/mcpb`). Run: ./scripts/build-mcpb.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+MANIFEST="mcpb/manifest.json"
+VERSION="$(grep '"version"' "$MANIFEST" | head -1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')"
+BUILD_DIR="$(mktemp -d)"
+OUT_DIR="$ROOT/dist"
+OUT="$OUT_DIR/apple-mail-fast-mcp-${VERSION}.mcpb"
+
+cleanup() { rm -rf "$BUILD_DIR"; }
+trap cleanup EXIT
+
+echo "Building apple-mail-fast-mcp.mcpb v${VERSION}"
+
+# Stage only what `uv run` needs at the bundle root to resolve + launch the
+# server: the manifest, the project metadata/lock, the README referenced by
+# pyproject, the license, and the package source.
+cp "$MANIFEST" "$BUILD_DIR/manifest.json"
+cp pyproject.toml uv.lock README.md LICENSE "$BUILD_DIR/"
+mkdir -p "$BUILD_DIR/src"
+cp -R src/apple_mail_fast_mcp "$BUILD_DIR/src/"
+
+# Validate against the MCPB schema, then pack the directory into a .mcpb (zip).
+npx --yes @anthropic-ai/mcpb@latest validate "$BUILD_DIR/manifest.json"
+mkdir -p "$OUT_DIR"
+npx --yes @anthropic-ai/mcpb@latest pack "$BUILD_DIR" "$OUT"
+
+echo ""
+npx --yes @anthropic-ai/mcpb@latest info "$OUT" || true
+echo ""
+echo "Built: $OUT"

--- a/scripts/check_version_sync.sh
+++ b/scripts/check_version_sync.sh
@@ -39,6 +39,16 @@ if [ -f ".claude/CLAUDE.md" ]; then
     fi
 fi
 
+# Check mcpb/manifest.json (#332 — the .mcpb bundle version must track pyproject)
+if [ -f "mcpb/manifest.json" ]; then
+    MCPB_VERSION=$(grep '"version"' mcpb/manifest.json | head -1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')
+    echo "  mcpb/manifest:  $MCPB_VERSION"
+    if [ "$MCPB_VERSION" != "$PYPROJECT_VERSION" ]; then
+        echo "  ERROR: mcpb/manifest.json version mismatch!"
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
 # Check CHANGELOG.md
 if [ -f "CHANGELOG.md" ]; then
     CHANGELOG_VERSION=$(grep '^## \[' CHANGELOG.md | grep -v 'Unreleased' | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "")


### PR DESCRIPTION
Closes #396.

First slice of #332 (frictionless install). Adds a Claude Desktop **"install from file"** `.mcpb` bundle. Picked the `.mcpb` slice; PyPI/plugin/guided-config remain for follow-ups.

## Approach — `type: "uv"` (the key decision)
Researched the current MCPB spec. Two findings drove the design:
- Current manifest is **`manifest_version: "0.4"`** with a **`type: "uv"`** server type where **Claude Desktop manages Python + uv and resolves deps automatically** at install.
- The spec warns Python bundles **"cannot portably bundle compiled dependencies (e.g. pydantic)"** — and our stack is FastMCP → `pydantic-core` (compiled Rust). So the bundle-`lib/` approach (what patrickfreyer ships) is the fragile path for us.

→ `type: "uv"` reuses our existing `pyproject.toml`/`uv.lock`, sidesteps the compiled-deps trap, is **macOS-only** (tighter `compatibility` than the generic example), and **decouples from the not-yet-done PyPI slice** (deps resolve from the bundled project, not PyPI).

## What's here
- `mcpb/manifest.json` — uv-type, `tools_generated: true` (no 25-tool hand-sync).
- `scripts/build-mcpb.sh` — `mcpb validate` + `mcpb pack` → `dist/apple-mail-fast-mcp-<version>.mcpb`.
- `release.yml` — builds + attaches the `.mcpb` to every GitHub Release (Node only; no compiled artifacts so it builds on Linux).
- `check_version_sync.sh` + release skill — manifest version is now gate-enforced against pyproject.
- README — "install from file" section.

## Verified end-to-end (not just schema)
- `mcpb validate` passes; bundle packs (521 KB, 36 files).
- **Unpacked the real `.mcpb` and ran the exact launch command** `uv run --directory <bundle> apple-mail-fast-mcp`: uv installed **108 packages incl. compiled `pydantic-core`**, and the server **completed the MCP `initialize` handshake over stdio** (`serverInfo: apple-mail`) with a clean startup. This is precisely what Claude Desktop does.
- `make check-all` green (parity, version-sync incl. the manifest, doc-drift at 25 tools).

## Notes
- No telemetry; security posture intact. `--read-only` split stays documented for source installs (a clean boolean→flag mapping isn't expressible in `mcp_config`, so the bundle runs the full server).
- Bundle is unsigned (the `mcpb sign` step needs a maintainer cert — a later enhancement; che noted Developer-ID signing also makes a future FDA grant survive version bumps).

Follow-ups for #332: PyPI go-live (workflow already exists), Claude Code plugin manifest, guided-config subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)