### PR TITLE
docs(#397): advertise uvx / pip install (already on PyPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ from the bundled `pyproject.toml`/`uv.lock` — no PyPI needed), so you only nee
 macOS only. See [`docs/reference/TOOLS.md`](docs/reference/TOOLS.md) for IMAP setup and the
 read/write split.
 
+### pip / uvx (any MCP client)
+
+Published on [PyPI](https://pypi.org/project/apple-mail-fast-mcp/):
+
+```bash
+uvx apple-mail-fast-mcp          # zero-install, run on demand
+pip install apple-mail-fast-mcp  # or install the console script
+```
+
+Then point your MCP client at it — the config is a one-liner (no absolute paths):
+
+```json
+{
+  "mcpServers": {
+    "apple-mail": { "command": "uvx", "args": ["apple-mail-fast-mcp"] }
+  }
+}
+```
+
 ### From source (development)
 
 ```bash


### PR DESCRIPTION
Closes #397.

## The surprise
`apple-mail-fast-mcp` has been **published on PyPI since 0.10.0** (Jun 6) — 0.10.0 / 0.10.1 / 0.10.2 are all live via the existing `release.yml` OIDC `publish-pypi` job. `pip install apple-mail-fast-mcp` and `uvx apple-mail-fast-mcp` already work. So #397's "publish to PyPI" was effectively **done a month ago**; the trusted-publisher registration and first publish were already in place.

The *only* thing left was that the README never said so — the Installation section showed `.mcpb` / plugin / from-source but no `uvx`/`pip` command. We were shipping to PyPI and not telling anyone.

## Change
Adds a **"pip / uvx (any MCP client)"** install section with:
```bash
uvx apple-mail-fast-mcp
pip install apple-mail-fast-mcp
```
plus the one-line `uvx` `mcpServers` config (no absolute paths).

Docs-only. Doc-drift + readme-claims gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)