### PR TITLE
feat(#322): wrapper-free send for send_now=True via SMTP

### DIFF
--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -963,7 +963,7 @@ Create a draft (fresh, reply, or forward). Optionally send immediately.
 | `template_name` | string | No | None | Optional template to render for `subject` + `body`. Caller-supplied `subject`/`body` override the rendered output. |
 | `template_vars` | object | No | None | Variables for the template renderer. Requires `template_name`. |
 | `from_account` | string | No | None | Mail.app account name or UUID. None = Mail's default. On a save-as-draft with exactly one enabled account, that account is adopted so the clean (no iOS quote bug) IMAP draft path can engage — it's Mail's default sender anyway, so the From is unchanged (#321). |
-| `send_now` | boolean | No | False | `False` saves as draft. `True` sends immediately and elicits confirmation. |
+| `send_now` | boolean | No | False | `False` saves as draft. `True` sends immediately and elicits confirmation. When the account has SMTP + IMAP credentials configured, the send goes out over a clean **SMTP** submission (#322) — a wrapper-free RFC 822 message — so sent mail avoids the iOS cite-blockquote (Mail.app bug FB11734014); it falls back to Mail's AppleScript send (which does apply the wrapper) when SMTP isn't available. Unlike a save-as-draft, a `send_now` with no `from_account` is **not** auto-resolved to the sole account (#321) — pass `from_account` to get the clean SMTP path. |
 
 **Returns:**
 
@@ -991,6 +991,21 @@ response includes an optional `warnings: list[str]` field noting the body
 may render as a blockquote on iOS Mail (Mail.app bug FB11734014, #245).
 The field is **omitted** on the clean path. Configure IMAP for the account
 (`apple-mail-fast-mcp setup-imap`) — or pass `from_account` — to avoid it.
+
+**Send path (`send_now=True`, #322).** Historically every send went out via
+Mail's AppleScript `tell theMessage to send`, whose `content` setter wraps
+the body in the same FB11734014 cite-blockquote as the draft case — so sent
+mail could render as a quote on iOS too. When `from_account` is given and
+that account has SMTP + IMAP credentials, `create_draft` now submits a clean,
+wrapper-free RFC 822 message (the same `build_draft_mime` output as the draft
+path) directly over the account's **SMTP** server, reusing the account's IMAP
+app-password (no separate SMTP credential). It falls back to the AppleScript
+send when SMTP isn't configured/reachable. In test mode (`MAIL_TEST_MODE`),
+the SMTP path re-verifies every **resolved** recipient — including reply-all
+recipients derived inside the connector — against the reserved-domain
+allowlist at the transport boundary and refuses the send
+(`error_type: "safety_violation"`) on a violation, closing the #175 class of
+bypass for the new transport.
 
 **Examples:**
 

--- a/src/apple_mail_fast_mcp/imap_connector.py
+++ b/src/apple_mail_fast_mcp/imap_connector.py
@@ -90,6 +90,7 @@ scan depth."""
 
 _FLAG_SEEN = b"\\Seen"
 _FLAG_FLAGGED = b"\\Flagged"
+_FLAG_ANSWERED = b"\\Answered"
 
 
 # ---------------------------------------------------------------------------
@@ -1347,6 +1348,19 @@ class ImapConnector:
         "INBOX.Drafts",
     )
 
+    # Conventional Sent folder names to fall back on when the server
+    # doesn't advertise \\Sent via SPECIAL-USE (RFC 6154). Issue #406.
+    # "Sent Messages" is iCloud's name; "[Gmail]/Sent Mail" is Gmail's
+    # (Gmail also advertises \\Sent, so the convention list is only a
+    # safety net there). Order is informative — first match wins per
+    # ``client.list_folders``.
+    _CONVENTIONAL_SENT_NAMES: tuple[str, ...] = (
+        "Sent",
+        "Sent Messages",
+        "[Gmail]/Sent Mail",
+        "INBOX.Sent",
+    )
+
     def append_draft(self, raw_message: bytes) -> str:
         """APPEND a pre-built RFC822 message to the account's Drafts
         folder with the ``\\Draft`` flag, and return the folder used.
@@ -1392,6 +1406,75 @@ class ImapConnector:
             else:
                 present.add(name)
         for candidate in self._CONVENTIONAL_DRAFTS_NAMES:
+            if candidate in present:
+                return candidate
+        return None
+
+    def append_sent_copy(
+        self, raw_message: bytes, *, answered: bool = False
+    ) -> str:
+        """APPEND a copy of an already-sent message to the Sent folder.
+
+        Restores the Sent-mailbox copy that the SMTP send path (#322)
+        dropped: Mail.app's AppleScript ``tell theMessage to send`` used to
+        save a copy into Sent as a side effect, but the direct ``smtplib``
+        submission bypasses that. This mirrors :meth:`append_draft` (#245)
+        — same IMAP-APPEND transport, targeting the Sent folder instead of
+        Drafts and flagging the copy as already-read (issue #406).
+
+        The copy is flagged ``\\Seen`` (outgoing mail is not "unread" to its
+        own sender) and, when ``answered`` is true, ``\\Answered`` — matching
+        the flag a normal reply carries in the Sent mailbox.
+
+        The Sent folder is resolved by the RFC 6154 ``\\Sent`` SPECIAL-USE
+        flag first (Gmail advertises it, so ``[Gmail]/Sent Mail`` is found
+        without hard-coding), then a conventional-name fallback that covers
+        iCloud's ``Sent Messages`` and other providers.
+
+        Args:
+            raw_message: The serialized RFC 822 message that was sent (from
+                ``build_draft_mime``; still carries any ``Bcc`` header, which
+                is intentional — the Sent copy records blind recipients, as
+                Mail.app's own Sent copy does).
+            answered: True when the sent message was itself a reply.
+
+        Returns:
+            The Sent folder name the copy was APPENDed to.
+
+        Raises:
+            MailMessageNotFoundError: No Sent folder discoverable via
+                SPECIAL-USE or conventional names. Callers treat this (like
+                any failure here) as best-effort — the message is already
+                delivered — and must not surface it as a send failure.
+            IMAPClientError: Protocol-level APPEND failure.
+        """
+        flags: list[bytes] = [_FLAG_SEEN]
+        if answered:
+            flags.append(_FLAG_ANSWERED)
+        with self._session() as client:
+            folder = self._find_sent_folder(
+                client
+            ) or self._find_sent_by_convention(client)
+            if folder is None:
+                raise MailMessageNotFoundError(
+                    f"No Sent folder found on {self._host} "
+                    f"(no \\Sent SPECIAL-USE flag and none of "
+                    f"{list(self._CONVENTIONAL_SENT_NAMES)} present)."
+                )
+            client.append(folder, raw_message, flags=flags)
+            return folder
+
+    def _find_sent_by_convention(self, client: IMAPClient) -> str | None:
+        """Fall back to conventional Sent names for servers that don't
+        advertise SPECIAL-USE ``\\Sent`` (e.g. iCloud's ``Sent Messages``).
+        First match wins in :attr:`_CONVENTIONAL_SENT_NAMES` order (#406)."""
+        present: set[str] = set()
+        for _flags, _delim, name in client.list_folders():
+            if isinstance(name, (bytes, bytearray)):
+                present.add(name.decode("utf-8", errors="replace"))
+            else:
+                present.add(name)
+        for candidate in self._CONVENTIONAL_SENT_NAMES:
             if candidate in present:
                 return candidate
         return None
@@ -1603,7 +1686,9 @@ class ImapConnector:
         """Return the Sent folder name via the ``\\Sent`` SPECIAL-USE flag,
         or None if not found. Used by Tier 1.5 (#125) as the second
         anchor-lookup target after INBOX — covers the common case of a
-        thread anchored at a sent message."""
+        thread anchored at a sent message — and by :meth:`append_sent_copy`
+        (#406), which falls back to :meth:`_find_sent_by_convention` when
+        this returns None."""
         for flags, _delim, name in client.list_folders():
             if b"\\Sent" in flags:
                 if isinstance(name, (bytes, bytearray)):

--- a/src/apple_mail_fast_mcp/imap_providers.py
+++ b/src/apple_mail_fast_mcp/imap_providers.py
@@ -21,6 +21,13 @@ class Provider:
     name: str
     app_password_url: str | None
     steps: tuple[str, ...]
+    # True when the provider's SMTP submission server auto-files a copy of
+    # sent mail into the Sent folder server-side (Gmail does; iCloud, Yahoo,
+    # Outlook/Office365, Fastmail do not). The SMTP send path (#322/#406)
+    # uses this to skip its own IMAP-APPEND Sent copy for such providers —
+    # appending would produce a duplicate. Verified live against Gmail during
+    # the PR #404 review.
+    smtp_saves_sent_copy: bool = False
 
 
 ICLOUD = Provider(
@@ -43,6 +50,7 @@ GMAIL = Provider(
         "Create an app password (any name) — you get a 16-character code.",
         "Paste it below (spaces are fine — they're stripped).",
     ),
+    smtp_saves_sent_copy=True,
 )
 
 YAHOO = Provider(

--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -51,6 +51,7 @@ from .exceptions import (
 )
 from .imap_connector import ImapConnectionPool, ImapConnector
 from .imap_overrides import get_login_override
+from .imap_providers import detect_provider
 from .keychain import get_imap_password
 from .security import send_recipients_test_violation
 from .smtp_sender import SmtpSender
@@ -5211,7 +5212,9 @@ class AppleMailConnector:
         recipients = list(to) + list(cc or []) + list(bcc or [])
         self._smtp_send(from_account, raw, recipients, smtp_config=smtp_config)
         self._imap_clear_breaker(from_account)
-        self._save_sent_copy(from_account, raw, answered=False)
+        self._save_sent_copy(
+            from_account, raw, answered=False, smtp_config=smtp_config
+        )
         return {"draft_id": "", "sent_message_id": ""}
 
     def _send_reply_forward_via_smtp(
@@ -5258,7 +5261,11 @@ class AppleMailConnector:
         # Reuse the connector already built for the original fetch — a reply
         # carries \\Answered in Sent.
         self._save_sent_copy(
-            from_account, raw, answered=(seed == "reply"), imap=imap
+            from_account,
+            raw,
+            answered=(seed == "reply"),
+            smtp_config=smtp_config,
+            imap=imap,
         )
         return {"draft_id": "", "sent_message_id": ""}
 
@@ -5268,6 +5275,7 @@ class AppleMailConnector:
         raw_message: bytes,
         *,
         answered: bool,
+        smtp_config: tuple[str, int, str],
         imap: ImapConnector | None = None,
     ) -> None:
         """Best-effort: APPEND a copy of a just-SMTP-sent message to the
@@ -5278,6 +5286,16 @@ class AppleMailConnector:
         theMessage to send`` used to save as a side effect. This restores it,
         reusing the IMAP-APPEND infrastructure of the clean draft path
         (#245/#246/#292) via :meth:`ImapConnector.append_sent_copy`.
+
+        Provider exception (PR #404 re-review): a few providers — Gmail among
+        the ones we support — already auto-file a copy of SMTP-submitted mail
+        into Sent *server-side*. Appending our own copy there produces a
+        duplicate, so for a provider flagged ``smtp_saves_sent_copy`` we skip
+        the APPEND entirely. The provider is detected from ``smtp_config``
+        (the SMTP host / login), independent of the reused ``imap`` connector.
+        This was confirmed live against a Gmail account during the review: one
+        SMTP submission with no APPEND of our own still produced exactly one
+        Sent copy.
 
         Failure boundary (deliberate): by the time this runs the message has
         already been accepted by the server and delivered to the recipient —
@@ -5297,10 +5315,22 @@ class AppleMailConnector:
                 any ``Bcc`` header, which the Sent copy legitimately records).
             answered: True when the sent message was a reply (adds
                 ``\\Answered`` to the Sent copy).
+            smtp_config: ``(smtp_host, port, login_email)`` for the account —
+                used to detect providers that auto-save Sent copies (see
+                above) so the APPEND can be skipped for them.
             imap: An existing connector for ``from_account`` to reuse (the
                 reply/forward path already built one to fetch the original);
                 ``None`` means build one from the account's resolved config.
         """
+        smtp_host, _port, login_email = smtp_config
+        if detect_provider(smtp_host, login_email).smtp_saves_sent_copy:
+            logger.debug(
+                "Skipping Sent-copy APPEND for %r: provider auto-saves "
+                "SMTP-submitted mail to Sent server-side (an APPEND would "
+                "duplicate it). (#406)",
+                from_account,
+            )
+            return
         try:
             if imap is None:
                 host, port, email = self._resolve_imap_config(from_account)

--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -4,6 +4,7 @@ AppleScript-based connector for Apple Mail.
 
 import logging
 import re
+import smtplib
 import subprocess
 import tempfile
 import time
@@ -44,12 +45,15 @@ from .exceptions import (
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
     MailRuleNotFoundError,
+    MailSafetyError,
     MailUnsupportedGmailSystemLabelError,
     MailUnsupportedRuleActionError,
 )
 from .imap_connector import ImapConnectionPool, ImapConnector
 from .imap_overrides import get_login_override
 from .keychain import get_imap_password
+from .security import send_recipients_test_violation
+from .smtp_sender import SmtpSender
 from .utils import (
     applescript_account_clause,
     escape_applescript_string,
@@ -85,6 +89,21 @@ _IMAP_FALLBACK_EXCS: tuple[type[Exception], ...] = (
     MailImapMoveUnsupportedError,
     MailImapTrashNotFoundError,
     UnicodeEncodeError,
+)
+
+# Exceptions that trigger AppleScript fallback for the clean SMTP send path
+# (issue #322). Mirrors _IMAP_FALLBACK_EXCS: Keychain opt-out and connection
+# failures degrade gracefully to `tell theMessage to send`. OSError covers
+# socket errors / timeouts; smtplib.SMTPException covers auth and protocol
+# failures. MailAccountNotFoundError / ValueError are deliberately excluded —
+# they are caller/config errors that must surface. MailSafetyError is also
+# excluded on purpose: a test-mode reserved-domain violation must HARD-FAIL,
+# never fall back to an equally-unsafe AppleScript send (#322/#175).
+_SMTP_FALLBACK_EXCS: tuple[type[Exception], ...] = (
+    MailKeychainEntryNotFoundError,
+    MailKeychainAccessDeniedError,
+    OSError,
+    smtplib.SMTPException,
 )
 
 logger = logging.getLogger(__name__)
@@ -4803,25 +4822,54 @@ class AppleMailConnector:
         password = self._get_imap_password_with_fallback(from_account, email)
         imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
 
-        raw = imap.fetch_raw_message(seed_id, seed_mailbox)
-        orig = parse_original_message(raw)
+        message_id, draft_raw, _recipients = self._build_reply_forward_mime(
+            imap=imap,
+            seed=seed,
+            seed_id=seed_id,
+            seed_mailbox=seed_mailbox,
+            sender=sender,
+            self_email=email,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            subject=subject,
+            body=body,
+            reply_all=reply_all,
+            attachment_paths=attachment_paths,
+        )
+        imap.append_draft(draft_raw)
+        self._imap_clear_breaker(from_account)
+        return {"draft_id": _bare_message_id(message_id), "sent_message_id": ""}
 
-        # Threading: In-Reply-To = the original's Message-ID; References =
-        # the original's References chain plus the original's Message-ID.
-        in_reply_to = orig.message_id or None
-        references = list(orig.references)
-        if orig.message_id and orig.message_id not in references:
-            references.append(orig.message_id)
+    def _resolve_reply_forward_fields(
+        self,
+        *,
+        seed: str,
+        orig: Any,
+        self_email: str,
+        to: list[str] | None,
+        cc: list[str] | None,
+        subject: str | None,
+        body: str,
+        reply_all: bool,
+    ) -> tuple[list[str], list[str] | None, str | None, str, Any]:
+        """Derive the final (to, cc, subject, body, forwarded_attachments)
+        for a clean reply/forward from the parsed original.
 
-        final_to: list[str]
-        final_cc: list[str] | None
+        For ``seed="reply"`` recipients are derived from the original's
+        headers (reply-all minus self) unless the caller overrode them;
+        for ``seed="forward"`` the original's attachments are carried over.
+        Extracted from the reply/forward builders so each stays under the
+        complexity ceiling and so the draft (APPEND) and send (SMTP) paths
+        derive recipients identically.
+        """
         if seed == "reply":
             derived_to, derived_cc = derive_reply_recipients(
                 from_header=orig.from_header,
                 reply_to_header=orig.reply_to_header,
                 to_header=orig.to_header,
                 cc_header=orig.cc_header,
-                self_addresses=[email],
+                self_addresses=[self_email],
                 reply_all=reply_all,
             )
             final_to = to if to is not None else derived_to
@@ -4835,22 +4883,80 @@ class AppleMailConnector:
                 original_date=orig.date,
                 original_text=orig.text,
             )
-            forwarded_attachments = None
-        else:  # forward
-            final_to = to if to is not None else []
-            final_cc = cc
-            final_subject = (
-                subject if subject is not None else forward_subject(orig.subject)
-            )
-            final_body = build_forward_body(
-                new_body=body,
-                original_from=orig.from_header,
-                original_date=orig.date,
-                original_subject=orig.subject,
-                original_to=orig.to_header,
-                original_text=orig.text,
-            )
-            forwarded_attachments = orig.attachments or None
+            return final_to, final_cc, final_subject, final_body, None
+
+        final_to = to if to is not None else []
+        final_subject = (
+            subject if subject is not None else forward_subject(orig.subject)
+        )
+        final_body = build_forward_body(
+            new_body=body,
+            original_from=orig.from_header,
+            original_date=orig.date,
+            original_subject=orig.subject,
+            original_to=orig.to_header,
+            original_text=orig.text,
+        )
+        return final_to, cc, final_subject, final_body, orig.attachments or None
+
+    def _build_reply_forward_mime(
+        self,
+        *,
+        imap: ImapConnector,
+        seed: str,
+        seed_id: str,
+        seed_mailbox: str,
+        sender: str,
+        self_email: str,
+        to: list[str] | None,
+        cc: list[str] | None,
+        bcc: list[str] | None,
+        subject: str | None,
+        body: str,
+        reply_all: bool,
+        attachment_paths: list[Path] | None,
+    ) -> tuple[str, bytes, list[str]]:
+        """Fetch the original over IMAP, rebuild a clean (no cite-blockquote)
+        reply/forward MIME with threading headers, and return
+        ``(message_id, raw_bytes, envelope_recipients)``.
+
+        ``envelope_recipients`` is the fully-resolved ``to + cc + bcc`` set
+        actually addressed. Reply/forward recipient *derivation* happens here,
+        so this is the only point at which the true recipient list is known —
+        which is exactly why the SMTP send path runs its test-mode
+        reserved-domain guard against this value, not the caller-supplied one
+        (#322/#175).
+
+        Shared by the draft path (``_create_reply_forward_draft_via_imap``,
+        which then APPENDs) and the send path
+        (``_send_reply_forward_via_smtp``, which then submits via SMTP).
+        """
+        raw = imap.fetch_raw_message(seed_id, seed_mailbox)
+        orig = parse_original_message(raw)
+
+        # Threading: In-Reply-To = the original's Message-ID; References =
+        # the original's References chain plus the original's Message-ID.
+        in_reply_to = orig.message_id or None
+        references = list(orig.references)
+        if orig.message_id and orig.message_id not in references:
+            references.append(orig.message_id)
+
+        (
+            final_to,
+            final_cc,
+            final_subject,
+            final_body,
+            forwarded_attachments,
+        ) = self._resolve_reply_forward_fields(
+            seed=seed,
+            orig=orig,
+            self_email=self_email,
+            to=to,
+            cc=cc,
+            subject=subject,
+            body=body,
+            reply_all=reply_all,
+        )
 
         message_id, draft_raw = build_draft_mime(
             sender=sender,
@@ -4866,9 +4972,8 @@ class AppleMailConnector:
             references=references or None,
             forwarded_attachments=forwarded_attachments,
         )
-        imap.append_draft(draft_raw)
-        self._imap_clear_breaker(from_account)
-        return {"draft_id": _bare_message_id(message_id), "sent_message_id": ""}
+        recipients = list(final_to) + list(final_cc or []) + list(bcc or [])
+        return message_id, draft_raw, recipients
 
     def _try_imap_compose_draft(
         self,
@@ -4973,6 +5078,336 @@ class AppleMailConnector:
             self._log_imap_fallback(from_account, exc)
         return None
 
+    def _query_smtp_server(self, account: str) -> tuple[str, int]:
+        """Query Mail.app for an account's outgoing (SMTP) server host/port.
+
+        Returns ``("", 0)`` when the account has no SMTP server configured
+        (e.g. a receive-only / mid-configuration account), which the caller
+        treats as "SMTP unavailable — fall back to AppleScript". Mirrors
+        ``_resolve_imap_config``'s Mail.app-property discovery (#322).
+
+        Raises:
+            MailAccountNotFoundError: If the account doesn't exist.
+        """
+        account_clause = applescript_account_clause(account)
+        tell_body = f"""
+        tell application "Mail"
+            set acctRef to {account_clause}
+            set smtpRef to smtp server of acctRef
+            if smtpRef is missing value then
+                set resultData to {{|host|:"", |port|:0}}
+            else
+                set smtpHost to server name of smtpRef
+                if smtpHost is missing value then set smtpHost to ""
+                set smtpPort to port of smtpRef
+                if smtpPort is missing value then set smtpPort to 0
+                set resultData to {{|host|:smtpHost, |port|:smtpPort}}
+            end if
+        end tell
+        """
+        script = _wrap_as_json_script(tell_body, timeout=self.timeout)
+        raw = self._run_applescript(script)
+        try:
+            parsed = parse_applescript_json(raw)
+        except ValueError:
+            # Unparseable Mail.app output — treat as "SMTP not discoverable"
+            # and let the caller fall back to AppleScript rather than crashing
+            # the send.
+            return "", 0
+        if not isinstance(parsed, dict):
+            # Unexpected shape from Mail.app — same graceful degradation. A
+            # real AppleScript error (account not found, permission) has
+            # already raised in `_run_applescript` before reaching here.
+            return "", 0
+        host = cast(str, parsed.get("host") or "")
+        port = cast(int, parsed.get("port") or 0)
+        return host, port
+
+    def _resolve_smtp_config(self, account: str) -> tuple[str, int, str]:
+        """Resolve ``(smtp_host, smtp_port, login_email)`` for an account.
+
+        SMTP host/port come from Mail.app's ``smtp server`` object; the login
+        email reuses ``_resolve_imap_config``'s identity resolution (custom-
+        domain / third-party-Apple-ID handling — #201/#299/#341) because the
+        SMTP AUTH user and the IMAP LOGIN user are the same app-password-backed
+        credential for every provider we support. A missing/zero SMTP port
+        defaults to ``587`` (STARTTLS submission). An empty host signals "not
+        configured" to the caller (#322).
+
+        Raises:
+            MailAccountNotFoundError: If the account doesn't exist.
+        """
+        host, port = self._query_smtp_server(account)
+        if not host:
+            # No SMTP server configured — signal "unavailable" without a
+            # further (and pointless) IMAP-config round-trip.
+            return "", 0, ""
+        _imap_host, _imap_port, email = self._resolve_imap_config(account)
+        if port == 0:
+            port = 587
+        return host, port, email
+
+    def _smtp_send(
+        self,
+        from_account: str,
+        raw_message: bytes,
+        recipients: list[str],
+        *,
+        smtp_config: tuple[str, int, str],
+    ) -> None:
+        """Enforce the test-mode reserved-domain guard, then submit
+        ``raw_message`` over SMTP (issue #322).
+
+        The reserved-domain guard runs *here*, at the transport boundary,
+        where the final envelope recipient set is known — closing the #175
+        gap for send paths that derive recipients inside the connector (an
+        SMTP ``reply_all`` whose ``cc`` is pulled from the original message).
+        A violation raises ``MailSafetyError``, which is deliberately NOT in
+        ``_SMTP_FALLBACK_EXCS``, so an unsafe send hard-fails instead of
+        silently falling back to an equally-unsafe AppleScript send.
+
+        Raises:
+            MailSafetyError: A recipient is not on a reserved test domain
+                while ``MAIL_TEST_MODE`` is set.
+            OSError / smtplib.SMTPException: Connection / SMTP failures (the
+                caller catches these to fall back to AppleScript).
+        """
+        violation = send_recipients_test_violation(recipients)
+        if violation:
+            raise MailSafetyError(violation)
+        host, port, login_email = smtp_config
+        password = self._get_imap_password_with_fallback(from_account, login_email)
+        SmtpSender(host, port, login_email, password, timeout=self.timeout).send(
+            raw_message, recipients
+        )
+
+    def _send_new_via_smtp(
+        self,
+        *,
+        from_account: str,
+        to: list[str],
+        cc: list[str] | None,
+        bcc: list[str] | None,
+        subject: str,
+        body: str,
+        attachment_paths: list[Path] | None,
+        smtp_config: tuple[str, int, str],
+    ) -> dict[str, str]:
+        """Build a clean fresh-compose RFC 822 message and SMTP-send it
+        (issue #322 — the ``seed="new"`` send analog of the #246 draft path).
+        """
+        sender = self._resolve_account_to_sender(from_account)
+        _message_id, raw = build_draft_mime(
+            sender=sender,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            subject=subject,
+            body=body,
+            attachments=(
+                [Path(p) for p in attachment_paths] if attachment_paths else None
+            ),
+        )
+        recipients = list(to) + list(cc or []) + list(bcc or [])
+        self._smtp_send(from_account, raw, recipients, smtp_config=smtp_config)
+        self._imap_clear_breaker(from_account)
+        return {"draft_id": "", "sent_message_id": ""}
+
+    def _send_reply_forward_via_smtp(
+        self,
+        *,
+        seed: str,
+        seed_id: str,
+        seed_mailbox: str,
+        from_account: str,
+        to: list[str] | None,
+        cc: list[str] | None,
+        bcc: list[str] | None,
+        subject: str | None,
+        body: str,
+        reply_all: bool,
+        attachment_paths: list[Path] | None,
+        smtp_config: tuple[str, int, str],
+    ) -> dict[str, str]:
+        """Rebuild a clean reply/forward from the original (fetched over IMAP)
+        and SMTP-send it (issue #322 — the send analog of the #292 draft
+        path). Recipient derivation and the transport-boundary safety guard
+        both run against the fully-resolved recipient set."""
+        sender = self._resolve_account_to_sender(from_account)
+        host, port, email = self._resolve_imap_config(from_account)
+        password = self._get_imap_password_with_fallback(from_account, email)
+        imap = ImapConnector(host, port, email, password, pool=self._imap_pool)
+        _message_id, raw, recipients = self._build_reply_forward_mime(
+            imap=imap,
+            seed=seed,
+            seed_id=seed_id,
+            seed_mailbox=seed_mailbox,
+            sender=sender,
+            self_email=email,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            subject=subject,
+            body=body,
+            reply_all=reply_all,
+            attachment_paths=attachment_paths,
+        )
+        self._smtp_send(from_account, raw, recipients, smtp_config=smtp_config)
+        self._imap_clear_breaker(from_account)
+        return {"draft_id": "", "sent_message_id": ""}
+
+    def _try_clean_create_or_send(
+        self,
+        *,
+        seed: str,
+        seed_id: str | None,
+        seed_mailbox: str | None,
+        send_now: bool,
+        effective_account: str | None,
+        to: list[str] | None,
+        cc: list[str] | None,
+        bcc: list[str] | None,
+        subject: str | None,
+        body: str,
+        body_html: str | None,
+        reply_all: bool,
+        attachment_paths: list[Path] | None,
+    ) -> dict[str, str] | None:
+        """Try the clean, wrapper-free paths in order and return the first
+        that engages, or ``None`` to fall through to AppleScript.
+
+        - save-as-draft → IMAP APPEND (#245), then poke Mail.app to sync so
+          the draft surfaces locally (#269);
+        - ``send_now`` → SMTP submit (#322).
+
+        Both avoid Mail.app's AppleScript ``content`` setter and its
+        FB11734014 cite-blockquote. Extracted from ``create_draft`` so that
+        method stays under the complexity ceiling.
+        """
+        imap_result = self._try_imap_draft_paths(
+            seed=seed,
+            seed_id=seed_id,
+            seed_mailbox=seed_mailbox,
+            send_now=send_now,
+            effective_account=effective_account,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            subject=subject,
+            body=body,
+            body_html=body_html,
+            reply_all=reply_all,
+            attachment_paths=attachment_paths,
+        )
+        if imap_result is not None:
+            imap_result.setdefault("from_account", effective_account or "")
+            self._sync_account_drafts(effective_account)
+            return imap_result
+
+        # `_effective_from_account` deliberately does NOT auto-resolve an
+        # implicit account for send_now (#321), so an implicit-account send
+        # stays on the AppleScript path — pass `from_account` for clean SMTP.
+        smtp_result = self._try_smtp_send(
+            seed=seed,
+            seed_id=seed_id,
+            seed_mailbox=seed_mailbox,
+            send_now=send_now,
+            from_account=effective_account,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+            subject=subject,
+            body=body,
+            reply_all=reply_all,
+            attachment_paths=attachment_paths,
+        )
+        if smtp_result is not None:
+            smtp_result.setdefault("from_account", effective_account or "")
+            return smtp_result
+        return None
+
+    def _try_smtp_send(
+        self,
+        *,
+        seed: str,
+        seed_id: str | None,
+        seed_mailbox: str | None,
+        send_now: bool,
+        from_account: str | None,
+        to: list[str] | None,
+        cc: list[str] | None,
+        bcc: list[str] | None,
+        subject: str | None,
+        body: str,
+        reply_all: bool,
+        attachment_paths: list[Path] | None,
+    ) -> dict[str, str] | None:
+        """Clean SMTP send path for ``send_now=True`` (issue #322).
+
+        Submits a wrapper-free RFC 822 message over SMTP instead of Mail.app's
+        AppleScript ``tell theMessage to send`` (whose ``content`` setter
+        applies the FB11734014 cite-blockquote to sent mail). Returns the
+        send-result dict when it handles the request, or ``None`` to fall
+        through to the AppleScript send path.
+
+        Engages only for ``send_now`` with a known account, no open circuit
+        breaker, and a configured SMTP server. On the usual degradation
+        signals (SMTP not configured, no Keychain opt-in, network/protocol
+        failure, or a reply/forward folder-guess miss) it logs and returns
+        ``None``. A test-mode reserved-domain violation is NOT a degradation
+        signal — it propagates as ``MailSafetyError`` (#322/#175).
+        """
+        if not (
+            send_now
+            and from_account is not None
+            and not self._imap_breaker_open(from_account)
+        ):
+            return None
+        is_compose = seed == "new"
+        is_reply_forward = (
+            seed in ("reply", "forward")
+            and seed_id is not None
+            and "@" in seed_id
+        )
+        if not (is_compose or is_reply_forward):
+            return None
+        try:
+            smtp_config = self._resolve_smtp_config(from_account)
+            if not smtp_config[0]:
+                return None  # No SMTP server configured — fall through.
+            if is_compose:
+                return self._send_new_via_smtp(
+                    from_account=from_account,
+                    to=to or [],
+                    cc=cc,
+                    bcc=bcc,
+                    subject=subject or "",
+                    body=body,
+                    attachment_paths=attachment_paths,
+                    smtp_config=smtp_config,
+                )
+            return self._send_reply_forward_via_smtp(
+                seed=seed,
+                seed_id=cast(str, seed_id),
+                seed_mailbox=seed_mailbox or "INBOX",
+                from_account=from_account,
+                to=to,
+                cc=cc,
+                bcc=bcc,
+                subject=subject,
+                body=body,
+                reply_all=reply_all,
+                attachment_paths=attachment_paths,
+                smtp_config=smtp_config,
+            )
+        except _SMTP_FALLBACK_EXCS as exc:
+            self._log_imap_fallback(from_account, exc)
+        except MailMessageNotFoundError as exc:
+            # Original not in seed_mailbox (or wrong folder hint) — the
+            # AppleScript send path resolves the seed across all folders.
+            self._log_imap_fallback(from_account, exc)
+        return None
+
     def create_draft(
         self,
         *,
@@ -5007,8 +5442,18 @@ class AppleMailConnector:
         ``Fwd:`` subject + ``In-Reply-To``/``References`` threading are
         rebuilt in plain text (forwards carry the original's attachments).
         Falls back to AppleScript when IMAP isn't configured or the
-        original isn't in ``seed_mailbox``. ``send_now=True`` still uses
-        AppleScript.
+        original isn't in ``seed_mailbox``.
+
+        ``send_now=True`` takes the clean SMTP send path (issue #322): a
+        wrapper-free RFC 822 message (built by the same ``build_draft_mime``)
+        is submitted over the account's SMTP server, so sent mail no longer
+        carries the cite-blockquote wrapper either. It engages when the
+        account has SMTP + IMAP credentials configured, and falls back to the
+        AppleScript ``tell theMessage to send`` path (which does apply the
+        wrapper) when SMTP isn't available. In test mode
+        (``MAIL_TEST_MODE``) the SMTP path re-checks every resolved recipient
+        against the reserved-domain allowlist at the transport boundary and
+        raises ``MailSafetyError`` on a violation (#175).
 
         After an IMAP-path APPEND the account is synchronized so the draft
         appears in Mail.app's local Drafts pane promptly rather than after
@@ -5071,10 +5516,11 @@ class AppleMailConnector:
         # sender anyway, so the From is unchanged).
         effective_account = self._effective_from_account(from_account, send_now)
 
-        # Clean IMAP-APPEND paths (issue #245) avoid Mail.app's
-        # cite-blockquote wrapper (bug FB11734014); they return a draft
-        # dict, or None to fall through to AppleScript.
-        imap_result = self._try_imap_draft_paths(
+        # Clean (wrapper-free) paths that avoid Mail.app's cite-blockquote
+        # (bug FB11734014): IMAP-APPEND for save-as-draft (#245), SMTP submit
+        # for send_now (#322). Returns a result dict, or None to fall through
+        # to the AppleScript path below.
+        clean_result = self._try_clean_create_or_send(
             seed=seed,
             seed_id=seed_id,
             seed_mailbox=seed_mailbox,
@@ -5089,13 +5535,8 @@ class AppleMailConnector:
             reply_all=reply_all,
             attachment_paths=attachment_paths,
         )
-        if imap_result is not None:
-            imap_result.setdefault("from_account", effective_account or "")
-            # The draft is now on the server, but Mail.app doesn't poll
-            # Drafts on its own — nudge it to sync so the draft surfaces in
-            # the local UI promptly. (#269)
-            self._sync_account_drafts(effective_account)
-            return imap_result
+        if clean_result is not None:
+            return clean_result
 
         # HTML drafts exist only on the clean IMAP path (Mail.app's
         # AppleScript `content` setter is plain-text only). If the IMAP path

--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -5211,6 +5211,7 @@ class AppleMailConnector:
         recipients = list(to) + list(cc or []) + list(bcc or [])
         self._smtp_send(from_account, raw, recipients, smtp_config=smtp_config)
         self._imap_clear_breaker(from_account)
+        self._save_sent_copy(from_account, raw, answered=False)
         return {"draft_id": "", "sent_message_id": ""}
 
     def _send_reply_forward_via_smtp(
@@ -5254,7 +5255,74 @@ class AppleMailConnector:
         )
         self._smtp_send(from_account, raw, recipients, smtp_config=smtp_config)
         self._imap_clear_breaker(from_account)
+        # Reuse the connector already built for the original fetch — a reply
+        # carries \\Answered in Sent.
+        self._save_sent_copy(
+            from_account, raw, answered=(seed == "reply"), imap=imap
+        )
         return {"draft_id": "", "sent_message_id": ""}
+
+    def _save_sent_copy(
+        self,
+        from_account: str,
+        raw_message: bytes,
+        *,
+        answered: bool,
+        imap: ImapConnector | None = None,
+    ) -> None:
+        """Best-effort: APPEND a copy of a just-SMTP-sent message to the
+        account's Sent folder over IMAP (issue #406).
+
+        The SMTP send path (#322) submits directly via ``smtplib`` and so
+        loses the Sent-mailbox copy that Mail.app's AppleScript ``tell
+        theMessage to send`` used to save as a side effect. This restores it,
+        reusing the IMAP-APPEND infrastructure of the clean draft path
+        (#245/#246/#292) via :meth:`ImapConnector.append_sent_copy`.
+
+        Failure boundary (deliberate): by the time this runs the message has
+        already been accepted by the server and delivered to the recipient —
+        the send has *succeeded*. Any failure here (no Sent folder, IMAP
+        error, missing Keychain opt-in) is therefore logged and swallowed,
+        never raised. In particular it must never propagate into
+        :meth:`_try_smtp_send`'s fallback ``except`` clauses, because that
+        would drop through to the AppleScript ``tell theMessage to send`` path
+        and deliver a *second* copy — the exact duplicate-send class of bug
+        fixed for QUIT teardown in PR #404. Catching ``Exception`` broadly is
+        the intent: nothing about saving a courtesy copy may affect the send
+        outcome the caller already committed to.
+
+        Args:
+            from_account: Mail.app account whose Sent folder receives the copy.
+            raw_message: The exact bytes submitted over SMTP (still carrying
+                any ``Bcc`` header, which the Sent copy legitimately records).
+            answered: True when the sent message was a reply (adds
+                ``\\Answered`` to the Sent copy).
+            imap: An existing connector for ``from_account`` to reuse (the
+                reply/forward path already built one to fetch the original);
+                ``None`` means build one from the account's resolved config.
+        """
+        try:
+            if imap is None:
+                host, port, email = self._resolve_imap_config(from_account)
+                password = self._get_imap_password_with_fallback(
+                    from_account, email
+                )
+                imap = ImapConnector(
+                    host, port, email, password, pool=self._imap_pool
+                )
+            folder = imap.append_sent_copy(raw_message, answered=answered)
+            logger.debug(
+                "Saved Sent copy to %r for account %r", folder, from_account
+            )
+        except Exception as exc:  # best-effort — must never fail the send
+            logger.warning(
+                "SMTP send for account %r succeeded but saving a "
+                "Sent-mailbox copy failed; the message was delivered, so not "
+                "retrying (a retry could duplicate the send). Cause: %s",
+                from_account,
+                exc,
+                exc_info=True,
+            )
 
     def _try_clean_create_or_send(
         self,

--- a/src/apple_mail_fast_mcp/security.py
+++ b/src/apple_mail_fast_mcp/security.py
@@ -580,3 +580,37 @@ def check_test_mode_safety(
             )
 
     return None
+
+
+def send_recipients_test_violation(recipients: list[str]) -> str | None:
+    """Transport-boundary reserved-domain guard for send paths (#322/#175).
+
+    ``check_test_mode_safety`` runs in the server-tool wrapper, which only
+    sees the *caller-supplied* recipients. A send path that derives further
+    recipients inside the connector — e.g. an SMTP ``reply_all`` whose ``cc``
+    is pulled from the original message — can therefore reach the wire with
+    real addresses the server gate never validated. This is the #175 class
+    of bug re-armed by a new transport. Call this at the point where the
+    *final* envelope recipient set is known (just before handing bytes to
+    ``smtplib``) and refuse the send when it returns a message.
+
+    Returns:
+        ``None`` when the send is allowed (not in test mode, or every
+        recipient is on an RFC 2606 reserved test domain). Otherwise a
+        human-readable violation message. Outside test mode this always
+        returns ``None`` — it never constrains real sends.
+    """
+    if not _is_test_mode_enabled():
+        return None
+    if not recipients:
+        return (
+            "Test mode: send requires explicit recipients (implicit-reply "
+            "targets cannot be safety-verified before send)."
+        )
+    bad = [r for r in recipients if not _is_reserved_test_domain(r)]
+    if bad:
+        return (
+            "Test mode: recipients must use RFC 2606 reserved domains "
+            f"(example.com/.test/.invalid/etc.). Violations: {', '.join(bad)}"
+        )
+    return None

--- a/src/apple_mail_fast_mcp/server.py
+++ b/src/apple_mail_fast_mcp/server.py
@@ -30,6 +30,7 @@ from .exceptions import (
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
     MailRuleNotFoundError,
+    MailSafetyError,
     MailTemplateError,
     MailTemplateInvalidFormatError,
     MailTemplateInvalidNameError,
@@ -2669,6 +2670,11 @@ def _draft_action_error(op: str, e: Exception) -> dict[str, Any] | None:
         return {"success": False, "error": str(e), "error_type": "message_not_found"}
     if isinstance(e, MailAccountNotFoundError):
         return {"success": False, "error": str(e), "error_type": "account_not_found"}
+    if isinstance(e, MailSafetyError):
+        # Test-mode reserved-domain violation raised by the clean SMTP send
+        # path's transport-boundary guard (#322/#175). Surface it as a
+        # safety violation rather than a generic "unknown" error.
+        return {"success": False, "error": str(e), "error_type": "safety_violation"}
     if isinstance(e, FileNotFoundError):
         return {"success": False, "error": str(e), "error_type": "file_not_found"}
     if isinstance(e, MailDraftError):

--- a/src/apple_mail_fast_mcp/smtp_sender.py
+++ b/src/apple_mail_fast_mcp/smtp_sender.py
@@ -1,0 +1,139 @@
+"""SMTP submission for wrapper-free immediate send (issue #322).
+
+``create_draft(send_now=True)`` historically routed through Mail.app's
+AppleScript ``tell theMessage to send``, whose ``content`` setter wraps the
+body in an ``Apple-Mail-URLShareWrapper`` cite-blockquote that renders as a
+quote on iOS (Mail.app bug FB11734014, #245). IMAP ``APPEND`` fixed the
+draft case (#246/#292) but can only create drafts, never send. This module
+submits a clean RFC 822 message (built by
+:func:`apple_mail_fast_mcp.draft_builder.build_draft_mime`) over SMTP, so a
+direct send never touches the AppleScript ``content`` setter.
+
+Credential model: the account's IMAP app-password (see :mod:`keychain`) is
+reused. For every provider we support (iCloud, Gmail, Yahoo, Outlook) the
+same app-specific password authenticates both IMAP and SMTP submission, so
+we deliberately reuse the existing Keychain entry rather than building a
+parallel SMTP credential store (issue #322 "extend the keychain module").
+
+``smtplib`` is the single point of external I/O for this module and the mock
+boundary for unit tests, mirroring ``_run_applescript`` (AppleScript) and
+``IMAPClient`` (IMAP).
+"""
+
+from __future__ import annotations
+
+import logging
+import smtplib
+import ssl
+from email import message_from_bytes
+from email.message import Message
+from email.policy import default as _default_policy
+
+logger = logging.getLogger(__name__)
+
+# Implicit-TLS submission port (RFC 8314). Anything else (587 submission,
+# 25) is treated as explicit-TLS: connect cleartext, then STARTTLS.
+_SMTP_SSL_PORT = 465
+
+_DEFAULT_TIMEOUT_S = 30.0
+
+
+class SmtpSender:
+    """Submit a pre-built RFC 822 message over authenticated SMTP.
+
+    One instance targets one account's outgoing server. The message bytes
+    come from ``build_draft_mime`` (the same builder the clean IMAP draft
+    path uses), so message construction is already correct and tested — this
+    class only adds the send transport.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        email: str,
+        password: str,
+        *,
+        timeout: float = _DEFAULT_TIMEOUT_S,
+    ) -> None:
+        """Store connection parameters.
+
+        Args:
+            host: SMTP server hostname (e.g. ``smtp.mail.me.com``).
+            port: SMTP submission port. ``465`` uses implicit TLS
+                (``SMTP_SSL``); any other value connects cleartext then
+                issues ``STARTTLS``.
+            email: SMTP AUTH username / envelope ``MAIL FROM`` address.
+            password: App-specific password (shared with IMAP; see module
+                docstring).
+            timeout: Socket timeout in seconds.
+        """
+        self._host = host
+        self._port = port
+        self._email = email
+        self._password = password
+        self._timeout = timeout
+
+    def send(self, raw_message: bytes, recipients: list[str]) -> None:
+        """Authenticate and submit ``raw_message`` to ``recipients``.
+
+        The ``Bcc`` header is stripped from the transmitted message — blind
+        recipients are carried only in the envelope ``RCPT TO`` list, never
+        on the wire — while the caller-supplied ``recipients`` list is used
+        verbatim as the envelope recipients (it already includes any Bcc).
+
+        Args:
+            raw_message: A serialized RFC 822 message from
+                ``build_draft_mime``.
+            recipients: The full envelope recipient list (to + cc + bcc).
+                Must be non-empty.
+
+        Raises:
+            ValueError: ``recipients`` is empty.
+            smtplib.SMTPException: Any SMTP-level failure (auth, refused
+                recipient, protocol error). Callers that want graceful
+                AppleScript fallback catch this plus ``OSError``.
+            OSError: Connection failure (host unreachable, TLS error,
+                timeout).
+        """
+        if not recipients:
+            raise ValueError("SMTP send requires at least one recipient")
+
+        msg = message_from_bytes(raw_message, policy=_default_policy)
+        # A Bcc header must never travel on the wire; the envelope RCPT list
+        # (passed explicitly below) is what actually delivers to blind
+        # recipients. ``del`` is a no-op when no Bcc header is present.
+        del msg["Bcc"]
+
+        context = ssl.create_default_context()
+        if self._port == _SMTP_SSL_PORT:
+            with smtplib.SMTP_SSL(
+                self._host, self._port, timeout=self._timeout, context=context
+            ) as client:
+                self._authenticate_and_send(client, msg, recipients)
+        else:
+            with smtplib.SMTP(
+                self._host, self._port, timeout=self._timeout
+            ) as client:
+                client.ehlo()
+                client.starttls(context=context)
+                client.ehlo()
+                self._authenticate_and_send(client, msg, recipients)
+
+    def _authenticate_and_send(
+        self,
+        client: smtplib.SMTP,
+        msg: Message,
+        recipients: list[str],
+    ) -> None:
+        """Log in and hand the message to ``send_message`` with an explicit
+        envelope (``MAIL FROM`` = the login address, ``RCPT TO`` = the
+        caller-supplied recipient list)."""
+        client.login(self._email, self._password)
+        client.send_message(msg, from_addr=self._email, to_addrs=recipients)
+        logger.debug(
+            "SMTP send via %s:%d to %d recipient(s)",
+            self._host,
+            self._port,
+            len(recipients),
+        )

--- a/src/apple_mail_fast_mcp/smtp_sender.py
+++ b/src/apple_mail_fast_mcp/smtp_sender.py
@@ -28,6 +28,7 @@ import ssl
 from email import message_from_bytes
 from email.message import Message
 from email.policy import default as _default_policy
+from email.utils import parseaddr
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,12 @@ class SmtpSender:
             port: SMTP submission port. ``465`` uses implicit TLS
                 (``SMTP_SSL``); any other value connects cleartext then
                 issues ``STARTTLS``.
-            email: SMTP AUTH username / envelope ``MAIL FROM`` address.
+            email: SMTP AUTH username (the login credential). This is *not*
+                necessarily the envelope ``MAIL FROM`` address — for a
+                custom-domain iCloud account, or a Gmail/Outlook send-as
+                alias, the login and the sending identity legitimately
+                differ. The envelope-from is resolved separately in
+                :meth:`send`.
             password: App-specific password (shared with IMAP; see module
                 docstring).
             timeout: Socket timeout in seconds.
@@ -74,7 +80,13 @@ class SmtpSender:
         self._password = password
         self._timeout = timeout
 
-    def send(self, raw_message: bytes, recipients: list[str]) -> None:
+    def send(
+        self,
+        raw_message: bytes,
+        recipients: list[str],
+        *,
+        envelope_from: str | None = None,
+    ) -> None:
         """Authenticate and submit ``raw_message`` to ``recipients``.
 
         The ``Bcc`` header is stripped from the transmitted message — blind
@@ -82,19 +94,44 @@ class SmtpSender:
         on the wire — while the caller-supplied ``recipients`` list is used
         verbatim as the envelope recipients (it already includes any Bcc).
 
+        Envelope ``MAIL FROM`` is the *sender's own address*, kept separate
+        from the SMTP AUTH login (``self._email``). The two frequently
+        differ: a custom-domain iCloud account authenticates as its Apple ID
+        login (e.g. ``appleid@example.com``) but sends *as* its configured
+        send-as address (e.g. ``you@example.com``); Gmail and Outlook send-as
+        aliases behave the same way. Reusing the login as the envelope sender
+        makes iCloud reject the message with ``550 5.7.0 From address is not
+        one of your addresses`` (issue #322 / PR #404). When ``envelope_from``
+        is ``None`` the address is taken from the message ``From:`` header —
+        the same address the recipient sees.
+
+        Once the server accepts the message (``send_message`` returns), any
+        error raised while tearing the session down is swallowed rather than
+        propagated. The notable case is a non-221 reply to ``QUIT``: on
+        exiting the ``with`` block ``smtplib.SMTP.__exit__`` issues ``QUIT``
+        and raises ``SMTPResponseException`` for any non-221 reply. Sending
+        is non-idempotent, so letting that propagate would make the caller's
+        AppleScript fallback deliver a *second* copy (PR #404 review). Errors
+        *before* acceptance (connect, AUTH, refused recipient, rejected DATA)
+        still propagate so the caller can fall back safely.
+
         Args:
             raw_message: A serialized RFC 822 message from
                 ``build_draft_mime``.
             recipients: The full envelope recipient list (to + cc + bcc).
                 Must be non-empty.
+            envelope_from: Explicit envelope ``MAIL FROM`` address. When
+                ``None``, it is parsed from the message ``From:`` header.
 
         Raises:
-            ValueError: ``recipients`` is empty.
-            smtplib.SMTPException: Any SMTP-level failure (auth, refused
-                recipient, protocol error). Callers that want graceful
-                AppleScript fallback catch this plus ``OSError``.
+            ValueError: ``recipients`` is empty, or no envelope-from address
+                could be resolved (no override and no parseable ``From:``).
+            smtplib.SMTPException: An SMTP-level failure *before* the message
+                was accepted (auth, refused recipient, protocol error).
+                Callers that want graceful AppleScript fallback catch this
+                plus ``OSError``.
             OSError: Connection failure (host unreachable, TLS error,
-                timeout).
+                timeout) before acceptance.
         """
         if not recipients:
             raise ValueError("SMTP send requires at least one recipient")
@@ -104,36 +141,92 @@ class SmtpSender:
         # (passed explicitly below) is what actually delivers to blind
         # recipients. ``del`` is a no-op when no Bcc header is present.
         del msg["Bcc"]
+        env_from = self._resolve_envelope_from(msg, envelope_from)
 
         context = ssl.create_default_context()
-        if self._port == _SMTP_SSL_PORT:
-            with smtplib.SMTP_SSL(
-                self._host, self._port, timeout=self._timeout, context=context
-            ) as client:
-                self._authenticate_and_send(client, msg, recipients)
-        else:
-            with smtplib.SMTP(
-                self._host, self._port, timeout=self._timeout
-            ) as client:
-                client.ehlo()
-                client.starttls(context=context)
-                client.ehlo()
-                self._authenticate_and_send(client, msg, recipients)
+        accepted = False
+        try:
+            if self._port == _SMTP_SSL_PORT:
+                with smtplib.SMTP_SSL(
+                    self._host, self._port, timeout=self._timeout, context=context
+                ) as client:
+                    self._authenticate_and_send(client, msg, recipients, env_from)
+                    accepted = True
+            else:
+                with smtplib.SMTP(
+                    self._host, self._port, timeout=self._timeout
+                ) as client:
+                    client.ehlo()
+                    client.starttls(context=context)
+                    client.ehlo()
+                    self._authenticate_and_send(client, msg, recipients, env_from)
+                    accepted = True
+        except (smtplib.SMTPException, OSError):
+            # Not yet accepted → a real send failure; propagate so the caller
+            # falls back to AppleScript. Already accepted → the message is
+            # out; the only thing left to fail is session teardown (e.g. a
+            # non-221 QUIT surfaced by ``SMTP.__exit__``). Swallow it — a
+            # duplicate AppleScript send would otherwise follow (PR #404).
+            if not accepted:
+                raise
+            logger.warning(
+                "SMTP message accepted by %s but session teardown failed; "
+                "not retrying, to avoid a duplicate send",
+                self._host,
+                exc_info=True,
+            )
+
+    def _resolve_envelope_from(self, msg: Message, override: str | None) -> str:
+        """Resolve the envelope ``MAIL FROM`` address (issue #322 / PR #404).
+
+        Precedence: an explicit ``override``, else the message ``From:``
+        header. Either way the bare address is extracted with
+        ``email.utils.parseaddr``, so a display-name form (``Name <addr>``)
+        yields just ``addr``. This is deliberately independent of the SMTP
+        AUTH login (``self._email``): the two legitimately differ for
+        custom-domain iCloud and send-as-alias setups.
+
+        Args:
+            msg: The parsed message whose ``From:`` header is the fallback
+                source of the envelope sender.
+            override: An explicit envelope-from address, or ``None``.
+
+        Returns:
+            The bare envelope ``MAIL FROM`` address.
+
+        Raises:
+            ValueError: Neither an override nor a parseable ``From:`` address
+                is available.
+        """
+        source = override if override else msg.get("From", "")
+        address = parseaddr(source)[1]
+        if not address:
+            raise ValueError(
+                "SMTP send requires an envelope-from address "
+                "(no override and no parseable From: header)"
+            )
+        return address
 
     def _authenticate_and_send(
         self,
         client: smtplib.SMTP,
         msg: Message,
         recipients: list[str],
+        envelope_from: str,
     ) -> None:
-        """Log in and hand the message to ``send_message`` with an explicit
-        envelope (``MAIL FROM`` = the login address, ``RCPT TO`` = the
-        caller-supplied recipient list)."""
+        """Log in with the AUTH credential and submit the message.
+
+        The SMTP AUTH login (``self._email``) and the envelope ``MAIL FROM``
+        (``envelope_from``) are passed as two distinct values — see
+        :meth:`send` for why they legitimately differ. ``RCPT TO`` is the
+        caller-supplied recipient list.
+        """
         client.login(self._email, self._password)
-        client.send_message(msg, from_addr=self._email, to_addrs=recipients)
+        client.send_message(msg, from_addr=envelope_from, to_addrs=recipients)
         logger.debug(
-            "SMTP send via %s:%d to %d recipient(s)",
+            "SMTP send via %s:%d as %s to %d recipient(s)",
             self._host,
             self._port,
+            envelope_from,
             len(recipients),
         )

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -3595,6 +3595,100 @@ class TestAppendDraft:
         assert mock_client.append.call_args[0][0] == "Drafts"
 
 
+class TestAppendSentCopy:
+    """#406: after an SMTP send (#322), a copy is APPENDed to the account's
+    Sent folder over IMAP (Mail.app's AppleScript send used to do this as a
+    side effect). Mirrors TestAppendDraft: SPECIAL-USE first, conventional
+    fallback, plus the \\Seen / \\Answered flag conventions."""
+
+    @patch("apple_mail_fast_mcp.imap_connector.IMAPClient")
+    def test_appends_to_special_use_sent_with_seen_flag(self, mock_cls):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\Sent", b"\\HasNoChildren"), b"/", "[Gmail]/Sent Mail"),
+        ]
+
+        conn = ImapConnector("imap.gmail.com", 993, "u@gmail.com", "pw")
+        folder = conn.append_sent_copy(b"raw-bytes")
+
+        assert folder == "[Gmail]/Sent Mail"
+        args, kwargs = mock_client.append.call_args
+        assert args[0] == "[Gmail]/Sent Mail"
+        assert args[1] == b"raw-bytes"
+        flags = kwargs.get("flags", args[2] if len(args) > 2 else None)
+        assert flags is not None
+        assert b"\\Seen" in list(flags)
+        # A non-reply must NOT be marked answered.
+        assert b"\\Answered" not in list(flags)
+        mock_client.logout.assert_called_once()
+
+    @patch("apple_mail_fast_mcp.imap_connector.IMAPClient")
+    def test_falls_back_to_conventional_icloud_sent_messages(self, mock_cls):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        # iCloud does not advertise \Sent SPECIAL-USE; it names the folder
+        # "Sent Messages".
+        mock_client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\HasNoChildren",), b"/", "Sent Messages"),
+        ]
+
+        conn = ImapConnector("imap.mail.me.com", 993, "u@me.com", "pw")
+        folder = conn.append_sent_copy(b"raw-bytes")
+
+        assert folder == "Sent Messages"
+        assert mock_client.append.call_args[0][0] == "Sent Messages"
+
+    @patch("apple_mail_fast_mcp.imap_connector.IMAPClient")
+    def test_conventional_fallback_handles_bytes_folder_names(self, mock_cls):
+        # Some servers return folder names as bytes rather than str; the
+        # convention scan must decode them before matching.
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", b"INBOX"),
+            ((b"\\HasNoChildren",), b"/", b"Sent Messages"),
+        ]
+
+        conn = ImapConnector("imap.mail.me.com", 993, "u@me.com", "pw")
+        folder = conn.append_sent_copy(b"raw-bytes")
+
+        assert folder == "Sent Messages"
+
+    @patch("apple_mail_fast_mcp.imap_connector.IMAPClient")
+    def test_reply_copy_is_marked_answered(self, mock_cls):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.list_folders.return_value = [
+            ((b"\\Sent",), b"/", "Sent"),
+        ]
+
+        conn = ImapConnector("imap.example.com", 993, "u@e.com", "pw")
+        conn.append_sent_copy(b"raw-bytes", answered=True)
+
+        _args, kwargs = mock_client.append.call_args
+        flags = list(kwargs["flags"])
+        assert b"\\Seen" in flags
+        assert b"\\Answered" in flags
+
+    @patch("apple_mail_fast_mcp.imap_connector.IMAPClient")
+    def test_no_sent_folder_raises_not_found(self, mock_cls):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        # Neither SPECIAL-USE \Sent nor any conventional name present.
+        mock_client.list_folders.return_value = [
+            ((b"\\HasNoChildren",), b"/", "INBOX"),
+            ((b"\\HasNoChildren",), b"/", "Archive"),
+        ]
+
+        conn = ImapConnector("imap.example.com", 993, "u@e.com", "pw")
+        with pytest.raises(MailMessageNotFoundError):
+            conn.append_sent_copy(b"raw-bytes")
+        mock_client.append.assert_not_called()
+
+
 class TestEnvelopeVanishRobustness:
     """#314: a message can be expunged/moved between SEARCH and FETCH (a
     concurrent change), so the server's FETCH response omits ENVELOPE for

--- a/tests/unit/test_imap_providers.py
+++ b/tests/unit/test_imap_providers.py
@@ -81,3 +81,30 @@ class TestProviderTable:
         assert all(
             p.app_password_url for k, p in PROVIDERS.items() if k != "generic"
         )
+
+
+class TestSmtpSavesSentCopy:
+    """Gmail's SMTP server auto-files submitted mail into Sent Mail
+    server-side; every other provider we support does not. The
+    ``smtp_saves_sent_copy`` flag lets the send path skip its own Sent-copy
+    APPEND for Gmail to avoid a duplicate (#406 / PR #404 re-review)."""
+
+    def test_only_gmail_auto_saves(self):
+        assert PROVIDERS["gmail"].smtp_saves_sent_copy is True
+        assert all(
+            p.smtp_saves_sent_copy is False
+            for k, p in PROVIDERS.items()
+            if k != "gmail"
+        )
+
+    def test_detect_carries_the_flag(self):
+        # Both the SMTP host and the IMAP host resolve to the Gmail provider.
+        assert detect_provider(
+            "smtp.gmail.com", "me@x.test"
+        ).smtp_saves_sent_copy
+        assert detect_provider(
+            "imap.gmail.com", "me@gmail.com"
+        ).smtp_saves_sent_copy
+        assert not detect_provider(
+            "smtp.x.test", "me@x.test"
+        ).smtp_saves_sent_copy

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -8112,7 +8112,7 @@ class TestSmtpSendPath:
     def connector(self) -> AppleMailConnector:
         return AppleMailConnector(timeout=30)
 
-    def _configure_smtp(
+    def _configure_smtp_without_sent_stub(
         self,
         connector: AppleMailConnector,
         monkeypatch: pytest.MonkeyPatch,
@@ -8122,7 +8122,9 @@ class TestSmtpSendPath:
         email: str = "me@x.test",
         password: str = "pw",
     ) -> None:
-        """Wire the connector so the SMTP path engages without real I/O."""
+        """Wire the connector so the SMTP path engages without real I/O,
+        leaving ``_save_sent_copy`` real so the Sent-copy behavior (#406) can
+        be exercised (with ``ImapConnector`` patched at the class boundary)."""
         monkeypatch.setattr(
             connector, "_resolve_smtp_config", lambda account: (host, port, email)
         )
@@ -8141,6 +8143,31 @@ class TestSmtpSendPath:
         )
         monkeypatch.setattr(connector, "_imap_breaker_open", lambda account: False)
         monkeypatch.setattr(connector, "_imap_clear_breaker", lambda account: None)
+
+    def _configure_smtp(
+        self,
+        connector: AppleMailConnector,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        host: str = "smtp.x.test",
+        port: int = 587,
+        email: str = "me@x.test",
+        password: str = "pw",
+    ) -> None:
+        """Wire the connector so the SMTP path engages without real I/O.
+
+        These transport tests assert on the SMTP submission, not the
+        post-send Sent-mailbox copy (#406), which would otherwise attempt
+        real IMAP I/O — so ``_save_sent_copy`` is stubbed. The Sent-copy
+        behavior has its own dedicated coverage (see the ``#406`` tests,
+        which use :meth:`_configure_smtp_without_sent_stub`)."""
+        self._configure_smtp_without_sent_stub(
+            connector, monkeypatch,
+            host=host, port=port, email=email, password=password,
+        )
+        monkeypatch.setattr(
+            connector, "_save_sent_copy", lambda *a, **k: None
+        )
 
     # --- the bug regression -------------------------------------------------
 
@@ -8395,6 +8422,113 @@ class TestSmtpSendPath:
             )
         assert result is None
         sender_cls.assert_not_called()
+
+    # --- Sent-mailbox copy after a successful send (#406) -------------------
+
+    def test_compose_send_saves_sent_copy(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#406: a successful compose send APPENDs a copy to the account's
+        Sent folder over IMAP (not marked as a reply)."""
+        self._configure_smtp_without_sent_stub(connector, monkeypatch)
+        monkeypatch.setattr(connector, "_run_applescript", lambda s: "")
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender"), patch(
+            "apple_mail_fast_mcp.mail_connector.ImapConnector"
+        ) as imap_cls:
+            connector.create_draft(
+                seed="new",
+                to=["a@example.com"],
+                subject="Hi",
+                body="Hello there",
+                from_account="Gmail",
+                send_now=True,
+            )
+        imap_cls.return_value.append_sent_copy.assert_called_once()
+        _args, kwargs = imap_cls.return_value.append_sent_copy.call_args
+        assert kwargs.get("answered") is False
+
+    def test_reply_send_saves_sent_copy_marked_answered(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#406: a reply send saves an \\Answered Sent copy, reusing the
+        connector already built to fetch the original."""
+        self._configure_smtp_without_sent_stub(connector, monkeypatch)
+        monkeypatch.setattr(
+            connector,
+            "_build_reply_forward_mime",
+            lambda **kw: ("<m@id>", b"rawreply", ["orig@example.net"]),
+        )
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender"), patch(
+            "apple_mail_fast_mcp.mail_connector.ImapConnector"
+        ) as imap_cls:
+            connector._try_smtp_send(
+                seed="reply", seed_id="orig@id", seed_mailbox="INBOX",
+                send_now=True, from_account="Gmail", to=None, cc=None, bcc=None,
+                subject=None, body="thanks", reply_all=False,
+                attachment_paths=None,
+            )
+        imap_cls.return_value.append_sent_copy.assert_called_once()
+        _args, kwargs = imap_cls.return_value.append_sent_copy.call_args
+        assert kwargs.get("answered") is True
+
+    def test_forward_send_sent_copy_not_answered(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A forward is not a reply, so its Sent copy is not \\Answered."""
+        self._configure_smtp_without_sent_stub(connector, monkeypatch)
+        monkeypatch.setattr(
+            connector,
+            "_build_reply_forward_mime",
+            lambda **kw: ("<m@id>", b"rawfwd", ["dest@example.net"]),
+        )
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender"), patch(
+            "apple_mail_fast_mcp.mail_connector.ImapConnector"
+        ) as imap_cls:
+            connector._try_smtp_send(
+                seed="forward", seed_id="orig@id", seed_mailbox="INBOX",
+                send_now=True, from_account="Gmail", to=["dest@example.net"],
+                cc=None, bcc=None, subject=None, body="fyi", reply_all=False,
+                attachment_paths=None,
+            )
+        _args, kwargs = imap_cls.return_value.append_sent_copy.call_args
+        assert kwargs.get("answered") is False
+
+    def test_sent_copy_failure_is_swallowed_and_no_applescript_fallback(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#406 hard rule: the message is already delivered when the Sent-copy
+        APPEND runs, so a failure there must be swallowed (logged, not raised)
+        and must NOT trigger the AppleScript ``tell theMessage to send``
+        fallback — that would deliver a duplicate (the PR #404 double-send
+        class of bug). The send result is still the normal success dict."""
+        self._configure_smtp_without_sent_stub(connector, monkeypatch)
+        scripts: list[str] = []
+        monkeypatch.setattr(
+            connector, "_run_applescript", lambda s: scripts.append(s) or "SENT"
+        )
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender"), patch(
+            "apple_mail_fast_mcp.mail_connector.ImapConnector"
+        ) as imap_cls:
+            # Sent-copy APPEND blows up hard (no Sent folder, protocol error…).
+            imap_cls.return_value.append_sent_copy.side_effect = (
+                MailMessageNotFoundError("no Sent folder")
+            )
+            result = connector.create_draft(
+                seed="new",
+                to=["a@example.com"],
+                subject="Hi",
+                body="Hello there",
+                from_account="Gmail",
+                send_now=True,
+            )
+        # The failure was swallowed: normal success dict, single SMTP send,
+        # and crucially NO AppleScript fallback send.
+        assert result == {
+            "draft_id": "",
+            "sent_message_id": "",
+            "from_account": "Gmail",
+        }
+        assert not any("tell theMessage to send" in s for s in scripts)
 
     # --- test-mode transport-boundary safety guard (#322 / #175) -----------
 

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -8247,6 +8247,48 @@ class TestSmtpSendPath:
             )
         assert any("tell theMessage to send" in s for s in scripts)
 
+    def test_non_221_quit_after_accept_does_not_double_send(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PR #404: if the server accepts the message (send_message → 250) but
+        then returns a non-221 to QUIT, ``SMTP.__exit__`` raises
+        ``SMTPResponseException``. That teardown error must NOT propagate into
+        an AppleScript fallback — otherwise a second copy is sent. Uses a real
+        ``SmtpSender`` over a mocked ``smtplib`` so the whole send path (not
+        just a mocked SmtpSender) is exercised.
+        """
+        self._configure_smtp(connector, monkeypatch)
+        scripts: list[str] = []
+        monkeypatch.setattr(
+            connector, "_run_applescript", lambda s: scripts.append(s) or "SENT"
+        )
+        with patch(
+            "apple_mail_fast_mcp.smtp_sender.smtplib.SMTP"
+        ) as mock_smtp:
+            client = mock_smtp.return_value.__enter__.return_value
+            # send_message succeeds (message accepted); QUIT on `with` exit
+            # returns non-221, which SMTP.__exit__ raises.
+            mock_smtp.return_value.__exit__.side_effect = (
+                smtplib.SMTPResponseException(421, b"4.7.0 try later")
+            )
+            result = connector.create_draft(
+                seed="new",
+                to=["a@example.com"],
+                subject="Hi",
+                body="Hello there",
+                from_account="Gmail",
+                send_now=True,
+            )
+
+        # Exactly one real SMTP submission, and no AppleScript duplicate.
+        client.send_message.assert_called_once()
+        assert not any("tell theMessage to send" in s for s in scripts)
+        assert result == {
+            "draft_id": "",
+            "sent_message_id": "",
+            "from_account": "Gmail",
+        }
+
     def test_keychain_miss_falls_back_to_applescript(
         self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -8493,6 +8493,55 @@ class TestSmtpSendPath:
         _args, kwargs = imap_cls.return_value.append_sent_copy.call_args
         assert kwargs.get("answered") is False
 
+    def test_gmail_send_skips_sent_copy_because_gmail_auto_saves(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PR #404 re-review: Gmail's SMTP server auto-files submitted mail
+        into ``[Gmail]/Sent Mail`` server-side. Appending our own copy would
+        create a DUPLICATE in Sent, so for Gmail (and any provider flagged
+        ``smtp_saves_sent_copy``) the post-send APPEND is skipped. Verified
+        empirically against a live Gmail account during the #404 review."""
+        self._configure_smtp_without_sent_stub(
+            connector, monkeypatch, host="smtp.gmail.com", email="me@gmail.com"
+        )
+        monkeypatch.setattr(connector, "_run_applescript", lambda s: "")
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender"), patch(
+            "apple_mail_fast_mcp.mail_connector.ImapConnector"
+        ) as imap_cls:
+            connector.create_draft(
+                seed="new",
+                to=["a@example.com"],
+                subject="Hi",
+                body="Hello there",
+                from_account="Gmail",
+                send_now=True,
+            )
+        imap_cls.return_value.append_sent_copy.assert_not_called()
+
+    def test_gmail_reply_send_also_skips_sent_copy(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Gmail skip applies to the reply/forward path too (which reuses
+        the fetch connector), not just fresh compose."""
+        self._configure_smtp_without_sent_stub(
+            connector, monkeypatch, host="smtp.gmail.com", email="me@gmail.com"
+        )
+        monkeypatch.setattr(
+            connector,
+            "_build_reply_forward_mime",
+            lambda **kw: ("<m@id>", b"rawreply", ["orig@example.net"]),
+        )
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender"), patch(
+            "apple_mail_fast_mcp.mail_connector.ImapConnector"
+        ) as imap_cls:
+            connector._try_smtp_send(
+                seed="reply", seed_id="orig@id", seed_mailbox="INBOX",
+                send_now=True, from_account="Gmail", to=None, cc=None, bcc=None,
+                subject=None, body="thanks", reply_all=False,
+                attachment_paths=None,
+            )
+        imap_cls.return_value.append_sent_copy.assert_not_called()
+
     def test_sent_copy_failure_is_swallowed_and_no_applescript_fallback(
         self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1,6 +1,7 @@
 """Unit tests for mail connector."""
 
 import logging
+import smtplib
 import time
 import warnings
 from pathlib import Path
@@ -21,6 +22,7 @@ from apple_mail_fast_mcp.exceptions import (
     MailKeychainEntryNotFoundError,
     MailMailboxNotFoundError,
     MailMessageNotFoundError,
+    MailSafetyError,
 )
 from apple_mail_fast_mcp.mail_connector import (
     AppleMailConnector,
@@ -8096,3 +8098,371 @@ class TestSyncAccountDrafts:
                 from_account="iCloud",
             )
         assert result["draft_id"] == "<m@h>"
+
+
+class TestSmtpSendPath:
+    """#322: create_draft(send_now=True) submits a wrapper-free RFC 822
+    message over SMTP, bypassing Mail.app's AppleScript
+    ``tell theMessage to send`` (whose ``content`` setter applies the
+    FB11734014 cite-blockquote to sent mail). The SMTP boundary is
+    ``mail_connector.SmtpSender``.
+    """
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    def _configure_smtp(
+        self,
+        connector: AppleMailConnector,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        host: str = "smtp.x.test",
+        port: int = 587,
+        email: str = "me@x.test",
+        password: str = "pw",
+    ) -> None:
+        """Wire the connector so the SMTP path engages without real I/O."""
+        monkeypatch.setattr(
+            connector, "_resolve_smtp_config", lambda account: (host, port, email)
+        )
+        monkeypatch.setattr(
+            connector,
+            "_resolve_imap_config",
+            lambda account: ("imap.x.test", 993, email),
+        )
+        monkeypatch.setattr(
+            connector,
+            "_get_imap_password_with_fallback",
+            lambda account, e: password,
+        )
+        monkeypatch.setattr(
+            connector, "_resolve_account_to_sender", lambda account: email
+        )
+        monkeypatch.setattr(connector, "_imap_breaker_open", lambda account: False)
+        monkeypatch.setattr(connector, "_imap_clear_breaker", lambda account: None)
+
+    # --- the bug regression -------------------------------------------------
+
+    def test_send_now_compose_uses_smtp_not_applescript(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression for #322: with SMTP configured, a fresh send_now is
+        submitted over SMTP as a clean (no cite-blockquote) message and the
+        AppleScript ``tell theMessage to send`` path is never reached."""
+        self._configure_smtp(connector, monkeypatch)
+        scripts: list[str] = []
+        monkeypatch.setattr(
+            connector, "_run_applescript", lambda s: scripts.append(s) or ""
+        )
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender") as sender_cls:
+            result = connector.create_draft(
+                seed="new",
+                to=["a@example.com"],
+                subject="Hi",
+                body="Hello there",
+                from_account="Gmail",
+                send_now=True,
+            )
+
+        assert not any("tell theMessage to send" in s for s in scripts)
+        sender_cls.assert_called_once()
+        sender_cls.return_value.send.assert_called_once()
+        raw, recipients = sender_cls.return_value.send.call_args.args
+        assert b"Hello there" in raw
+        assert b"blockquote" not in raw.lower()  # FB11734014 wrapper absent
+        assert recipients == ["a@example.com"]
+        assert result == {
+            "draft_id": "",
+            "sent_message_id": "",
+            "from_account": "Gmail",
+        }
+
+    def test_send_now_compose_includes_cc_and_bcc_in_envelope(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._configure_smtp(connector, monkeypatch)
+        monkeypatch.setattr(connector, "_run_applescript", lambda s: "")
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender") as sender_cls:
+            connector.create_draft(
+                seed="new",
+                to=["a@example.com"],
+                cc=["c@example.net"],
+                bcc=["b@example.org"],
+                subject="Hi",
+                body="x",
+                from_account="Gmail",
+                send_now=True,
+            )
+        _raw, recipients = sender_cls.return_value.send.call_args.args
+        assert recipients == ["a@example.com", "c@example.net", "b@example.org"]
+
+    # --- graceful fallback --------------------------------------------------
+
+    def test_smtp_not_configured_falls_back_to_applescript(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            connector, "_resolve_smtp_config", lambda account: ("", 0, "")
+        )
+        monkeypatch.setattr(connector, "_imap_breaker_open", lambda account: False)
+        monkeypatch.setattr(
+            connector, "_resolve_account_to_sender", lambda account: "me@x.test"
+        )
+        scripts: list[str] = []
+        monkeypatch.setattr(
+            connector, "_run_applescript", lambda s: scripts.append(s) or "SENT"
+        )
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender") as sender_cls:
+            connector.create_draft(
+                seed="new",
+                to=["a@example.com"],
+                subject="Hi",
+                body="x",
+                from_account="Gmail",
+                send_now=True,
+            )
+        sender_cls.assert_not_called()
+        assert any("tell theMessage to send" in s for s in scripts)
+
+    def test_smtp_failure_falls_back_to_applescript(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._configure_smtp(connector, monkeypatch)
+        scripts: list[str] = []
+        monkeypatch.setattr(
+            connector, "_run_applescript", lambda s: scripts.append(s) or "SENT"
+        )
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender") as sender_cls:
+            sender_cls.return_value.send.side_effect = (
+                smtplib.SMTPAuthenticationError(535, b"bad creds")
+            )
+            connector.create_draft(
+                seed="new",
+                to=["a@example.com"],
+                subject="Hi",
+                body="x",
+                from_account="Gmail",
+                send_now=True,
+            )
+        assert any("tell theMessage to send" in s for s in scripts)
+
+    def test_keychain_miss_falls_back_to_applescript(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._configure_smtp(connector, monkeypatch)
+
+        def _raise(account: str, email: str) -> str:
+            raise MailKeychainEntryNotFoundError("no opt-in")
+
+        monkeypatch.setattr(
+            connector, "_get_imap_password_with_fallback", _raise
+        )
+        scripts: list[str] = []
+        monkeypatch.setattr(
+            connector, "_run_applescript", lambda s: scripts.append(s) or "SENT"
+        )
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender") as sender_cls:
+            connector.create_draft(
+                seed="new",
+                to=["a@example.com"],
+                subject="Hi",
+                body="x",
+                from_account="Gmail",
+                send_now=True,
+            )
+        sender_cls.assert_not_called()
+        assert any("tell theMessage to send" in s for s in scripts)
+
+    # --- non-engagement -----------------------------------------------------
+
+    def test_try_smtp_send_returns_none_when_not_send_now(
+        self, connector: AppleMailConnector
+    ) -> None:
+        assert (
+            connector._try_smtp_send(
+                seed="new", seed_id=None, seed_mailbox=None, send_now=False,
+                from_account="Gmail", to=["a@example.com"], cc=None, bcc=None,
+                subject="Hi", body="x", reply_all=False, attachment_paths=None,
+            )
+            is None
+        )
+
+    def test_try_smtp_send_returns_none_without_account(
+        self, connector: AppleMailConnector
+    ) -> None:
+        assert (
+            connector._try_smtp_send(
+                seed="new", seed_id=None, seed_mailbox=None, send_now=True,
+                from_account=None, to=["a@example.com"], cc=None, bcc=None,
+                subject="Hi", body="x", reply_all=False, attachment_paths=None,
+            )
+            is None
+        )
+
+    def test_try_smtp_send_returns_none_for_non_rfc_reply_seed(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(connector, "_imap_breaker_open", lambda account: False)
+        # A numeric Mail id (no "@") can't be fetched over IMAP → fall through.
+        assert (
+            connector._try_smtp_send(
+                seed="reply", seed_id="12345", seed_mailbox="INBOX",
+                send_now=True, from_account="Gmail", to=None, cc=None, bcc=None,
+                subject=None, body="x", reply_all=False, attachment_paths=None,
+            )
+            is None
+        )
+
+    # --- reply / forward send ----------------------------------------------
+
+    def test_reply_send_via_smtp_uses_derived_recipients(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._configure_smtp(connector, monkeypatch)
+        monkeypatch.setattr(
+            connector,
+            "_build_reply_forward_mime",
+            lambda **kw: ("<m@id>", b"rawreply", ["orig@example.net"]),
+        )
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender") as sender_cls:
+            result = connector._try_smtp_send(
+                seed="reply", seed_id="orig@id", seed_mailbox="INBOX",
+                send_now=True, from_account="Gmail", to=None, cc=None, bcc=None,
+                subject=None, body="thanks", reply_all=False, attachment_paths=None,
+            )
+        sender_cls.return_value.send.assert_called_once_with(
+            b"rawreply", ["orig@example.net"]
+        )
+        assert result == {"draft_id": "", "sent_message_id": ""}
+
+    def test_reply_forward_folder_miss_falls_back(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._configure_smtp(connector, monkeypatch)
+
+        def _miss(**kw: object) -> object:
+            raise MailMessageNotFoundError("not in folder")
+
+        monkeypatch.setattr(connector, "_build_reply_forward_mime", _miss)
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender") as sender_cls:
+            result = connector._try_smtp_send(
+                seed="reply", seed_id="orig@id", seed_mailbox="Archive",
+                send_now=True, from_account="Gmail", to=None, cc=None, bcc=None,
+                subject=None, body="x", reply_all=False, attachment_paths=None,
+            )
+        assert result is None
+        sender_cls.assert_not_called()
+
+    # --- test-mode transport-boundary safety guard (#322 / #175) -----------
+
+    def test_test_mode_blocks_non_reserved_recipient(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+        monkeypatch.setattr(
+            connector, "_get_imap_password_with_fallback", lambda a, e: "pw"
+        )
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender") as sender_cls:
+            with pytest.raises(MailSafetyError):
+                connector._smtp_send(
+                    "Gmail",
+                    b"raw",
+                    ["real@person.com"],
+                    smtp_config=("smtp.x", 587, "me@x.test"),
+                )
+        sender_cls.assert_not_called()
+
+    def test_test_mode_allows_reserved_recipient(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+        monkeypatch.setattr(
+            connector, "_get_imap_password_with_fallback", lambda a, e: "pw"
+        )
+        monkeypatch.setattr(connector, "_imap_clear_breaker", lambda a: None)
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender") as sender_cls:
+            connector._smtp_send(
+                "Gmail",
+                b"raw",
+                ["ok@example.com"],
+                smtp_config=("smtp.x", 587, "me@x.test"),
+            )
+        sender_cls.return_value.send.assert_called_once_with(
+            b"raw", ["ok@example.com"]
+        )
+
+    def test_test_mode_blocks_derived_reply_all_recipient(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#175/#322: reply_all derives cc from the original — a real derived
+        recipient the server-layer gate never saw must be caught at the
+        transport boundary, and must NOT silently fall back to AppleScript."""
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+        self._configure_smtp(connector, monkeypatch)
+        monkeypatch.setattr(
+            connector,
+            "_build_reply_forward_mime",
+            lambda **kw: (
+                "<m@id>",
+                b"raw",
+                ["ok@example.com", "boss@real-company.com"],
+            ),
+        )
+        with patch("apple_mail_fast_mcp.mail_connector.SmtpSender") as sender_cls:
+            with pytest.raises(MailSafetyError):
+                connector._try_smtp_send(
+                    seed="reply", seed_id="orig@id", seed_mailbox="INBOX",
+                    send_now=True, from_account="Gmail", to=["ok@example.com"],
+                    cc=None, bcc=None, subject=None, body="hi", reply_all=True,
+                    attachment_paths=None,
+                )
+        sender_cls.assert_not_called()
+
+    # --- config discovery ---------------------------------------------------
+
+    def test_query_smtp_server_parses_host_port(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            connector,
+            "_run_applescript",
+            lambda s: '{"host":"smtp.mail.me.com","port":587}',
+        )
+        assert connector._query_smtp_server("iCloud") == ("smtp.mail.me.com", 587)
+
+    def test_query_smtp_server_missing_server_returns_empty(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            connector, "_run_applescript", lambda s: '{"host":"","port":0}'
+        )
+        assert connector._query_smtp_server("iCloud") == ("", 0)
+
+    def test_query_smtp_server_unparseable_returns_empty(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(connector, "_run_applescript", lambda s: "not-json")
+        assert connector._query_smtp_server("iCloud") == ("", 0)
+
+    def test_resolve_smtp_config_defaults_missing_port_to_587(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(connector, "_query_smtp_server", lambda a: ("smtp.x", 0))
+        monkeypatch.setattr(
+            connector, "_resolve_imap_config", lambda a: ("imap.x", 993, "me@x")
+        )
+        assert connector._resolve_smtp_config("Gmail") == ("smtp.x", 587, "me@x")
+
+    def test_resolve_smtp_config_unconfigured_short_circuits(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(connector, "_query_smtp_server", lambda a: ("", 0))
+        called: list[str] = []
+        monkeypatch.setattr(
+            connector,
+            "_resolve_imap_config",
+            lambda a: called.append(a) or ("h", 1, "e"),
+        )
+        assert connector._resolve_smtp_config("Gmail") == ("", 0, "")
+        assert called == []

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -18,6 +18,7 @@ from apple_mail_fast_mcp.security import (
     detect_prompt_injection,
     operation_logger,
     rate_limiter,
+    send_recipients_test_violation,
     validate_bulk_operation,
     validate_send_operation,
 )
@@ -633,3 +634,36 @@ class TestInjectionScanEnabled:
     def test_other_values_keep_enabled(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("APPLE_MAIL_MCP_DISABLE_INJECTION_SCAN", "0")
         assert _injection_scan_enabled() is True
+
+
+class TestTestModeRecipientViolation:
+    """#322/#175: transport-boundary reserved-domain guard for send paths
+    whose final recipient set is only known after in-connector derivation."""
+
+    def test_outside_test_mode_always_allowed(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv("MAIL_TEST_MODE", raising=False)
+        assert send_recipients_test_violation(["real@person.com"]) is None
+
+    def test_reserved_recipients_allowed(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+        assert (
+            send_recipients_test_violation(
+                ["a@example.com", "b@example.net", "c@foo.test"]
+            )
+            is None
+        )
+
+    def test_real_recipient_blocked(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+        msg = send_recipients_test_violation(
+            ["ok@example.com", "leak@real-person.com"]
+        )
+        assert msg is not None
+        assert "leak@real-person.com" in msg
+        assert "ok@example.com" not in msg
+
+    def test_empty_recipients_blocked(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("MAIL_TEST_MODE", "true")
+        msg = send_recipients_test_violation([])
+        assert msg is not None
+        assert "explicit recipients" in msg

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -3390,6 +3390,31 @@ class TestCreateDraftTool:
         mock_mail.create_draft.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_connector_safety_error_maps_to_safety_violation(
+        self,
+        isolated_drafts: Any,
+        mock_mail: MagicMock,
+        mock_logger: MagicMock,
+        mock_ctx_accept: MagicMock,
+    ) -> None:
+        """#322/#175: the SMTP send path's transport-boundary guard raises
+        MailSafetyError for a derived non-reserved recipient the server-layer
+        gate never saw; the server surfaces it as a safety_violation, not a
+        generic ``unknown`` error."""
+        from apple_mail_fast_mcp.exceptions import MailSafetyError
+        from apple_mail_fast_mcp.server import create_draft
+
+        mock_mail.create_draft.side_effect = MailSafetyError(
+            "Test mode: recipients must use RFC 2606 reserved domains"
+        )
+        result = await create_draft(
+            to=["ok@example.com"], subject="hi", body="x",
+            send_now=True, ctx=mock_ctx_accept,
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "safety_violation"
+
+    @pytest.mark.asyncio
     async def test_send_now_missing_ctx_blocks_with_confirmation_required(
         self,
         isolated_drafts: Any,

--- a/tests/unit/test_smtp_sender.py
+++ b/tests/unit/test_smtp_sender.py
@@ -1,0 +1,130 @@
+"""Unit tests for the SMTP submission transport (issue #322).
+
+The mock boundary is ``smtplib`` — the SMTP equivalent of the connector's
+``_run_applescript`` / ``IMAPClient`` boundaries. No test opens a real
+socket or touches real credentials.
+"""
+
+from email import message_from_bytes
+from email.policy import default as _default_policy
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apple_mail_fast_mcp.smtp_sender import SmtpSender
+
+
+def _raw_with_bcc() -> bytes:
+    return (
+        b"From: Fred <fred@example.com>\r\n"
+        b"To: alice@example.net\r\n"
+        b"Cc: carol@example.org\r\n"
+        b"Bcc: secret@example.com\r\n"
+        b"Subject: Hi\r\n"
+        b"\r\n"
+        b"Body text.\r\n"
+    )
+
+
+class TestConstructor:
+    def test_stores_credentials(self) -> None:
+        sender = SmtpSender("smtp.example.com", 587, "u@example.com", "pw")
+        assert sender._host == "smtp.example.com"
+        assert sender._port == 587
+        assert sender._email == "u@example.com"
+        assert sender._password == "pw"
+
+    def test_default_timeout(self) -> None:
+        sender = SmtpSender("h", 587, "u", "p")
+        assert sender._timeout == 30.0
+
+    def test_custom_timeout(self) -> None:
+        sender = SmtpSender("h", 587, "u", "p", timeout=5.0)
+        assert sender._timeout == 5.0
+
+
+class TestStartTls:
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
+    def test_port_587_uses_starttls_then_login_and_send(
+        self, mock_smtp: MagicMock
+    ) -> None:
+        client = mock_smtp.return_value.__enter__.return_value
+        sender = SmtpSender("smtp.example.com", 587, "u@example.com", "pw")
+
+        sender.send(_raw_with_bcc(), ["alice@example.net", "secret@example.com"])
+
+        mock_smtp.assert_called_once()
+        assert mock_smtp.call_args.args[0] == "smtp.example.com"
+        client.starttls.assert_called_once()
+        client.login.assert_called_once_with("u@example.com", "pw")
+        client.send_message.assert_called_once()
+
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
+    def test_envelope_uses_login_from_and_explicit_recipients(
+        self, mock_smtp: MagicMock
+    ) -> None:
+        client = mock_smtp.return_value.__enter__.return_value
+        sender = SmtpSender("smtp.example.com", 587, "u@example.com", "pw")
+        recipients = ["alice@example.net", "carol@example.org", "secret@example.com"]
+
+        sender.send(_raw_with_bcc(), recipients)
+
+        _msg, kwargs = (
+            client.send_message.call_args.args,
+            client.send_message.call_args.kwargs,
+        )
+        assert kwargs["from_addr"] == "u@example.com"
+        assert kwargs["to_addrs"] == recipients
+
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
+    def test_bcc_header_stripped_from_wire_message(
+        self, mock_smtp: MagicMock
+    ) -> None:
+        client = mock_smtp.return_value.__enter__.return_value
+        sender = SmtpSender("smtp.example.com", 587, "u@example.com", "pw")
+
+        sender.send(_raw_with_bcc(), ["alice@example.net", "secret@example.com"])
+
+        sent_msg = client.send_message.call_args.args[0]
+        assert sent_msg["Bcc"] is None
+        # To/Cc must still be present on the wire message.
+        assert sent_msg["To"] is not None
+
+
+class TestSsl:
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP_SSL")
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
+    def test_port_465_uses_ssl_no_starttls(
+        self, mock_smtp: MagicMock, mock_ssl: MagicMock
+    ) -> None:
+        client = mock_ssl.return_value.__enter__.return_value
+        sender = SmtpSender("smtp.example.com", 465, "u@example.com", "pw")
+
+        sender.send(_raw_with_bcc(), ["alice@example.net"])
+
+        mock_ssl.assert_called_once()
+        mock_smtp.assert_not_called()
+        client.starttls.assert_not_called()
+        client.login.assert_called_once_with("u@example.com", "pw")
+        client.send_message.assert_called_once()
+
+
+class TestValidation:
+    def test_empty_recipients_raises(self) -> None:
+        sender = SmtpSender("h", 587, "u", "p")
+        with pytest.raises(ValueError, match="recipient"):
+            sender.send(b"From: a@example.com\r\n\r\nx", [])
+
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
+    def test_wire_message_is_parseable(self, mock_smtp: MagicMock) -> None:
+        """Regression guard: the object handed to send_message is a real
+        parsed EmailMessage, not the raw bytes."""
+        client = mock_smtp.return_value.__enter__.return_value
+        sender = SmtpSender("h", 587, "u@example.com", "p")
+
+        sender.send(_raw_with_bcc(), ["alice@example.net"])
+
+        sent = client.send_message.call_args.args[0]
+        # Re-serialize round-trips cleanly.
+        reparsed = message_from_bytes(sent.as_bytes(), policy=_default_policy)
+        assert reparsed["Subject"] == "Hi"

--- a/tests/unit/test_smtp_sender.py
+++ b/tests/unit/test_smtp_sender.py
@@ -5,6 +5,7 @@ The mock boundary is ``smtplib`` — the SMTP equivalent of the connector's
 socket or touches real credentials.
 """
 
+import smtplib
 from email import message_from_bytes
 from email.policy import default as _default_policy
 from unittest.mock import MagicMock, patch
@@ -60,21 +61,68 @@ class TestStartTls:
         client.send_message.assert_called_once()
 
     @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
-    def test_envelope_uses_login_from_and_explicit_recipients(
+    def test_envelope_from_is_message_from_not_login_and_recipients_explicit(
         self, mock_smtp: MagicMock
     ) -> None:
+        """Regression for #322 / PR #404: the envelope ``MAIL FROM`` is the
+        message's own ``From:`` address (``fred@example.com``), NOT the SMTP
+        AUTH login (``u@example.com``). Reusing the login as the envelope
+        sender is what made custom-domain iCloud reject the send with
+        ``550 5.7.0 From address is not one of your addresses``. ``RCPT TO``
+        is the caller's explicit recipient list."""
         client = mock_smtp.return_value.__enter__.return_value
         sender = SmtpSender("smtp.example.com", 587, "u@example.com", "pw")
         recipients = ["alice@example.net", "carol@example.org", "secret@example.com"]
 
         sender.send(_raw_with_bcc(), recipients)
 
-        _msg, kwargs = (
-            client.send_message.call_args.args,
-            client.send_message.call_args.kwargs,
-        )
-        assert kwargs["from_addr"] == "u@example.com"
+        # AUTH login and envelope-from are two distinct values.
+        client.login.assert_called_once_with("u@example.com", "pw")
+        kwargs = client.send_message.call_args.kwargs
+        assert kwargs["from_addr"] == "fred@example.com"
+        assert kwargs["from_addr"] != "u@example.com"
         assert kwargs["to_addrs"] == recipients
+
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
+    def test_envelope_from_strips_display_name(
+        self, mock_smtp: MagicMock
+    ) -> None:
+        """A ``Display Name <addr>`` From header yields the bare address for
+        the envelope (``_resolve_account_to_sender`` may return that form)."""
+        client = mock_smtp.return_value.__enter__.return_value
+        raw = (
+            b"From: Fred Masi <fred@example.com>\r\n"
+            b"To: alice@example.net\r\n"
+            b"Subject: Hi\r\n\r\nx\r\n"
+        )
+        sender = SmtpSender("smtp.example.com", 587, "u@example.com", "pw")
+
+        sender.send(raw, ["alice@example.net"])
+
+        assert client.send_message.call_args.kwargs["from_addr"] == "fred@example.com"
+
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
+    def test_explicit_envelope_from_overrides_header(
+        self, mock_smtp: MagicMock
+    ) -> None:
+        """An explicit ``envelope_from`` wins over the ``From:`` header."""
+        client = mock_smtp.return_value.__enter__.return_value
+        sender = SmtpSender("smtp.example.com", 587, "u@example.com", "pw")
+
+        sender.send(
+            _raw_with_bcc(),
+            ["alice@example.net"],
+            envelope_from="Alias <alias@example.com>",
+        )
+
+        assert client.send_message.call_args.kwargs["from_addr"] == "alias@example.com"
+
+    def test_missing_from_and_no_override_raises(self) -> None:
+        """No override and no ``From:`` header → an explicit ValueError rather
+        than a silent, wrong envelope sender."""
+        sender = SmtpSender("h", 587, "u@example.com", "pw")
+        with pytest.raises(ValueError, match="envelope-from"):
+            sender.send(b"To: a@example.net\r\nSubject: x\r\n\r\nx", ["a@example.net"])
 
     @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
     def test_bcc_header_stripped_from_wire_message(
@@ -128,3 +176,76 @@ class TestValidation:
         # Re-serialize round-trips cleanly.
         reparsed = message_from_bytes(sent.as_bytes(), policy=_default_policy)
         assert reparsed["Subject"] == "Hi"
+
+
+class TestTeardownAfterAccept:
+    """PR #404: once the server has accepted the message (``send_message``
+    returned), a failure during session teardown — most notably a non-221
+    reply to ``QUIT`` that ``SMTP.__exit__`` raises as ``SMTPResponseException``
+    — must NOT propagate, or the caller would fall back to AppleScript and
+    send a duplicate. Failures *before* acceptance must still propagate."""
+
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
+    def test_non_221_quit_after_accept_is_swallowed(
+        self, mock_smtp: MagicMock
+    ) -> None:
+        """DATA→250 then a non-221 QUIT: ``send`` returns normally (no
+        exception surfaces), so the caller never retries via AppleScript."""
+        client = mock_smtp.return_value.__enter__.return_value
+        # Exiting the `with` (post-accept) raises, as real __exit__ does on a
+        # non-221 QUIT reply.
+        mock_smtp.return_value.__exit__.side_effect = smtplib.SMTPResponseException(
+            421, b"4.7.0 closing transmission channel"
+        )
+        sender = SmtpSender("smtp.example.com", 587, "u@example.com", "pw")
+
+        # Must not raise — the message was accepted.
+        sender.send(_raw_with_bcc(), ["alice@example.net"])
+
+        client.send_message.assert_called_once()
+
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP_SSL")
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
+    def test_non_221_quit_after_accept_is_swallowed_ssl(
+        self, mock_smtp: MagicMock, mock_ssl: MagicMock
+    ) -> None:
+        """Same guarantee on the implicit-TLS (:465) path."""
+        client = mock_ssl.return_value.__enter__.return_value
+        mock_ssl.return_value.__exit__.side_effect = smtplib.SMTPResponseException(
+            421, b"4.7.0 closing transmission channel"
+        )
+        sender = SmtpSender("smtp.example.com", 465, "u@example.com", "pw")
+
+        sender.send(_raw_with_bcc(), ["alice@example.net"])
+
+        client.send_message.assert_called_once()
+
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
+    def test_send_message_failure_before_accept_propagates(
+        self, mock_smtp: MagicMock
+    ) -> None:
+        """A pre-acceptance failure (DATA rejected) must propagate so the
+        caller can fall back to AppleScript — the message was never sent."""
+        client = mock_smtp.return_value.__enter__.return_value
+        client.send_message.side_effect = smtplib.SMTPRecipientsRefused(
+            {"alice@example.net": (550, b"5.1.1 no such user")}
+        )
+        sender = SmtpSender("smtp.example.com", 587, "u@example.com", "pw")
+
+        with pytest.raises(smtplib.SMTPException):
+            sender.send(_raw_with_bcc(), ["alice@example.net"])
+
+    @patch("apple_mail_fast_mcp.smtp_sender.smtplib.SMTP")
+    def test_auth_failure_before_accept_propagates(
+        self, mock_smtp: MagicMock
+    ) -> None:
+        """An AUTH failure is pre-acceptance and must propagate."""
+        client = mock_smtp.return_value.__enter__.return_value
+        client.login.side_effect = smtplib.SMTPAuthenticationError(
+            535, b"bad creds"
+        )
+        sender = SmtpSender("smtp.example.com", 587, "u@example.com", "pw")
+
+        with pytest.raises(smtplib.SMTPException):
+            sender.send(_raw_with_bcc(), ["alice@example.net"])
+        client.send_message.assert_not_called()


### PR DESCRIPTION
## Linked issues
Closes #322. Also fixes #406 (Sent-mailbox copy), raised during live testing of this PR.

## Summary
`create_draft(send_now=True)` always sent via Mail.app's AppleScript `tell theMessage to send`, whose `content` setter wraps the body in the FB11734014 cite-blockquote that renders as a quote on iOS/some clients. IMAP APPEND (#245/#246/#292) fixed the draft case but can only create drafts, never send. This adds a dedicated SMTP submission path so a direct send never touches the AppleScript content setter — plus three follow-up fixes surfaced by live testing against a real iCloud account.

## The SMTP send path (#322)
- New `smtp_sender.SmtpSender`: submits a clean RFC 822 message (built by the existing `draft_builder.build_draft_mime`) over STARTTLS (or implicit TLS on :465), stripping Bcc from the wire and carrying it in the envelope `RCPT TO`. `smtplib` is the mock boundary, mirroring `_run_applescript`/`IMAPClient`.
- `mail_connector._resolve_smtp_config` mirrors `_resolve_imap_config` (Mail.app `smtp server` host/port + reused IMAP login identity). SMTP auth reuses the account's existing IMAP app-password rather than a second credential store — valid for iCloud/Gmail/Yahoo/Outlook, where the same app-password covers both.
- `_try_smtp_send` engages for `send_now=True` with a configured account and falls back to AppleScript (returning `None`) on the standard degradation signals, mirroring the existing IMAP draft fallback chain. Reply/forward recipient derivation is shared with the draft path via `_build_reply_forward_mime`.
- `send_now` with no `from_account` intentionally stays on AppleScript, preserving the #321 invariant.

## Security (#175)
The reserved-domain test-mode gate previously only validated recipients the *caller* passed in — not ones the connector derives internally (e.g. a reply-all's resolved `cc`). The check is re-run at the SMTP transport boundary against the fully-resolved recipient set. A violation raises `MailSafetyError` and does **not** fall back to AppleScript (falling back would just reach the same unsafe address by another route). `server._draft_action_error` maps it to `error_type: "safety_violation"`.

## Follow-up fix 1 — envelope-from vs AUTH login (commit e47fe2c)
Live testing against a custom-domain iCloud account failed with `550 5.7.0 From address is not one of your addresses`. The SMTP AUTH login (the Apple ID, e.g. `appleid@example.com`) legitimately differs from the sending identity (the send-as address, e.g. `you@example.com`); Gmail/Outlook send-as aliases behave the same. `SmtpSender.send` now resolves the envelope `MAIL FROM` from the message `From:` header (or an explicit override), kept separate from `self._email` (the AUTH login).

## Follow-up fix 2 — no double-send on session teardown (commit e47fe2c)
Once the server accepts the message (`send_message` returns 250), any error raised while tearing the session down is swallowed rather than propagated — notably a non-221 reply to `QUIT`, which `smtplib.SMTP.__exit__` raises as `SMTPResponseException`. Sending is non-idempotent, so letting that propagate would make the caller's AppleScript fallback deliver a *second* copy. Errors *before* acceptance still propagate so the caller can fall back safely.

## Follow-up fix 3 — save a Sent-mailbox copy (#406, commit 8f5153b)
The SMTP path bypasses AppleScript's `tell theMessage to send`, which used to drop a copy into the account's Sent mailbox as a side effect — so real SMTP sends left no local Sent record (confirmed via live testing: sent messages never appeared in Sent, even after IMAP sync).
- New `ImapConnector.append_sent_copy()` APPENDs the sent bytes to the Sent folder over IMAP, mirroring the `append_draft` path. Sent folder resolved by RFC 6154 `\Sent` SPECIAL-USE first (reusing the existing `_find_sent_folder` helper, so Gmail's `[Gmail]/Sent Mail` is found without hard-coding), then a conventional-name fallback covering iCloud's `Sent Messages`.
- The copy is flagged `\Seen`, and `\Answered` when the send was a reply.
- `_save_sent_copy` hooks in **after** the message is accepted and delivered, and swallows every failure (log, never raise) — kept strictly outside `_try_smtp_send`'s fallback-eligible `except` clauses, so a Sent-copy failure can never drop through to the AppleScript send and duplicate delivery (same class of bug as follow-up fix 2). The reply/forward path reuses the connector already built to fetch the original.

## Test plan
- [x] Unit tests cover all new paths + error branches — `test_smtp_sender.py`, `test_imap_connector.py` (`TestAppendSentCopy`), and SMTP-path/config/fallback/Sent-copy tests in `test_mail_connector.py`
- [x] Regression tests for each bug fix (fail before, pass after): `test_send_now_compose_uses_smtp_not_applescript`, `test_non_221_quit_after_accept_does_not_double_send`, `test_sent_copy_failure_is_swallowed_and_no_applescript_fallback`
- [x] `make check-all` green; coverage 92.99% (`smtp_sender.py` 100%)
- [x] **Live-verified against a real iCloud account:** `create_draft(send_now=True)` lands a Sent copy in "Sent Messages" flagged `\Seen` (compose) and `\Answered`+`\Seen` (reply). Gmail-backed accounts on the test machine use OAuth (no IMAP app-password), so their `send_now` falls back to AppleScript and never reaches the SMTP/Sent-copy path; Gmail's `\Sent` resolution is exercised by the reused `_find_sent_folder` helper and unit tests.

## Checklist
- [x] Linked to issues (above)
- [x] Documentation updated (`docs/reference/TOOLS.md`)
- [x] Security checklist reviewed — see the #175 transport-boundary guard
- [x] Branch follows `{type}/issue-{num}-{description}` convention
- [x] No new lint/type errors (mypy strict, coverage ≥90%)

## Notes / judgment calls (not directly spec'd)
- Credential reuse (IMAP app-password for SMTP auth) rather than a new keychain entry.
- The SMTP-transport-boundary safety guard (#175).
- The Sent copy retains the `Bcc` header (as Mail.app's own Sent copy does), while the wire message strips it.
