### PR TITLE
feat(#398): Claude Code plugin (marketplace manifest)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "apple-mail-fast-mcp",
+  "version": "0.10.2",
+  "description": "Apple Mail for Claude Code — fast, security-first email management via MCP (macOS)",
+  "owner": {
+    "name": "Morgan Jeffries"
+  },
+  "plugins": [
+    {
+      "name": "apple-mail-fast",
+      "displayName": "Apple Mail (Fast MCP)",
+      "description": "Search, read, organize, draft, templates, rules, and inbox stats for Apple Mail — with an IMAP fast path and a security-first design. macOS only.",
+      "version": "0.10.2",
+      "source": "./",
+      "author": {
+        "name": "Morgan Jeffries"
+      },
+      "homepage": "https://github.com/s-morgan-jeffries/apple-mail-fast-mcp",
+      "repository": "https://github.com/s-morgan-jeffries/apple-mail-fast-mcp",
+      "license": "MIT",
+      "keywords": ["mcp", "apple-mail", "email", "macos", "imap"],
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "apple-mail-fast",
+  "version": "0.10.2",
+  "description": "Apple Mail for Claude Code — search, read, organize, draft, templates, rules, and inbox stats via MCP, with an IMAP fast path. macOS only.",
+  "author": {
+    "name": "Morgan Jeffries"
+  },
+  "homepage": "https://github.com/s-morgan-jeffries/apple-mail-fast-mcp",
+  "repository": "https://github.com/s-morgan-jeffries/apple-mail-fast-mcp",
+  "license": "MIT",
+  "keywords": ["mcp", "apple-mail", "email", "macos"],
+  "mcpServers": {
+    "apple-mail": {
+      "command": "uv",
+      "args": ["run", "--directory", "${CLAUDE_PLUGIN_ROOT}", "apple-mail-fast-mcp"]
+    }
+  }
+}

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -25,6 +25,7 @@ Update ALL files (pyproject.toml is authoritative):
 3. `.claude/CLAUDE.md` — `**Version:** vX.Y.Z`
 4. `README.md` — all version references
 5. `mcpb/manifest.json` — `"version": "X.Y.Z"` (the .mcpb bundle; `check_version_sync.sh` enforces it)
+6. `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json` — every `"version": "X.Y.Z"` (the Claude Code plugin; `check_version_sync.sh` enforces all occurrences)
 
 ## Phase 5: Generate CHANGELOG
 - Commits since last tag: `git log v{prev}..HEAD --oneline`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ and dependencies for you via `uv` — no manual venv, no config JSON to hand-edi
 To build the bundle yourself: `./scripts/build-mcpb.sh` → `dist/apple-mail-fast-mcp-<version>.mcpb`
 (requires Node for the `mcpb` packer).
 
+### Claude Code — install as a plugin
+
+One command in Claude Code, no config JSON:
+
+```
+/plugin marketplace add s-morgan-jeffries/apple-mail-fast-mcp
+/plugin install apple-mail-fast@apple-mail-fast-mcp
+```
+
+Claude Code launches the server via `uv run` from the plugin directory (resolves dependencies
+from the bundled `pyproject.toml`/`uv.lock` — no PyPI needed), so you only need `uv` installed.
+macOS only. See [`docs/reference/TOOLS.md`](docs/reference/TOOLS.md) for IMAP setup and the
+read/write split.
+
 ### From source (development)
 
 ```bash

--- a/scripts/check_version_sync.sh
+++ b/scripts/check_version_sync.sh
@@ -49,6 +49,21 @@ if [ -f "mcpb/manifest.json" ]; then
     fi
 fi
 
+# Check Claude Code plugin manifests (#398). Both files carry version fields
+# (marketplace has a top-level + per-plugin-entry version); every one must
+# track pyproject. `for v in $(...)` runs in the current shell so ERRORS sticks.
+for PLUGIN_FILE in .claude-plugin/marketplace.json .claude-plugin/plugin.json; do
+    if [ -f "$PLUGIN_FILE" ]; then
+        for v in $(grep -oE '"version"[[:space:]]*:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$PLUGIN_FILE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'); do
+            if [ "$v" != "$PYPROJECT_VERSION" ]; then
+                echo "  ERROR: $PLUGIN_FILE version $v != $PYPROJECT_VERSION"
+                ERRORS=$((ERRORS + 1))
+            fi
+        done
+        echo "  $PLUGIN_FILE: $PYPROJECT_VERSION"
+    fi
+done
+
 # Check CHANGELOG.md
 if [ -f "CHANGELOG.md" ]; then
     CHANGELOG_VERSION=$(grep '^## \[' CHANGELOG.md | grep -v 'Unreleased' | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "")


### PR DESCRIPTION
Closes #398. Second slice of the #332 distribution work — a **Claude Code plugin** for one-command install. Independent of #391 (all-new files).

## Install
```
/plugin marketplace add s-morgan-jeffries/apple-mail-fast-mcp
/plugin install apple-mail-fast@apple-mail-fast-mcp
```

## Approach
- `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json`, `source: "./"` so the repo itself is the plugin (our `pyproject.toml`/`uv.lock`/`src/` are all there for `uv` to resolve).
- The MCP server launches via `uv run --directory ${CLAUDE_PLUGIN_ROOT} apple-mail-fast-mcp` — **the same command I verified for the `.mcpb`**, resolving deps from the bundled project. So it's **PyPI-independent** (decoupled from #397) and needs only `uv`. macOS only.
- Verified the schema against the official Claude Code plugins reference (`plugin.json` requires only `name`; `mcpServers` inline with `${CLAUDE_PLUGIN_ROOT}`; version resolves plugin.json → marketplace entry → git SHA).

## Verified (real tooling, not just JSON lint)
- `claude plugin validate` passes for **both** the marketplace and plugin manifests.
- The exact `mcpServers` launch command completes an **MCP `initialize` handshake over stdio** (`serverInfo: apple-mail`) — same end-to-end proof as the bundle.
- `make check-all` green — `check_version_sync.sh` now tracks **every** version field in both manifests (top-level + per-plugin-entry + plugin.json) against pyproject; parity, doc-drift all pass.

## Notes
- Ships just the MCP server (no bundled skill/commands yet) — a companion skill/slash command is #333's territory.
- Version bumps: the release skill now lists both plugin manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)