### PR TITLE
fix(#415): resolve thread anchors without freezing Mail on large mailboxes

### DIFF
--- a/.claude/skills/performance-patterns/SKILL.md
+++ b/.claude/skills/performance-patterns/SKILL.md
@@ -76,6 +76,19 @@ Gmail operations are inherently slower than IMAP because:
 - Label operations don't map cleanly to folder operations
 - Search across Gmail labels may scan differently than IMAP folders
 
+**Threading cost scales with folder count (not account size).** IMAP `SEARCH` runs
+against one selected mailbox at a time — there is no cross-folder search — so
+`get_thread`'s member collection probes each candidate folder in turn. Gmail exposes
+every label as an IMAP folder *and* copies each message into every label it carries, so
+a thread's members are scattered across many folders. The mitigation is All Mail: enable
+Gmail Settings → Labels → "All Mail" → *Show in IMAP*, and `_find_all_mail_folder`
+(`\All` SPECIAL-USE, RFC 6154) collapses the probe to that single mailbox holding one
+copy of everything. Without it, threading falls back to per-label probing. This is not
+Gmail-specific in principle: any IMAP account with dozens of folders pays the same
+per-folder cost — non-Gmail accounts are usually fast only because their mail is
+concentrated in a handful of folders (INBOX/Sent). See #415 and the `get_thread`
+performance callout in `docs/reference/TOOLS.md`.
+
 ## Profiling
 
 No formal benchmarking infrastructure yet (see issue #31). When added:

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -251,6 +251,10 @@ Row fields include both `id` (path-native — see `search_messages` for details)
 
 Uses the connector's tiered IMAP threading dispatch (Tier 1 X-GM-THRID for Gmail per #122, Tier 3 header-search BFS fallback) when IMAP is configured; falls back to AppleScript otherwise.
 
+> **⚡ Performance on large accounts (Gmail especially).** IMAP `SEARCH` runs on **one mailbox at a time** — there is no cross-folder search — so threading cost scales with **how many mailboxes must be checked**, not how many messages you have. A thread's messages are inherently spread across mailboxes (INBOX for received, Sent for replies, plus labels/folders).
+>
+> Gmail is the outlier: it exposes each **label** as a folder and files a copy of a message into *every* label it carries, and accounts routinely have dozens of labels. The shortcut is **All Mail**, which holds every message exactly once — so on Gmail, enable **Settings → Labels → All Mail → "Show in IMAP"** for fast threading (and to search all mail). With All Mail hidden, `get_thread` must walk every label-folder (one `SEARCH` each), which is slow on many-label accounts. Non-Gmail (true folder) accounts usually have a handful of folders with thread members concentrated in INBOX/Sent, so they stay fast without any special mailbox — though an account with genuinely dozens of folders would hit the same per-folder cost.
+
 **Examples:**
 
 ```python

--- a/src/apple_mail_fast_mcp/imap_connector.py
+++ b/src/apple_mail_fast_mcp/imap_connector.py
@@ -46,6 +46,7 @@ from .exceptions import (
     MailImapTrashNotFoundError,
     MailMessageNotFoundError,
 )
+from .utils import parse_rfc822_ids
 
 logger = logging.getLogger(__name__)
 
@@ -815,6 +816,48 @@ def _select_body_bytes(entry: dict[bytes, Any], body_key: bytes) -> bytes:
     return body_bytes or b""
 
 
+def _header_fields_bytes(entry: dict[bytes, Any]) -> bytes:
+    """Pull the ``HEADER.FIELDS`` section bytes out of a FETCH entry,
+    tolerating imapclient's ``BODY.PEEK[…]`` → ``BODY[…]`` key normalization
+    (#415)."""
+    for key, value in entry.items():
+        if (
+            isinstance(key, bytes)
+            and b"HEADER.FIELDS" in key
+            and isinstance(value, (bytes, bytearray))
+        ):
+            return bytes(value)
+    return b""
+
+
+def _anchor_from_fetch(entry: dict[bytes, Any]) -> dict[str, Any]:
+    """Build a ``get_thread`` anchor from a FETCH of ENVELOPE +
+    REFERENCES/IN-REPLY-TO headers (#415). References is not carried in the
+    IMAP ENVELOPE, so it is parsed from the fetched header block."""
+    envelope = entry.get(b"ENVELOPE")
+    rfc_id = ""
+    subject = ""
+    in_reply_to = ""
+    if envelope is not None:
+        rfc_id = _strip_brackets(_decode(envelope.message_id))
+        subject = _decode_mime_header(envelope.subject)
+        in_reply_to = _strip_brackets(_decode(envelope.in_reply_to))
+    references: list[str] = []
+    header_bytes = _header_fields_bytes(entry)
+    if header_bytes:
+        parsed = message_from_bytes(header_bytes, policy=policy.default)
+        references = parse_rfc822_ids(parsed.get("References", "") or "")
+        if not in_reply_to:
+            irt = parse_rfc822_ids(parsed.get("In-Reply-To", "") or "")
+            in_reply_to = irt[0] if irt else ""
+    return {
+        "rfc_message_id": rfc_id,
+        "subject": subject,
+        "in_reply_to": in_reply_to or None,
+        "references": references,
+    }
+
+
 def _payload_to_attachment_meta(fa: ForwardedAttachment) -> dict[str, Any]:
     """Map a ``draft_builder`` ForwardedAttachment tuple
     ``(filename, maintype, subtype, payload)`` to the IMAP attachment-metadata
@@ -1246,6 +1289,64 @@ class ImapConnector:
             return _bodystructure_extract_attachments(
                 entry.get(b"BODYSTRUCTURE")
             )
+
+    def resolve_anchor(self, message_id: str) -> dict[str, Any] | None:
+        """Resolve an RFC 5322 Message-ID to a get_thread anchor via
+        server-side, INDEXED ``SEARCH HEADER Message-ID`` (#415).
+
+        This exists so ``get_thread`` never runs Mail.app's UNINDEXED
+        all-mailbox ``whose message id`` scan, which loads every message and
+        freezes Mail on a large account (a 33k-message INBOX takes >100s).
+        IMAP ``SEARCH HEADER`` is server-indexed and instant.
+
+        Probes a BOUNDED folder set — Gmail's ``\\All`` (All Mail mirrors every
+        message) if present, else INBOX + Sent — and never lists/scans every
+        folder or message. Returns an anchor dict
+        ``{rfc_message_id, subject, in_reply_to, references}`` for the first
+        probed folder that contains the Message-ID, or ``None`` if not found.
+        The caller supplies ``account``.
+
+        Raises:
+            IMAPClientError / OSError / LoginError: connection/auth failures,
+                so the caller can fall through to the next account.
+        """
+        bracketed = _bracket_message_id(message_id)
+        with self._session() as client:
+            for folder in self._anchor_probe_folders(client):
+                try:
+                    client.select_folder(folder, readonly=True)
+                    uids = client.search(["HEADER", "Message-ID", bracketed])
+                except IMAPClientError as exc:
+                    logger.debug(
+                        "resolve_anchor: skipping %s (%s)", folder, exc
+                    )
+                    continue
+                if not uids:
+                    continue
+                try:
+                    fetched = client.fetch(
+                        [uids[0]],
+                        [
+                            b"ENVELOPE",
+                            b"BODY.PEEK[HEADER.FIELDS "
+                            b"(REFERENCES IN-REPLY-TO)]",
+                        ],
+                    )
+                except IMAPClientError:
+                    continue
+                entry = fetched.get(uids[0])
+                if entry:
+                    return _anchor_from_fetch(entry)
+        return None
+
+    def _anchor_probe_folders(self, client: IMAPClient) -> list[str]:
+        """Bounded folder set for #415 anchor resolution: Gmail All Mail
+        (mirrors every message) if present, else INBOX + Sent. Never lists
+        all folders — that's the cost we're removing."""
+        all_mail = self._find_all_mail_folder(client)
+        if all_mail:
+            return [all_mail]
+        return list(self._anchor_lookup_folders(client))
 
     def find_thread_members(
         self,

--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -487,22 +487,22 @@ def _message_id_match_clause(message_id: str) -> str:
     lookup (save_attachments, get_thread anchor, …) without knowing which
     path produced it.
 
-    The numeric ``id`` branch is included ONLY when the input is all-digits:
-    comparing Mail's integer ``id`` against a non-numeric string raises inside
-    a ``whose`` filter and aborts the entire match — the bug that made
-    IMAP-sourced ids report "Message not found".
+    Performance / correctness (#415): an all-digit input is matched by the
+    numeric ``id`` ALONE. Mail's ``id`` is an integer and is INDEXED, so
+    ``whose id is N`` is instant; ``whose message id is`` is UNINDEXED and
+    forces Mail to load every message (~20s/mailbox), so it is emitted only for
+    a non-numeric RFC 5322 Message-ID (which always contains ``@``, hence is
+    never all-digits) where it is the sole matcher. Comparing the integer
+    ``id`` against a non-numeric string would also raise inside the ``whose``
+    filter and abort the match, which is the other reason the two never mix.
     """
     raw = sanitize_input(message_id)
     bare = raw[1:-1] if raw.startswith("<") and raw.endswith(">") else raw
+    if bare.isdigit():
+        return f"id is {bare}"
     bare_safe = escape_applescript_string(bare)
     brk_safe = escape_applescript_string(f"<{bare}>")
-    clauses = [
-        f'message id is "{bare_safe}"',
-        f'message id is "{brk_safe}"',
-    ]
-    if bare.isdigit():
-        clauses.insert(0, f"id is {bare}")
-    return " or ".join(clauses)
+    return f'message id is "{bare_safe}" or message id is "{brk_safe}"'
 
 
 # MCP-tool field name → Mail.app AppleScript `rule type` enum identifier.
@@ -2264,6 +2264,24 @@ class AppleMailConnector:
             body_format=body_format,
         )
 
+    def _reject_rfc_id_scan(self, message_id: str) -> None:
+        """Refuse to resolve an RFC 5322 Message-ID via the unindexed
+        all-mailbox ``whose message id`` AppleScript scan (#415).
+
+        That scan loads every message and freezes Mail on a large account. A
+        numeric id (no ``@``) is fine — it uses the indexed ``whose id is``.
+        For a Message-ID, the caller should pass ``account`` + ``mailbox``
+        (both are on every search result) to take the indexed IMAP fast path.
+        """
+        if "@" in message_id:
+            raise MailMessageNotFoundError(
+                f"Resolving message {message_id!r} by its RFC Message-ID "
+                "without an account+mailbox would scan every message and can "
+                "hang Mail on large accounts. Pass `account` and `mailbox` "
+                "(both are on your search result) to use the indexed IMAP "
+                "fast path. (#415)"
+            )
+
     def _get_message_applescript(
         self,
         message_id: str,
@@ -2276,6 +2294,7 @@ class AppleMailConnector:
         with a known account+mailbox should provide them to take the
         IMAP path instead.
         """
+        self._reject_rfc_id_scan(message_id)
         # Accept either the numeric AppleScript id or the RFC Message-ID that
         # the IMAP read path emits, so a search-result id resolves regardless
         # of which path produced it (issue F2).
@@ -2629,6 +2648,7 @@ class AppleMailConnector:
         ``dest_path`` via Mail.app's ``save`` command. Factored out so the
         byte-read path is unit-testable without a real Mail.app save.
         """
+        self._reject_rfc_id_scan(message_id)
         # Accept either the numeric AppleScript id or the RFC Message-ID from
         # the IMAP read path so a search-result id resolves either way (F2).
         id_match_clause = _message_id_match_clause(message_id)
@@ -2672,6 +2692,7 @@ class AppleMailConnector:
         Callers with a known account+mailbox should provide them to take
         the IMAP path instead.
         """
+        self._reject_rfc_id_scan(message_id)
         # Accept either the numeric AppleScript id or the RFC Message-ID from
         # the IMAP read path so a search-result id resolves either way (F2).
         id_match_clause = _message_id_match_clause(message_id)
@@ -2730,7 +2751,25 @@ class AppleMailConnector:
         Raises:
             MailMessageNotFoundError: If no message with the given id exists.
         """
-        anchor = self._resolve_thread_anchor_applescript(message_id)
+        # Resolve the anchor without ever running the unindexed all-mailbox
+        # `whose message id` scan, which loads every message and freezes Mail
+        # on a large account (#415).
+        if "@" in message_id:
+            # An RFC 5322 Message-ID (the id the IMAP read path returns).
+            # Resolve it server-side via indexed SEARCH HEADER Message-ID.
+            anchor = self._resolve_anchor_via_imap(message_id)
+            if anchor is None:
+                raise MailMessageNotFoundError(
+                    f"No message with Message-ID {message_id!r} found via "
+                    "IMAP. get_thread resolves RFC Message-IDs through IMAP — "
+                    "ensure the account has IMAP configured (`setup-imap`). "
+                    "The AppleScript fallback is intentionally not used for "
+                    "Message-IDs because it scans every message and can hang "
+                    "Mail on large accounts. (#415)"
+                )
+        else:
+            # Mail.app numeric internal id → indexed `whose id is N` (fast).
+            anchor = self._resolve_thread_anchor_applescript(message_id)
         anchor_account = cast(str, anchor["account"])
         if not self._imap_breaker_open(anchor_account):
             try:
@@ -2739,7 +2778,7 @@ class AppleMailConnector:
                 return result
             except _IMAP_FALLBACK_EXCS as exc:
                 self._log_imap_fallback(anchor_account, exc)
-                # fall through to AppleScript
+                # fall through to AppleScript (account-scoped, subject-filtered)
         return self._collect_thread_applescript(anchor)
 
     def _imap_get_thread(
@@ -2768,6 +2807,46 @@ class AppleMailConnector:
             anchor_rfc_message_id=cast(str, anchor["rfc_message_id"]),
             anchor_references=cast(list[str], anchor.get("references") or []),
         )
+
+    def _resolve_anchor_via_imap(
+        self, message_id: str,
+    ) -> dict[str, Any] | None:
+        """Resolve an RFC 5322 Message-ID to a get_thread anchor via IMAP,
+        across configured accounts (#415).
+
+        Tries each Mail.app account that has IMAP configured (a Keychain
+        app-password), skipping accounts with an open circuit breaker. The
+        per-account lookup (``ImapConnector.resolve_anchor``) is a server-side,
+        INDEXED ``SEARCH HEADER Message-ID`` over a bounded folder set — never
+        the unindexed all-mailbox AppleScript scan that freezes Mail. Returns
+        the anchor dict with ``account`` filled in for the first account whose
+        server contains the Message-ID, or ``None`` if none resolve it.
+        """
+        for acct in self.list_accounts():
+            account = cast(str, acct.get("name") or "")
+            if not account or self._imap_breaker_open(account):
+                continue
+            try:
+                host, port, email = self._resolve_imap_config(account)
+                if not host:
+                    continue
+                password = self._get_imap_password_with_fallback(
+                    account, email
+                )
+                imap = ImapConnector(
+                    host, port, email, password, pool=self._imap_pool
+                )
+                anchor = imap.resolve_anchor(message_id)
+            except _IMAP_FALLBACK_EXCS as exc:
+                # No creds / breaker / connect failure for this account — try
+                # the next one. (MailKeychainEntryNotFoundError is included.)
+                self._log_imap_fallback(account, exc)
+                continue
+            if anchor is not None:
+                self._imap_clear_breaker(account)
+                anchor["account"] = account
+                return anchor
+        return None
 
     def _imap_move_messages(
         self,
@@ -3483,6 +3562,7 @@ class AppleMailConnector:
             return {"saved": 0, "rejected": rejected}
 
         # Accept BOTH id spaces so a row from the IMAP search path pipes
+        self._reject_rfc_id_scan(message_id)
         # straight in (issue F2): the IMAP path returns `id` = the RFC 5322
         # Message-ID (bracketless), while the AppleScript path returns Mail's
         # internal numeric id. Match on either `id` (numeric) or `message id`

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -12,6 +12,7 @@ These tests require:
 Run with: MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=TestAccount pytest --run-integration
 """
 
+import time
 from pathlib import Path
 from typing import Any
 
@@ -232,6 +233,35 @@ class TestMailIntegration:
         from apple_mail_fast_mcp.exceptions import MailMessageNotFoundError
         with pytest.raises(MailMessageNotFoundError):
             connector.get_thread("99999999999")
+
+    def test_get_thread_does_not_freeze_mail(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """#415 freeze-regression guard: get_thread on a real search-result id
+        must never trigger the unindexed all-mailbox `whose message id` scan.
+
+        The bug: a numeric id emitted `message id is "N"` branches (unindexed,
+        ~20s/mailbox) across every account × mailbox, and an RFC id fell through
+        to the same AppleScript scan — either wedged Mail's UI for >100s. Both
+        paths are now indexed / IMAP-resolved, so any real anchor must resolve
+        and collect in well under the freeze threshold. A run over ~10s means
+        the scan has crept back; treat it as a hard FAILURE, not a slow test.
+        """
+        matches = connector.search_messages(
+            account=test_account, mailbox="INBOX", limit=1
+        )
+        if not matches:
+            pytest.skip("test inbox has no messages")
+
+        start = time.monotonic()
+        thread = connector.get_thread(matches[0]["id"])
+        elapsed = time.monotonic() - start
+
+        assert isinstance(thread, list) and len(thread) >= 1
+        assert elapsed < 10.0, (
+            f"get_thread took {elapsed:.1f}s — the #415 unindexed "
+            "`whose message id` scan has regressed (freezes Mail)."
+        )
 
     def test_get_message(
         self, connector: AppleMailConnector, test_account: str

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -3888,3 +3888,77 @@ class TestEnvelopeVanishRobustness:
         conn = ImapConnector("imap.example.com", 993, "u@e.com", "pw")
         with pytest.raises(MailMessageNotFoundError):
             conn.get_message("<gone@example.com>")
+
+
+class TestResolveAnchor:
+    """#415: resolve an RFC Message-ID to a get_thread anchor via server-side
+    INDEXED `SEARCH HEADER Message-ID`, bounded to Gmail All Mail (else
+    INBOX+Sent) — never the unindexed all-mailbox Mail.app scan."""
+
+    @staticmethod
+    def _fetch(uid: int, refs: bytes = b"") -> dict[int, dict[bytes, Any]]:
+        return {
+            uid: {
+                b"ENVELOPE": _fake_envelope(
+                    message_id=b"<abc@x>", subject=b"Hi there"
+                ),
+                b"BODY[HEADER.FIELDS (REFERENCES IN-REPLY-TO)]": (
+                    b"References: " + refs + b"\r\n"
+                ),
+            }
+        }
+
+    @patch("apple_mail_fast_mcp.imap_connector.IMAPClient")
+    def test_gmail_probes_all_mail_only(self, mock_cls: MagicMock) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.list_folders.return_value = [
+            ([b"\\All"], b"/", "[Gmail]/All Mail"),
+            ([b"\\Sent"], b"/", "[Gmail]/Sent Mail"),
+        ]
+        client.search.return_value = [42]
+        client.fetch.return_value = self._fetch(42, b"<r1@x> <r2@x>")
+
+        conn = ImapConnector("h", 993, "e@x", "pw")
+        anchor = conn.resolve_anchor("abc@x")
+
+        assert anchor is not None
+        assert anchor["rfc_message_id"] == "abc@x"
+        assert anchor["subject"] == "Hi there"
+        assert anchor["references"] == ["r1@x", "r2@x"]
+        # Gmail → ONLY All Mail probed (never INBOX/Sent/every folder).
+        client.select_folder.assert_called_once_with(
+            "[Gmail]/All Mail", readonly=True
+        )
+        # Indexed server-side SEARCH HEADER Message-ID (bracketed).
+        assert client.search.call_args[0][0] == [
+            "HEADER", "Message-ID", "<abc@x>",
+        ]
+
+    @patch("apple_mail_fast_mcp.imap_connector.IMAPClient")
+    def test_non_gmail_probes_inbox_then_sent_only(
+        self, mock_cls: MagicMock
+    ) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        # No \All; a \Sent folder present.
+        client.list_folders.return_value = [
+            ([b"\\Sent"], b"/", "Sent Messages"),
+        ]
+        client.search.return_value = []  # not found → None
+
+        conn = ImapConnector("h", 993, "e@x", "pw")
+        assert conn.resolve_anchor("abc@x") is None
+
+        # Bounded probe: INBOX then Sent, in order — never all folders.
+        selected = [c[0][0] for c in client.select_folder.call_args_list]
+        assert selected == ["INBOX", "Sent Messages"]
+
+    @patch("apple_mail_fast_mcp.imap_connector.IMAPClient")
+    def test_not_found_returns_none(self, mock_cls: MagicMock) -> None:
+        client = MagicMock()
+        mock_cls.return_value = client
+        client.list_folders.return_value = [([b"\\All"], b"/", "All Mail")]
+        client.search.return_value = []
+        conn = ImapConnector("h", 993, "e@x", "pw")
+        assert conn.resolve_anchor("nope@x") is None

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -26,9 +26,34 @@ from apple_mail_fast_mcp.exceptions import (
 )
 from apple_mail_fast_mcp.mail_connector import (
     AppleMailConnector,
+    _message_id_match_clause,
     _wrap_as_json_script,
     _wrap_with_timeout,
 )
+
+
+class TestMessageIdMatchClause:
+    """#415: the AppleScript match clause. A numeric (all-digit) id matches by
+    Mail's INDEXED integer `id` alone; the unindexed `message id is` branches
+    (which force loading every message) are emitted only for a non-numeric RFC
+    Message-ID, where they're the sole matcher."""
+
+    def test_numeric_id_is_indexed_only(self) -> None:
+        clause = _message_id_match_clause("12345")
+        assert clause == "id is 12345"
+        assert "message id is" not in clause
+
+    def test_rfc_message_id_uses_message_id_branches(self) -> None:
+        clause = _message_id_match_clause("abc.def@host.example")
+        assert 'message id is "abc.def@host.example"' in clause
+        assert 'message id is "<abc.def@host.example>"' in clause
+        # No spurious integer-id branch for a non-numeric id.
+        assert "id is " not in clause.replace("message id is ", "")
+
+    def test_bracketed_rfc_id_is_stripped(self) -> None:
+        clause = _message_id_match_clause("<abc@host>")
+        assert 'message id is "abc@host"' in clause
+        assert 'message id is "<abc@host>"' in clause
 
 
 class TestAppleMailConnector:
@@ -4295,12 +4320,12 @@ class TestAppleMailConnector:
         # All record keys must be |quoted| per the v0.4.1 selector-collision rule.
         assert "|rfc_message_id|:(message id of msg)" in anchor_script
         assert "|subject|:(subject of msg)" in anchor_script
-        # Anchor lookup now matches either the numeric `id` or the RFC
-        # `message id` (F2 cross-path piping). A numeric input keeps the
-        # integer `id` branch (unquoted, valid AppleScript), and the RFC
-        # branch is always present so an IMAP-sourced Message-ID resolves.
+        # #415: a numeric input matches by the INDEXED integer `id` ONLY. The
+        # unindexed `message id is` branches (which force Mail to load every
+        # message) are dropped for all-digit ids — an RFC Message-ID always
+        # contains "@", so it's never all-digits.
         assert "id is 12345" in anchor_script
-        assert 'message id is "12345"' in anchor_script
+        assert 'message id is "12345"' not in anchor_script
 
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_get_thread_anchor_not_found_raises(
@@ -4875,56 +4900,39 @@ class TestWhoseIdQuoting:
         return AppleMailConnector(timeout=30)
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_get_message_quotes_id_in_whose(
+    def test_get_message_rfc_id_without_account_fails_fast(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        mock_run.return_value = '{"id":"x","subject":"s","sender":"","date_received":"","read_status":false,"flagged":false,"content":""}'
+        # #415: an RFC Message-ID with no account+mailbox must NOT trigger the
+        # unindexed all-mailbox scan (which freezes Mail); it fails fast with a
+        # hint to pass the IMAP fast-path scope. RFC-id quoting/escaping safety
+        # is covered by TestMessageIdMatchClause.
         uuid_id = "CF7C3761-C190-40BA-B94E-3EBC321980ED@icloud.com"
-        connector.get_message(uuid_id, include_content=False)
-        script = mock_run.call_args[0][0]
-        # The clause now matches either the numeric `id` or the RFC `message
-        # id` (F2 cross-path piping), but a non-numeric id must still appear
-        # quoted inside the `whose` filter (injection safety — the original
-        # intent of #86 / this test).
-        assert f'message id is "{uuid_id}"' in script
-        assert f'message id is "<{uuid_id}>"' in script
+        with pytest.raises(MailMessageNotFoundError, match="account"):
+            connector.get_message(uuid_id, include_content=False)
+        mock_run.assert_not_called()
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_get_attachments_quotes_id_in_whose(
+    def test_get_attachments_rfc_id_without_account_fails_fast(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        mock_run.return_value = "[]"
         uuid_id = "CF7C3761-C190-40BA-B94E-3EBC321980ED@icloud.com"
-        connector.get_attachments(uuid_id)
-        script = mock_run.call_args[0][0]
-        assert f'message id is "{uuid_id}"' in script
-        assert f'message id is "<{uuid_id}>"' in script
+        with pytest.raises(MailMessageNotFoundError, match="account"):
+            connector.get_attachments(uuid_id)
+        mock_run.assert_not_called()
 
     @patch.object(AppleMailConnector, "_run_applescript")
-    def test_save_attachments_quotes_id_in_whose(
+    def test_save_attachments_rfc_id_without_account_fails_fast(
         self, mock_run: MagicMock, connector: AppleMailConnector
     ) -> None:
-        mock_run.return_value = "[]"
-        uuid_id = "CF7C3761-C190-40BA-B94E-3EBC321980ED@icloud.com"
-        # save_attachments takes a Path (uses .exists()).
         import tempfile
         from pathlib import Path
+
+        uuid_id = "CF7C3761-C190-40BA-B94E-3EBC321980ED@icloud.com"
         with tempfile.TemporaryDirectory() as td:
-            connector.save_attachments(uuid_id, Path(td))
-        # Multiple AppleScript calls may happen; check at least one
-        # contained the quoted-id pattern. The clause now matches either the
-        # numeric `id` or the RFC `message id` (F2 cross-path piping), but the
-        # id must still appear quoted inside the `whose` filter (injection
-        # safety — the original intent of this test).
-        scripts = [c[0][0] for c in mock_run.call_args_list]
-        assert any(f'message id is "{uuid_id}"' in s for s in scripts), (
-            f"expected quoted id in one of the scripts: {scripts}"
-        )
-        # And the RFC message-id branch (bracketed form) must be present so an
-        # IMAP-sourced id resolves without a numeric-id round-trip.
-        assert any(
-            f'message id is "<{uuid_id}>"' in s for s in scripts
-        ), f"expected message-id branch in one of the scripts: {scripts}"
+            with pytest.raises(MailMessageNotFoundError, match="account"):
+                connector.save_attachments(uuid_id, Path(td))
+        mock_run.assert_not_called()
 
 
 class TestUpdateMessageMatchesRfcMessageId:
@@ -8823,3 +8831,164 @@ class TestSmtpSendPath:
         )
         assert connector._resolve_smtp_config("Gmail") == ("", 0, "")
         assert called == []
+
+
+class TestResolveAnchorViaImap:
+    """#415: cross-account IMAP resolution of an RFC Message-ID anchor."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @staticmethod
+    def _fake_imap(anchor_by_host):
+        def _factory(host, port, email, password, pool=None):
+            m = MagicMock()
+            m.resolve_anchor.return_value = anchor_by_host(host)
+            return m
+        return _factory
+
+    def test_iterates_accounts_first_match_wins(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            connector, "list_accounts",
+            lambda: [{"name": "iCloud"}, {"name": "Gmail"}],
+        )
+        monkeypatch.setattr(connector, "_imap_breaker_open", lambda a: False)
+        monkeypatch.setattr(connector, "_imap_clear_breaker", lambda a: None)
+        monkeypatch.setattr(
+            connector, "_resolve_imap_config",
+            lambda a: (f"imap.{a}", 993, f"{a}@x"),
+        )
+        monkeypatch.setattr(
+            connector, "_get_imap_password_with_fallback", lambda a, e: "pw"
+        )
+        monkeypatch.setattr(
+            "apple_mail_fast_mcp.mail_connector.ImapConnector",
+            self._fake_imap(
+                lambda host: None if "iCloud" in host
+                else {"rfc_message_id": "abc@x", "references": [],
+                      "subject": "Hi", "in_reply_to": None}
+            ),
+        )
+        anchor = connector._resolve_anchor_via_imap("abc@x")
+        assert anchor is not None
+        assert anchor["account"] == "Gmail"
+        assert anchor["rfc_message_id"] == "abc@x"
+
+    def test_skips_accounts_without_keychain_creds(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from apple_mail_fast_mcp.exceptions import (
+            MailKeychainEntryNotFoundError,
+        )
+
+        monkeypatch.setattr(
+            connector, "list_accounts",
+            lambda: [{"name": "NoCreds"}, {"name": "Gmail"}],
+        )
+        monkeypatch.setattr(connector, "_imap_breaker_open", lambda a: False)
+        monkeypatch.setattr(connector, "_imap_clear_breaker", lambda a: None)
+        monkeypatch.setattr(
+            connector, "_resolve_imap_config",
+            lambda a: (f"imap.{a}", 993, f"{a}@x"),
+        )
+
+        def _pwd(a: str, e: str) -> str:
+            if a == "NoCreds":
+                raise MailKeychainEntryNotFoundError("no opt-in")
+            return "pw"
+
+        monkeypatch.setattr(
+            connector, "_get_imap_password_with_fallback", _pwd
+        )
+        monkeypatch.setattr(
+            "apple_mail_fast_mcp.mail_connector.ImapConnector",
+            self._fake_imap(lambda host: {"rfc_message_id": "abc@x",
+                                          "references": []}),
+        )
+        anchor = connector._resolve_anchor_via_imap("abc@x")
+        assert anchor is not None
+        assert anchor["account"] == "Gmail"
+
+    def test_none_when_no_account_resolves(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(connector, "list_accounts", lambda: [{"name": "Gmail"}])
+        monkeypatch.setattr(connector, "_imap_breaker_open", lambda a: False)
+        monkeypatch.setattr(
+            connector, "_resolve_imap_config", lambda a: ("imap.x", 993, "e@x")
+        )
+        monkeypatch.setattr(
+            connector, "_get_imap_password_with_fallback", lambda a, e: "pw"
+        )
+        monkeypatch.setattr(
+            "apple_mail_fast_mcp.mail_connector.ImapConnector",
+            self._fake_imap(lambda host: None),
+        )
+        assert connector._resolve_anchor_via_imap("nope@x") is None
+
+
+class TestGetThreadNeverScansForRfcId:
+    """#415: an RFC Message-ID anchor resolves via IMAP; get_thread must NEVER
+    run the unindexed AppleScript scan for it."""
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    def test_rfc_id_routes_through_imap_no_applescript(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        scripts: list[str] = []
+        monkeypatch.setattr(
+            connector, "_run_applescript",
+            lambda s: scripts.append(s) or "",
+        )
+        monkeypatch.setattr(
+            connector, "_resolve_anchor_via_imap",
+            lambda mid: {"account": "Gmail", "rfc_message_id": "abc@x",
+                         "references": [], "subject": "Hi"},
+        )
+        monkeypatch.setattr(connector, "_imap_breaker_open", lambda a: False)
+        monkeypatch.setattr(connector, "_imap_clear_breaker", lambda a: None)
+        monkeypatch.setattr(
+            connector, "_imap_get_thread", lambda anchor: [{"id": "abc@x"}]
+        )
+        result = connector.get_thread("abc@x")
+        assert result == [{"id": "abc@x"}]
+        # The whole point of #415: no AppleScript ran at all for an RFC id.
+        assert scripts == []
+
+    def test_rfc_id_unresolved_raises_without_scanning(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        scripts: list[str] = []
+        monkeypatch.setattr(
+            connector, "_run_applescript",
+            lambda s: scripts.append(s) or "",
+        )
+        monkeypatch.setattr(
+            connector, "_resolve_anchor_via_imap", lambda mid: None
+        )
+        with pytest.raises(MailMessageNotFoundError):
+            connector.get_thread("missing@x")
+        assert scripts == []  # raised instead of scanning
+
+    def test_numeric_id_still_uses_applescript_anchor(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: dict[str, str] = {}
+        monkeypatch.setattr(
+            connector, "_resolve_thread_anchor_applescript",
+            lambda mid: seen.update(mid=mid) or {
+                "account": "Gmail", "rfc_message_id": "x@y",
+                "references": [], "subject": "S", "internal_id": mid,
+            },
+        )
+        monkeypatch.setattr(connector, "_imap_breaker_open", lambda a: False)
+        monkeypatch.setattr(connector, "_imap_clear_breaker", lambda a: None)
+        monkeypatch.setattr(connector, "_imap_get_thread", lambda anchor: [])
+        connector.get_thread("12345")
+        assert seen["mid"] == "12345"


### PR DESCRIPTION
## Problem

`get_thread` / `get_message` resolved a message id via an **unscoped** AppleScript loop (all accounts × all mailboxes) whose match clause emitted `message id is "N"` — an **unindexed** comparison that loads every message (~20s/mailbox). On a 33k-message Gmail INBOX a single lookup ran **>100s and froze Mail's UI**. The 60s tool timeout kills the `osascript` client, but Mail keeps evaluating server-side, so it stays wedged long after the tool errors.

Two cost drivers, both fixed:

1. The clause emitted the unindexed `message id is` branches **even for all-digit numeric ids**.
2. Users with IMAP configured get back **RFC Message-IDs** (the IMAP fast path never assigns a numeric Mail id), which force the unindexed branch.

## Fix

- **§1 — indexed numeric lookups.** `_message_id_match_clause` returns `id is N` only for numeric input (indexed/instant). Non-numeric input keeps the bracketed `message id is` branches for the bounded last-resort path.
- **§2 — RFC ids resolve via the server, not a scan.** New `ImapConnector.resolve_anchor` (one pooled session; probes All Mail via `\All` SPECIAL-USE on Gmail, else INBOX+Sent; indexed `SEARCH HEADER Message-ID`; single ENVELOPE + References FETCH) and `AppleMailConnector._resolve_anchor_via_imap` (first account that resolves wins; skips breaker-open / no-credential accounts).
- **§3 — `get_thread` routing.** Numeric id → AppleScript anchor (now fast); RFC id (contains `@`) → IMAP resolver. If no account resolves an RFC id, raise `MailMessageNotFoundError` pointing at `setup-imap` — never fall back to the freeze-scan.
- **§4 — fail-fast guards.** The four other AppleScript-fallback callers (`_get_message_applescript`, the two attachment methods, `save_attachments` fallback) raise on an RFC id with no account+mailbox hint instead of scanning. Numeric ids there are now fast via §1.

## Verification

- `make check-all` green (lint, mypy strict, complexity, version-sync, parity, doc-drift, 1400+ unit tests).
- New **bounded integration freeze-regression guard**: `test_get_thread_does_not_freeze_mail` asserts `get_thread` on a real search-result id completes in <10s (a longer run means the scan regressed — hard FAILURE).
- **Real-Mail smoke** on a 33k Gmail account: numeric `get_thread` ~17s and RFC `get_thread` ~7.5s — **no freeze** (previously >100s + wedged UI).

## Docs

- TOOLS.md `get_thread` performance callout + performance-patterns skill note: IMAP SEARCH is per-mailbox (no cross-folder search), so **threading cost scales with folder count** — enable Gmail Settings → Labels → All Mail → *Show in IMAP* to collapse the probe to one mailbox.

## Known limitations (follow-ups)

- Non-Gmail anchor probe is INBOX+Sent only; a message living solely in a custom folder on such an account raises (rather than freezes). Widening the probe is a follow-up.
- The four §4 callers still require an account+mailbox hint for RFC ids; full auto-resolve is a follow-up.
- Numeric `get_thread` member collection is still cross-mailbox (~17s on 33k Gmail); scoping it via All Mail is a follow-up.

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)