### PR TITLE
fix(#407): draft lifecycle on localized Mail.app + Gmail (unified drafts mailbox)

### DIFF
--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -1018,6 +1018,11 @@ class AppleMailConnector:
                 ["/usr/bin/osascript", "-"],
                 input=script,
                 text=True,
+                # Pin UTF-8 so non-ASCII in a generated script or in osascript
+                # output (e.g. a localized mailbox name / a message subject)
+                # round-trips deterministically, independent of the locale the
+                # MCP client launched the server under (#407).
+                encoding="utf-8",
                 capture_output=True,
                 timeout=self.timeout,
             )
@@ -4398,10 +4403,70 @@ class AppleMailConnector:
         """
         if "@" not in draft_id:
             return draft_id
-        internal = self.find_message_by_message_id(draft_id)
+        # Resolve within the Drafts scope, NOT the account-wide
+        # find_message_by_message_id: on Gmail the latter returns the All Mail
+        # *mirror* of the draft, whose internal id the Drafts-scoped lifecycle
+        # loops can never match (#407 root cause 2).
+        internal = self._resolve_draft_internal_id(draft_id)
         if internal is None:
             raise MailDraftNotFoundError(f"no draft with id {draft_id!r}")
         return internal
+
+    def _resolve_draft_internal_id(
+        self, rfc5322_message_id: str
+    ) -> str | None:
+        """Resolve an RFC 5322 Message-ID to Mail's internal id, scoped to
+        the unified ``drafts mailbox`` (#407).
+
+        Unlike :meth:`find_message_by_message_id` (which scans every mailbox
+        of every account), this searches only Mail.app's unified
+        ``drafts mailbox`` — the locale-independent aggregation of every
+        account's Drafts folder. On Gmail that excludes the All Mail *mirror*
+        of the draft, so the id returned is the real Drafts copy's, which the
+        draft-lifecycle ``whose id is`` / id-match loops can then find.
+        ``find_message_by_message_id`` is deliberately left broad, because
+        reply/forward seed resolution needs to find seeds outside Drafts.
+
+        Iterates ``messages of drafts mailbox`` manually (rather than a
+        ``whose message id`` clause) — matching :meth:`get_draft_state`, whose
+        docstring notes a freshly-saved draft can briefly lag ``whose``
+        queryability.
+        """
+        if not rfc5322_message_id:
+            return None
+        bare = _bare_message_id(rfc5322_message_id)
+        bracketed = f"<{bare}>"
+        safe_bare = escape_applescript_string(sanitize_input(bare))
+        safe_bracketed = escape_applescript_string(sanitize_input(bracketed))
+
+        script = _wrap_with_timeout(
+            f"""tell application "Mail"
+            set foundId to ""
+            try
+                repeat with d in messages of drafts mailbox
+                    set mid to ""
+                    try
+                        set mid to message id of d
+                    end try
+                    if mid is "{safe_bare}" or mid is "{safe_bracketed}" then
+                        set foundId to (id of d as text)
+                        exit repeat
+                    end if
+                end repeat
+            end try
+            if foundId is "" then
+                return "NOT_FOUND"
+            else
+                return foundId
+            end if
+        end tell""",
+            timeout=self.timeout,
+        )
+
+        result = self._run_applescript(script).strip()
+        if result == "NOT_FOUND" or not result:
+            return None
+        return result
 
     def delete_draft(self, draft_id: str) -> bool:
         """Move a draft to Trash (lifecycle endpoint for cancellation).
@@ -4429,29 +4494,19 @@ class AppleMailConnector:
         # regex staying narrow. (#294)
         lookup_id_safe = escape_applescript_string(sanitize_input(lookup_id))
 
+        # Search Mail.app's unified "drafts mailbox" — its locale-independent
+        # aggregation of every account's Drafts folder — instead of matching a
+        # per-account mailbox by the English name "Drafts" (which misses
+        # localized names like "Entwürfe" and Gmail's All Mail mirror). (#407)
         script = _wrap_with_timeout(
             f"""tell application "Mail"
-            set didDelete to false
-            repeat with acc in accounts
-                try
-                    repeat with mb in mailboxes of acc
-                        if name of mb contains "Drafts" then
-                            try
-                                set m to first message of mb whose id is "{lookup_id_safe}"
-                                delete m
-                                set didDelete to true
-                                exit repeat
-                            end try
-                        end if
-                    end repeat
-                end try
-                if didDelete then exit repeat
-            end repeat
-            if didDelete then
+            try
+                set m to first message of drafts mailbox whose id is "{lookup_id_safe}"
+                delete m
                 return "OK"
-            else
+            on error
                 return "NOT_FOUND"
-            end if
+            end try
         end tell""",
             timeout=self.timeout,
         )
@@ -4561,22 +4616,15 @@ class AppleMailConnector:
         tell application "Mail"
             set targetId to "{lookup_id_safe}"
             set foundDraft to missing value
-            repeat with acc in accounts
-                try
-                    repeat with mb in mailboxes of acc
-                        if name of mb contains "Drafts" then
-                            repeat with d in messages of mb
-                                if (id of d as text) is targetId then
-                                    set foundDraft to d
-                                    exit repeat
-                                end if
-                            end repeat
-                        end if
-                        if foundDraft is not missing value then exit repeat
-                    end repeat
-                end try
-                if foundDraft is not missing value then exit repeat
-            end repeat
+            -- Unified "drafts mailbox": locale-independent, Gmail-mirror-safe. (#407)
+            try
+                repeat with d in messages of drafts mailbox
+                    if (id of d as text) is targetId then
+                        set foundDraft to d
+                        exit repeat
+                    end if
+                end repeat
+            end try
 
             if foundDraft is missing value then
                 set resultData to {{|found|:false}}
@@ -5760,23 +5808,15 @@ class AppleMailConnector:
                 delay 0.5
 
                 set newDraftId to ""
-                repeat with acc in accounts
-                    try
-                        repeat with mb in mailboxes of acc
-                            if name of mb contains "Drafts" then
-                                repeat with d in messages of mb
-                                    set candId to (id of d as text)
-                                    if candId is not in beforeIds then
-                                        set newDraftId to candId
-                                        exit repeat
-                                    end if
-                                end repeat
-                            end if
-                            if newDraftId is not "" then exit repeat
-                        end repeat
-                    end try
-                    if newDraftId is not "" then exit repeat
-                end repeat
+                try
+                    repeat with d in messages of drafts mailbox
+                        set candId to (id of d as text)
+                        if candId is not in beforeIds then
+                            set newDraftId to candId
+                            exit repeat
+                        end if
+                    end repeat
+                end try
                 return newDraftId
             """
 
@@ -5785,17 +5825,11 @@ class AppleMailConnector:
         if not send_now:
             snapshot_block = """
                 set beforeIds to {}
-                repeat with acc in accounts
-                    try
-                        repeat with mb in mailboxes of acc
-                            if name of mb contains "Drafts" then
-                                repeat with d in messages of mb
-                                    copy (id of d as text) to end of beforeIds
-                                end repeat
-                            end if
-                        end repeat
-                    end try
-                end repeat
+                try
+                    repeat with d in messages of drafts mailbox
+                        copy (id of d as text) to end of beforeIds
+                    end repeat
+                end try
             """
 
         script = _wrap_with_timeout(
@@ -6033,22 +6067,15 @@ class AppleMailConnector:
             f"""tell application "Mail"
             set targetId to "{lookup_id_safe}"
             set foundDraft to missing value
-            repeat with acc in accounts
-                try
-                    repeat with mb in mailboxes of acc
-                        if name of mb contains "Drafts" then
-                            repeat with d in messages of mb
-                                if (id of d as text) is targetId then
-                                    set foundDraft to d
-                                    exit repeat
-                                end if
-                            end repeat
-                        end if
-                        if foundDraft is not missing value then exit repeat
-                    end repeat
-                end try
-                if foundDraft is not missing value then exit repeat
-            end repeat
+            -- Unified "drafts mailbox": locale-independent, Gmail-mirror-safe. (#407)
+            try
+                repeat with d in messages of drafts mailbox
+                    if (id of d as text) is targetId then
+                        set foundDraft to d
+                        exit repeat
+                    end if
+                end repeat
+            end try
             if foundDraft is missing value then return "ERR_NOT_FOUND"
 
             set targetPaths to {{{targets_safe}}}

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -13,6 +13,7 @@ Run with: MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=TestAccount pytest --run-integra
 """
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -589,6 +590,31 @@ class TestDraftsLifecycleIntegration:
     Each test cleans up its own drafts.
     """
 
+    @staticmethod
+    def _wait_for_draft(
+        connector: AppleMailConnector, draft_id: str, timeout_s: float = 30.0
+    ) -> dict[str, Any]:
+        """Poll get_draft_state until an IMAP-APPEND draft has synced into
+        Mail.app. create_draft returns as soon as the server APPEND succeeds,
+        but Mail.app reflects the new draft asynchronously (~seconds, longer on
+        Gmail). The pre-#407 broad-mailbox scan incidentally masked this by
+        being slow; the #407 drafts-scoped lookup is fast, so tests that look
+        up a just-created draft must wait for the sync explicitly."""
+        import time
+
+        from apple_mail_fast_mcp.exceptions import MailDraftNotFoundError
+
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            try:
+                return connector.get_draft_state(draft_id)
+            except MailDraftNotFoundError:
+                time.sleep(1.0)
+        pytest.fail(
+            f"draft {draft_id!r} not visible {timeout_s}s after create "
+            "(IMAP-APPEND sync lag)"
+        )
+
     @pytest.fixture
     def anchor_message_id(
         self, connector: AppleMailConnector, test_account: str
@@ -691,7 +717,7 @@ class TestDraftsLifecycleIntegration:
         assert "<" not in draft_id and ">" not in draft_id
 
         try:
-            state = connector.get_draft_state(draft_id)
+            state = self._wait_for_draft(connector, draft_id)
             assert state["subject"] == "ZZZ-AMM-INTEG-MSGID"
             assert "integration message-id round-trip body" in state["body"]
         finally:
@@ -805,13 +831,17 @@ class TestDraftsLifecycleIntegration:
         )
         try:
             # Fetch the raw draft back over IMAP from the Drafts folder.
+            import imaplib as _imaplib
             imap = ImapConnector(host, port, email, password)
             raw = None
             for folder in ImapConnector._CONVENTIONAL_DRAFTS_NAMES:
                 try:
                     raw = imap.fetch_raw_message(draft_id, folder)
                     break
-                except MailMessageNotFoundError:
+                except (MailMessageNotFoundError, _imaplib.IMAP4.error):
+                    # Candidate folder absent on this server (e.g. bare
+                    # "Drafts" on Gmail, which uses "[Gmail]/Drafts") — the
+                    # SELECT raises; try the next conventional name.
                     continue
             assert raw is not None, "HTML draft not found in any Drafts folder"
             msg = _email.message_from_bytes(raw, policy=_policy.default)
@@ -822,6 +852,9 @@ class TestDraftsLifecycleIntegration:
             assert f"<b>{marker}</b>" in html.get_content()
             assert "plain fallback" in plain.get_content()
         finally:
+            # Wait for the APPENDed draft to sync into Mail.app before the
+            # AppleScript delete can find it (#407 sync lag).
+            self._wait_for_draft(connector, draft_id)
             assert connector.delete_draft(draft_id) is True
 
     def test_reply_save_preserves_threading_headers(
@@ -1180,18 +1213,26 @@ class TestDraftsLifecycleIntegration:
     def test_delete_draft_removes_from_drafts_mailbox(
         self,
         connector: AppleMailConnector,
+        test_account: str,
     ) -> None:
         import time
 
         from apple_mail_fast_mcp.exceptions import MailDraftNotFoundError
 
+        # Pin the IMAP-APPEND path (stable RFC Message-ID draft_id). A bare
+        # AppleScript-save on an IMAP account gets a *local* numeric id that
+        # Mail.app re-issues once the draft syncs to the server, so polling by
+        # the original id is unreliable — orthogonal to #407.
         result = connector.create_draft(
             seed="new",
+            from_account=test_account,
             to=["x@example.com"],
             subject="ZZZ-AMM-INTEG-DELETE",
             body="delete me",
         )
         draft_id = result["draft_id"]
+        # Wait for the IMAP-APPEND draft to sync in before deleting it (#407).
+        self._wait_for_draft(connector, draft_id)
         assert connector.delete_draft(draft_id) is True
 
         # IMAP sync lag: the delete returns synchronously but the
@@ -2069,28 +2110,29 @@ class TestDraftsLifecycleIntegration:
         # The IMAP-APPEND path (#245) returns a bare RFC Message-ID, not
         # Mail's internal id; resolve it so the `id of d` lookup below
         # matches (mirrors get_draft_state / delete_draft).
+        # #407: wait for the IMAP-APPEND draft to sync, then resolve to Mail's
+        # internal id via the fast Drafts-scoped resolver (the old broad
+        # find_message_by_message_id scans every mailbox and times out on a
+        # large Gmail's All Mail).
         lookup_id = draft_id
         if "@" in draft_id:
-            lookup_id = connector.find_message_by_message_id(draft_id) or draft_id
+            self._wait_for_draft(connector, draft_id)
+            lookup_id = (
+                connector._resolve_draft_internal_id(draft_id) or draft_id
+            )
 
         try:
             # Read the draft's headers via osascript and confirm the
-            # From header includes both the display name and email.
+            # From header includes both the display name and email. Iterate
+            # the unified "drafts mailbox" (locale-independent, Gmail-mirror-
+            # safe), not per-account name-matched mailboxes (#407).
             import subprocess as _subprocess
             script = f'''
             tell application "Mail"
-                repeat with acc in accounts
-                    try
-                        repeat with mb in mailboxes of acc
-                            if name of mb contains "Drafts" then
-                                repeat with d in messages of mb
-                                    if (id of d as text) is "{lookup_id}" then
-                                        return sender of d
-                                    end if
-                                end repeat
-                            end if
-                        end repeat
-                    end try
+                repeat with d in messages of drafts mailbox
+                    if (id of d as text) is "{lookup_id}" then
+                        return sender of d
+                    end if
                 end repeat
                 return ""
             end tell

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -5486,8 +5486,11 @@ class TestDeleteDraft:
         connector.delete_draft("160991")
         script = mock_run.call_args[0][0]
         assert 'whose id is "160991"' in script
-        # Lookup must be scoped to Drafts mailboxes only (perf + correctness).
-        assert 'name of mb contains "Drafts"' in script
+        # #407: search the unified, locale-independent "drafts mailbox" (which
+        # also excludes Gmail's All Mail mirror), not per-account mailboxes
+        # matched by the English name "Drafts".
+        assert "first message of drafts mailbox" in script
+        assert 'name of mb contains "Drafts"' not in script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_delete_draft_not_found_raises(
@@ -5525,7 +5528,7 @@ class TestDeleteDraft:
         assert connector.delete_draft("160991") is True
 
     @patch.object(
-        AppleMailConnector, "find_message_by_message_id", return_value="160991"
+        AppleMailConnector, "_resolve_draft_internal_id", return_value="160991"
     )
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_delete_draft_resolves_rfc_message_id(
@@ -5544,7 +5547,7 @@ class TestDeleteDraft:
         assert 'whose id is "160991"' in script
 
     @patch.object(
-        AppleMailConnector, "find_message_by_message_id", return_value=None
+        AppleMailConnector, "_resolve_draft_internal_id", return_value=None
     )
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_delete_draft_unresolved_rfc_message_id_raises(
@@ -5581,6 +5584,52 @@ class TestDeleteDraft:
         script = mock_run.call_args[0][0]
         expected = escape_applescript_string(sanitize_input('1"x\\y'))
         assert f'whose id is "{expected}"' in script
+
+
+class TestResolveDraftInternalId:
+    """#407: the draft lookup resolves a Message-ID within the unified
+    ``drafts mailbox`` (Drafts-scoped, Gmail-mirror-safe), NOT the account-
+    wide find_message_by_message_id (which returns Gmail's All Mail mirror)."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_scopes_to_unified_drafts_mailbox(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "173659"
+        assert connector._resolve_draft_internal_id("abc@host") == "173659"
+        script = mock_run.call_args[0][0]
+        # Drafts-scoped iteration, matched by message id — not an all-mailbox scan.
+        assert "messages of drafts mailbox" in script
+        assert "message id of d" in script
+        assert "mailboxes of acc" not in script
+        # Both bare and bracketed Message-ID forms are queried.
+        assert 'mid is "abc@host"' in script
+        assert 'mid is "<abc@host>"' in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_not_found_returns_none(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        mock_run.return_value = "NOT_FOUND"
+        assert connector._resolve_draft_internal_id("missing@host") is None
+
+    @patch.object(AppleMailConnector, "_resolve_draft_internal_id")
+    def test_lookup_id_uses_drafts_scoped_resolver_not_broad(
+        self, mock_resolve: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """_resolve_draft_lookup_id routes a Message-ID through the Drafts-
+        scoped resolver, never the broad find_message_by_message_id."""
+        mock_resolve.return_value = "173659"
+        with patch.object(
+            AppleMailConnector, "find_message_by_message_id"
+        ) as mock_broad:
+            assert connector._resolve_draft_lookup_id("abc@host") == "173659"
+        mock_resolve.assert_called_once_with("abc@host")
+        mock_broad.assert_not_called()
 
 
 class TestFindMessageByMessageId:
@@ -5741,7 +5790,7 @@ class TestGetDraftState:
             connector.get_draft_state("999999")
 
     @patch.object(
-        AppleMailConnector, "find_message_by_message_id", return_value="160991"
+        AppleMailConnector, "_resolve_draft_internal_id", return_value="160991"
     )
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_resolves_rfc_message_id(
@@ -5765,7 +5814,7 @@ class TestGetDraftState:
         assert 'set targetId to "160991"' in script
 
     @patch.object(
-        AppleMailConnector, "find_message_by_message_id", return_value=None
+        AppleMailConnector, "_resolve_draft_internal_id", return_value=None
     )
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_unresolved_rfc_message_id_raises(
@@ -5821,8 +5870,10 @@ class TestGetDraftState:
         except MailDraftNotFoundError:
             pass
         script = mock_run.call_args[0][0]
-        # Lookup should be scoped to Drafts mailboxes.
-        assert 'name of mb contains "Drafts"' in script
+        # #407: iterate the unified "drafts mailbox" (locale-independent,
+        # Gmail-mirror-safe), not per-account name-matched mailboxes.
+        assert "messages of drafts mailbox" in script
+        assert 'name of mb contains "Drafts"' not in script
         # Should use as-text id comparison (probes showed numeric whose
         # clauses are unreliable on IMAP-backed Drafts).
         assert "(id of d as text) is targetId" in script
@@ -6444,7 +6495,7 @@ class TestExtractDraftAttachments:
         assert "mail attachments of foundDraft" in script
 
     @patch.object(
-        AppleMailConnector, "find_message_by_message_id", return_value="160991"
+        AppleMailConnector, "_resolve_draft_internal_id", return_value="160991"
     )
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_extract_resolves_rfc_message_id(


### PR DESCRIPTION
## Problem
Reported by @Rasenschach (German Mail.app + Gmail, line-accurate diagnosis): `delete_draft`, `update_draft`, and `get_draft_state` return `draft_not_found` for every draft on **non-English Mail.app** and on **Gmail** — two independent bugs. `create_draft` worked (IMAP-APPEND resolves Drafts via the RFC 6154 `\Drafts` SPECIAL-USE flag), so only the AppleScript lifecycle ops failed.

- **Root cause 1:** five AppleScript loops gated on `name of mb contains "Drafts"` — misses a localized folder name (German "Entwürfe").
- **Root cause 2:** the Message-ID → internal-id resolver scanned **all** mailboxes; on Gmail it returned the **All Mail mirror** of the draft, whose id the Drafts-scoped lookups can never match.

## Fix — iterate Mail.app's unified `drafts mailbox`
Rather than a localized-name list (the reporter's suggestion), I use Mail.app's **unified `drafts mailbox`** — its own locale-independent aggregation of every account's Drafts folder. Verified empirically on real accounts that it reports Gmail drafts as `mailbox = "Drafts"` (the true copy), **not** the All Mail mirror — so it fixes **both** root causes at once, with zero folder-name matching, collapsing five nested loops into one.

- All five loops (`delete_draft`, `get_draft_state`, `create_draft` snapshot + terminal, `extract_draft_attachments`) now iterate `messages of drafts mailbox`.
- New Drafts-scoped resolver `_resolve_draft_internal_id` (used by `_resolve_draft_lookup_id`) searches only the unified drafts mailbox → resolves to the real Drafts copy, never the mirror. `find_message_by_message_id` stays broad for reply/forward seeds.
- `_run_applescript` pins `encoding="utf-8"` (the reporter's bonus observation).

**Side win:** draft lookups no longer scan every mailbox, so they're fast on large Gmail accounts where the old broad scan hit the 60s `osascript` timeout (confirmed: on `main`, IMAP-draft create/delete were *already* timing out on a big Gmail).

## Tests
- **Unit:** new script-shape assertions (`drafts mailbox`, no `name of mb contains "Drafts"`) + a `TestResolveDraftInternalId` class.
- **Integration (real Gmail — the hard case: All Mail mirror + `[Gmail]/Drafts`):** the four `TestDraftsLifecycleIntegration` draft tests pass; create → `get_draft_state` → delete → gone round-trips. Made sync-aware for the async IMAP-APPEND visibility lag the old slow scan used to mask.

Localization (root cause 1) is fixed by construction — Mail.app resolves the special-use role, no name matching — so it can't be reproduced on an English Mail.app here; @Rasenschach has German Mail.app and offered to confirm.

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)