### PR TITLE
perf(#419): bound numeric get_thread anchor resolution to the unified mailboxes

### DIFF
--- a/.claude/skills/performance-patterns/SKILL.md
+++ b/.claude/skills/performance-patterns/SKILL.md
@@ -89,6 +89,23 @@ per-folder cost — non-Gmail accounts are usually fast only because their mail 
 concentrated in a handful of folders (INBOX/Sent). See #415 and the `get_thread`
 performance callout in `docs/reference/TOOLS.md`.
 
+**Bound the mailbox set on the AppleScript side too — with the unified mailboxes.**
+The same "don't visit every mailbox" rule applies to AppleScript lookups, and Mail.app
+gives you ready-made bounds: the application-level `inbox`, `sent mailbox`, and
+`drafts mailbox` aggregate the corresponding folder across *every* account, so probing
+them needs no per-account mailbox iteration and no name matching (which would break on
+localized names). `whose id is N` works against them, and `account of (mailbox of msg)`
+walks back to the owning account. `_resolve_numeric_anchor_fast` uses this to replace a
+`repeat with acc in accounts / repeat with mb in mailboxes of acc` scan: ~1.3s vs ~3.0s
+on a 33k-message Gmail account (#419). Keep the full walk as a not-found backstop.
+
+**Don't assume IMAP is the fast side.** Indexed does not mean instant at scale: on that
+same account `SEARCH HEADER Message-ID` over a 33k-message All Mail measured ~17s, so
+replacing the AppleScript anchor above with an IMAP lookup would have been ~13× *slower*,
+not faster. Measure per-phase against a real large account before moving work across the
+AppleScript/IMAP boundary — and re-measure, because Gmail's server-side latency swings
+by tens of seconds with throttling.
+
 ## Profiling
 
 No formal benchmarking infrastructure yet (see issue #31). When added:

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -79,6 +79,24 @@ model the lifecycle:
 If IMAP isn't configured/reachable, `get_thread` reconstructs the thread via AppleScript (subject
 prefilter + `In-Reply-To`/`References` header walk).
 
+### Anchor resolution
+
+The tiers above cover **member collection**, which is shared by both `message_id` forms. Resolving
+the *anchor* first is what differs, and it is bounded in both cases (#415, #419):
+
+| id form | Strategy | Cost |
+|---------|----------|------|
+| RFC Message-ID | `ImapConnector.resolve_anchor` — indexed `SEARCH HEADER Message-ID` over Gmail All Mail, else INBOX + Sent | one bounded IMAP probe; no AppleScript |
+| numeric | `_resolve_numeric_anchor_fast` — `whose id is N` against Mail's unified `inbox`, then `sent mailbox` | 2 indexed lookups, account-count-independent |
+| numeric (not in either) | `_resolve_thread_anchor_applescript` — every mailbox of every account | correctness backstop; ~2× the probe on a 33k Gmail account |
+
+Both numeric paths emit the same anchor record (`_anchor_record_applescript` /
+`_anchor_from_applescript_record` are shared), so the choice between them is purely a cost decision.
+The unified mailboxes are used because they aggregate across accounts and are locale-independent —
+the same reason `drafts mailbox` is used for draft lookups (#407). Note that the numeric anchor
+deliberately stays in AppleScript: routing it through `resolve_anchor` instead measured ~17s on a
+33k-message Gmail account, since `SEARCH HEADER` over a 33k All Mail is far from instant.
+
 ## Module responsibilities
 
 | Module | Role |

--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -254,6 +254,8 @@ Uses the connector's tiered IMAP threading dispatch (Tier 1 X-GM-THRID for Gmail
 > **⚡ Performance on large accounts (Gmail especially).** IMAP `SEARCH` runs on **one mailbox at a time** — there is no cross-folder search — so threading cost scales with **how many mailboxes must be checked**, not how many messages you have. A thread's messages are inherently spread across mailboxes (INBOX for received, Sent for replies, plus labels/folders).
 >
 > Gmail is the outlier: it exposes each **label** as a folder and files a copy of a message into *every* label it carries, and accounts routinely have dozens of labels. The shortcut is **All Mail**, which holds every message exactly once — so on Gmail, enable **Settings → Labels → All Mail → "Show in IMAP"** for fast threading (and to search all mail). With All Mail hidden, `get_thread` must walk every label-folder (one `SEARCH` each), which is slow on many-label accounts. Non-Gmail (true folder) accounts usually have a handful of folders with thread members concentrated in INBOX/Sent, so they stay fast without any special mailbox — though an account with genuinely dozens of folders would hit the same per-folder cost.
+>
+> The cost above is **member collection**, and it is identical for both `message_id` forms — they converge on the same tiered dispatch. **Anchor resolution** differs by form: an RFC Message-ID is resolved over IMAP (one indexed `SEARCH HEADER Message-ID`), while a numeric Mail.app id is resolved by AppleScript against Mail's unified `inbox`, then `sent mailbox` — bounded, and locale-independent. A numeric id that is in neither falls back to a scan of every mailbox of every account, which is correct but markedly slower (~3.0s vs ~1.3s on a 33k-message Gmail account, #419).
 
 **Examples:**
 

--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -475,6 +475,57 @@ def _filter_imap_results_to_cutoff(
 _SLOW_SEARCH_THRESHOLD_SEC = 5.0
 
 
+def _anchor_record_applescript(msg_var: str, account_expr: str) -> str:
+    """AppleScript fragment building a ``get_thread`` anchor record from the
+    message in ``msg_var`` (account name read from ``account_expr``).
+
+    Shared by the bounded probe and the unbounded-walk backstop (#419) so the
+    two anchors cannot drift: ``get_thread`` chooses between them purely on
+    cost, which is only safe while they produce identical records.
+
+    ``missing value`` is coerced away here because NSJSONSerialization rejects
+    it outright — a single message with no subject would otherwise fail the
+    whole call.
+    """
+    return f'''
+                        set anchorInReplyTo to ""
+                        set anchorRefs to ""
+                        try
+                            repeat with h in headers of {msg_var}
+                                set hname to name of h
+                                if hname is "in-reply-to" then set anchorInReplyTo to (content of h)
+                                if hname is "references" then set anchorRefs to (content of h)
+                            end repeat
+                        end try
+                        set anchorAccount to ({account_expr})
+                        if anchorAccount is missing value then set anchorAccount to ""
+                        set anchorRfc to (message id of {msg_var})
+                        if anchorRfc is missing value then set anchorRfc to ""
+                        set anchorSubject to (subject of {msg_var})
+                        if anchorSubject is missing value then set anchorSubject to ""
+                        set anchorRecord to {{|found|:true, |account|:anchorAccount, |rfc_message_id|:anchorRfc, |subject|:anchorSubject, |in_reply_to|:anchorInReplyTo, |references_raw|:anchorRefs}}
+'''
+
+
+def _anchor_from_applescript_record(
+    raw: dict[str, Any], message_id: str
+) -> dict[str, Any]:
+    """Python half of :func:`_anchor_record_applescript` — normalize one
+    emitted anchor record into the dict ``get_thread`` consumes."""
+    from .utils import parse_rfc822_ids
+
+    in_reply_to_raw = raw.get("in_reply_to") or ""
+    references_raw = raw.get("references_raw") or ""
+    return {
+        "internal_id": message_id,
+        "account": cast(str, raw["account"]),
+        "rfc_message_id": cast(str, raw["rfc_message_id"]),
+        "subject": cast(str, raw["subject"]),
+        "in_reply_to": in_reply_to_raw or None,
+        "references": parse_rfc822_ids(references_raw),
+    }
+
+
 def _message_id_match_clause(message_id: str) -> str:
     """Build an AppleScript boolean (for a ``whose`` filter) that matches a
     message by EITHER Mail's numeric ``id`` OR its RFC 5322 ``message id``
@@ -2768,8 +2819,9 @@ class AppleMailConnector:
                     "Mail on large accounts. (#415)"
                 )
         else:
-            # Mail.app numeric internal id → indexed `whose id is N` (fast).
-            anchor = self._resolve_thread_anchor_applescript(message_id)
+            # Mail.app numeric internal id → bounded probe of the unified
+            # inbox/Sent, falling back to the all-mailbox walk (#419).
+            anchor = self._resolve_numeric_anchor(message_id)
         anchor_account = cast(str, anchor["account"])
         if not self._imap_breaker_open(anchor_account):
             try:
@@ -2847,6 +2899,19 @@ class AppleMailConnector:
                 anchor["account"] = account
                 return anchor
         return None
+
+    def _resolve_numeric_anchor(self, message_id: str) -> dict[str, Any]:
+        """Resolve a Mail.app numeric id to a get_thread anchor (#419).
+
+        Tries the bounded probe first and falls back to the unbounded
+        ``accounts x mailboxes`` walk only when the probe can't place the id.
+        Both produce the identical anchor dict, so this is purely a cost
+        reduction — see :meth:`_resolve_numeric_anchor_fast`.
+        """
+        return (
+            self._resolve_numeric_anchor_fast(message_id)
+            or self._resolve_thread_anchor_applescript(message_id)
+        )
 
     def _imap_move_messages(
         self,
@@ -3264,6 +3329,73 @@ class AppleMailConnector:
         anchor = self._resolve_thread_anchor_applescript(message_id)
         return self._collect_thread_applescript(anchor)
 
+    def _resolve_numeric_anchor_fast(
+        self, message_id: str,
+    ) -> dict[str, Any] | None:
+        """Bounded AppleScript probe resolving a numeric id to a thread
+        anchor (#419).
+
+        Returns the SAME anchor dict as
+        :meth:`_resolve_thread_anchor_applescript` — the two share the record
+        fragment — but reaches it without the ``accounts x mailboxes`` walk
+        that method pays. Instead of iterating every mailbox of every account
+        until the id turns up, it probes Mail.app's unified ``inbox`` then
+        ``sent mailbox``: application-level aggregations across all accounts,
+        so they need no per-account mailbox-name matching and are immune to
+        localized names (the property that made ``drafts mailbox`` the right
+        target in #407). That mirrors the bound ``_anchor_probe_folders``
+        already applies on the IMAP side.
+
+        The match uses ``_message_id_match_clause``, which for an all-digit id
+        emits Mail's INDEXED integer ``id is N`` (#415/#416).
+
+        Measured on a 33k-message Gmail account: 1.3s here vs 3.0s for the
+        full walk. (Handing the id to ``ImapConnector.resolve_anchor``
+        instead — the other obvious route to the same anchor — measured 17s
+        on that account, because ``SEARCH HEADER Message-ID`` over a 33k All
+        Mail is anything but instant. Hence AppleScript on both sides of this
+        branch.)
+
+        Returns:
+            The anchor dict, or ``None`` when the id is in neither probed
+            mailbox or the message can't be traced back to a named account.
+            ``None`` means "fall back to the unbounded walk", not "error" —
+            a genuinely nonexistent id is still reported by that walk, which
+            preserves the ``MailMessageNotFoundError`` contract.
+        """
+        id_match_clause = _message_id_match_clause(message_id)
+        anchor_record = _anchor_record_applescript(
+            "msgRef", "name of (account of (mailbox of msgRef))"
+        )
+        probe_body = f'''
+        tell application "Mail"
+            set msgRef to missing value
+            try
+                set msgRef to first message of inbox whose ({id_match_clause})
+            end try
+            if msgRef is missing value then
+                try
+                    set msgRef to first message of sent mailbox whose ({id_match_clause})
+                end try
+            end if
+
+            if msgRef is missing value then
+                set resultData to {{|found|:false}}
+            else
+{anchor_record}
+                set resultData to anchorRecord
+            end if
+        end tell
+        '''
+
+        probe_script = _wrap_as_json_script(probe_body, timeout=self.timeout)
+        raw = parse_applescript_json(self._run_applescript(probe_script))
+        if not isinstance(raw, dict) or not raw.get("found"):
+            return None
+        if not raw.get("account") or not raw.get("rfc_message_id"):
+            return None
+        return _anchor_from_applescript_record(raw, message_id)
+
     def _resolve_thread_anchor_applescript(
         self, message_id: str,
     ) -> dict[str, Any]:
@@ -3283,12 +3415,11 @@ class AppleMailConnector:
         Raises:
             MailMessageNotFoundError: If no message with the given id exists.
         """
-        from .utils import parse_rfc822_ids
-
         # Accept either the numeric AppleScript id or the RFC Message-ID that
         # the IMAP read path emits, so get_thread can anchor on a search
         # result id regardless of which path produced it (issue F2).
         id_match_clause = _message_id_match_clause(message_id)
+        anchor_record = _anchor_record_applescript("msg", "name of acc")
         anchor_body = f'''
         tell application "Mail"
             set anchorResult to missing value
@@ -3296,16 +3427,8 @@ class AppleMailConnector:
                 repeat with mb in mailboxes of acc
                     try
                         set msg to first message of mb whose ({id_match_clause})
-                        set anchorInReplyTo to ""
-                        set anchorRefs to ""
-                        try
-                            repeat with h in headers of msg
-                                set hname to name of h
-                                if hname is "in-reply-to" then set anchorInReplyTo to (content of h)
-                                if hname is "references" then set anchorRefs to (content of h)
-                            end repeat
-                        end try
-                        set resultData to {{|account|:(name of acc), |rfc_message_id|:(message id of msg), |subject|:(subject of msg), |in_reply_to|:anchorInReplyTo, |references_raw|:anchorRefs}}
+{anchor_record}
+                        set resultData to anchorRecord
                         set anchorResult to resultData
                         exit repeat
                     end try
@@ -3322,17 +3445,7 @@ class AppleMailConnector:
         anchor_script = _wrap_as_json_script(anchor_body, timeout=self.timeout)
         anchor_raw = self._run_applescript(anchor_script)
         raw = cast(dict[str, Any], parse_applescript_json(anchor_raw))
-
-        in_reply_to_raw = raw.get("in_reply_to") or ""
-        references_raw = raw.get("references_raw") or ""
-        return {
-            "internal_id": message_id,
-            "account": cast(str, raw["account"]),
-            "rfc_message_id": cast(str, raw["rfc_message_id"]),
-            "subject": cast(str, raw["subject"]),
-            "in_reply_to": in_reply_to_raw or None,
-            "references": parse_rfc822_ids(references_raw),
-        }
+        return _anchor_from_applescript_record(raw, message_id)
 
     def _collect_thread_applescript(
         self, anchor: dict[str, Any],

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -12,6 +12,7 @@ These tests require:
 Run with: MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=TestAccount pytest --run-integration
 """
 
+import statistics
 import time
 from pathlib import Path
 from typing import Any
@@ -25,7 +26,10 @@ from apple_mail_fast_mcp.mail_connector import (
     _wrap_as_json_script,
     _wrap_with_timeout,
 )
-from apple_mail_fast_mcp.utils import parse_applescript_json
+from apple_mail_fast_mcp.utils import (
+    escape_applescript_string,
+    parse_applescript_json,
+)
 
 # Skip all integration tests by default
 # Run with: pytest --run-integration
@@ -50,6 +54,49 @@ def test_account() -> str:
     """
     import os
     return os.getenv("MAIL_TEST_ACCOUNT", "Gmail")
+
+
+def _newest_inbox_ids(
+    connector: AppleMailConnector, account: str
+) -> tuple[str, str] | None:
+    """Both id forms for one real message in ``account``'s inbox (#419).
+
+    Returns ``(numeric_id, rfc_message_id)``, or ``None`` if the inbox is
+    empty. ``search_messages`` can't provide this: it returns the numeric id
+    on the AppleScript path and the RFC Message-ID on the IMAP path, never
+    both, and the #419 tests need to drive the same message through each.
+
+    Reads Mail.app's unified ``inbox`` and filters by account, so it needs no
+    per-account mailbox-name matching (which is locale-dependent).
+    """
+    account_safe = escape_applescript_string(account)
+    body = f'''
+    tell application "Mail"
+        set resultData to {{}}
+        repeat with m in (messages of inbox)
+            set mAccount to ""
+            try
+                set mAccount to (name of (account of (mailbox of m)))
+            end try
+            if mAccount is "{account_safe}" then
+                set resultData to {{|numeric_id|:(id of m as text), |rfc_message_id|:(message id of m)}}
+                exit repeat
+            end if
+        end repeat
+    end tell
+    '''
+    raw = parse_applescript_json(
+        connector._run_applescript(
+            _wrap_as_json_script(body, timeout=connector.timeout)
+        )
+    )
+    if not isinstance(raw, dict):
+        return None
+    numeric_id = str(raw.get("numeric_id") or "")
+    rfc_message_id = str(raw.get("rfc_message_id") or "")
+    if not numeric_id or not rfc_message_id:
+        return None
+    return numeric_id, rfc_message_id
 
 
 class TestMailIntegration:
@@ -262,6 +309,119 @@ class TestMailIntegration:
             f"get_thread took {elapsed:.1f}s — the #415 unindexed "
             "`whose message id` scan has regressed (freezes Mail)."
         )
+
+    # --- #419: numeric-id anchor resolution ------------------------------
+    #
+    # The tests above take an id from search_messages, which on an
+    # IMAP-configured account is an RFC Message-ID — i.e. the already-fast
+    # path. These cover the NUMERIC id, whose anchor used to cost a full
+    # accounts x mailboxes AppleScript walk (~17s vs ~7.5s on a 33k Gmail).
+
+    def test_numeric_anchor_fast_probe_resolves_real_message(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """#419: direct coverage for the bounded probe's AppleScript.
+
+        Unit tests mock _run_applescript and so cannot catch a bad script.
+        This exercises the three things the probe newly relies on against
+        real Mail: `whose id is N` against the unified `inbox`, walking
+        `account of (mailbox of msg)` back to an account name, and the JSON
+        record emission.
+
+        It also pins the invariant the whole change rests on: get_thread
+        chooses between the probe and the unbounded walk purely on cost, so
+        the two must return the SAME anchor.
+        """
+        ids = _newest_inbox_ids(connector, test_account)
+        if ids is None:
+            pytest.skip("test inbox has no messages")
+        numeric_id, rfc_message_id = ids
+
+        probe_anchor = connector._resolve_numeric_anchor_fast(numeric_id)
+
+        assert probe_anchor is not None, (
+            f"bounded probe failed to place numeric id {numeric_id} that "
+            "AppleScript just read out of the unified inbox"
+        )
+        assert probe_anchor["account"] == test_account
+        assert (
+            probe_anchor["rfc_message_id"].strip("<>")
+            == rfc_message_id.strip("<>")
+        )
+        walk_anchor = connector._resolve_thread_anchor_applescript(numeric_id)
+        assert probe_anchor == walk_anchor
+
+    def test_numeric_anchor_probe_beats_unbounded_walk(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """#419 regression guard on the phase this issue actually changes.
+
+        Deliberately times ANCHOR RESOLUTION rather than whole-of-get_thread:
+        the rest of get_thread is IMAP member collection, which is shared by
+        both id formats, is untouched here, and on a large Gmail account
+        swings by tens of seconds with server-side throttling — noise that
+        would swamp the signal and make this test meaningless.
+
+        Medians of 3 to ride out per-call jitter. Measured on a 33k-message
+        Gmail account: ~1.3s probe vs ~3.0s walk.
+        """
+        ids = _newest_inbox_ids(connector, test_account)
+        if ids is None:
+            pytest.skip("test inbox has no messages")
+        numeric_id, _ = ids
+
+        def _median(fn: Any) -> float:
+            samples = []
+            for _ in range(3):
+                start = time.monotonic()
+                assert fn(numeric_id) is not None
+                samples.append(time.monotonic() - start)
+            return statistics.median(samples)
+
+        probe_s = _median(connector._resolve_numeric_anchor_fast)
+        walk_s = _median(connector._resolve_thread_anchor_applescript)
+
+        assert probe_s < walk_s, (
+            f"bounded probe ({probe_s:.2f}s) is no faster than the "
+            f"accounts x mailboxes walk ({walk_s:.2f}s) it replaced (#419)"
+        )
+        assert probe_s < 10.0, (
+            f"numeric anchor resolution took {probe_s:.1f}s — the #415 "
+            "freeze bound applies to the probe too."
+        )
+
+    def test_get_thread_numeric_and_rfc_anchors_agree(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> None:
+        """#419 acceptance: 'threading results unchanged'.
+
+        Both id forms anchor on the same message, so they must return the
+        same member set. Member collection was always shared; this pins that
+        the numeric anchor still hands it an equivalent anchor.
+        """
+        from apple_mail_fast_mcp.exceptions import MailMessageNotFoundError
+
+        ids = _newest_inbox_ids(connector, test_account)
+        if ids is None:
+            pytest.skip("test inbox has no messages")
+        numeric_id, rfc_message_id = ids
+
+        by_numeric = connector.get_thread(numeric_id)
+        try:
+            by_rfc = connector.get_thread(rfc_message_id)
+        except MailMessageNotFoundError:
+            # The RFC form resolves its anchor over IMAP and has no
+            # AppleScript fallback by design (#415), so an unhealthy or
+            # throttled IMAP account leaves nothing to compare against.
+            pytest.skip("IMAP unavailable — cannot resolve the RFC anchor")
+
+        def _keys(thread: list[dict[str, Any]]) -> set[str]:
+            return {
+                str(m.get("rfc_message_id") or m["id"]).strip("<>")
+                for m in thread
+            }
+
+        assert _keys(by_numeric) == _keys(by_rfc)
 
     def test_get_message(
         self, connector: AppleMailConnector, test_account: str

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -1709,6 +1709,15 @@ class TestAppleMailConnector:
     @patch.object(AppleMailConnector, "_collect_thread_applescript")
     @patch.object(AppleMailConnector, "_imap_get_thread")
     @patch.object(AppleMailConnector, "_resolve_thread_anchor_applescript")
+    # #419: a numeric id now tries the bounded probe first. Force it to miss
+    # so these keep exercising the AppleScript-anchor -> member-collection
+    # delegation they were written for. (`new` is passed positionally, so no
+    # extra mock argument is injected into the signatures below.)
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_numeric_anchor_fast",
+        lambda self, mid: None,
+    )
     def test_get_thread_uses_imap_on_success(
         self,
         mock_anchor: MagicMock,
@@ -1732,6 +1741,15 @@ class TestAppleMailConnector:
     @patch.object(AppleMailConnector, "_collect_thread_applescript")
     @patch.object(AppleMailConnector, "_imap_get_thread")
     @patch.object(AppleMailConnector, "_resolve_thread_anchor_applescript")
+    # #419: a numeric id now tries the bounded probe first. Force it to miss
+    # so these keep exercising the AppleScript-anchor -> member-collection
+    # delegation they were written for. (`new` is passed positionally, so no
+    # extra mock argument is injected into the signatures below.)
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_numeric_anchor_fast",
+        lambda self, mid: None,
+    )
     def test_get_thread_falls_back_on_keychain_missing(
         self,
         mock_anchor: MagicMock,
@@ -1764,6 +1782,15 @@ class TestAppleMailConnector:
     @patch.object(AppleMailConnector, "_collect_thread_applescript")
     @patch.object(AppleMailConnector, "_imap_get_thread")
     @patch.object(AppleMailConnector, "_resolve_thread_anchor_applescript")
+    # #419: a numeric id now tries the bounded probe first. Force it to miss
+    # so these keep exercising the AppleScript-anchor -> member-collection
+    # delegation they were written for. (`new` is passed positionally, so no
+    # extra mock argument is injected into the signatures below.)
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_numeric_anchor_fast",
+        lambda self, mid: None,
+    )
     def test_get_thread_falls_back_on_oserror_with_warning(
         self,
         mock_anchor: MagicMock,
@@ -1795,6 +1822,15 @@ class TestAppleMailConnector:
     @patch.object(AppleMailConnector, "_collect_thread_applescript")
     @patch.object(AppleMailConnector, "_imap_get_thread")
     @patch.object(AppleMailConnector, "_resolve_thread_anchor_applescript")
+    # #419: a numeric id now tries the bounded probe first. Force it to miss
+    # so these keep exercising the AppleScript-anchor -> member-collection
+    # delegation they were written for. (`new` is passed positionally, so no
+    # extra mock argument is injected into the signatures below.)
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_numeric_anchor_fast",
+        lambda self, mid: None,
+    )
     def test_get_thread_falls_back_on_login_error(
         self,
         mock_anchor: MagicMock,
@@ -1818,6 +1854,15 @@ class TestAppleMailConnector:
     @patch.object(AppleMailConnector, "_collect_thread_applescript")
     @patch.object(AppleMailConnector, "_imap_get_thread")
     @patch.object(AppleMailConnector, "_resolve_thread_anchor_applescript")
+    # #419: a numeric id now tries the bounded probe first. Force it to miss
+    # so these keep exercising the AppleScript-anchor -> member-collection
+    # delegation they were written for. (`new` is passed positionally, so no
+    # extra mock argument is injected into the signatures below.)
+    @patch.object(
+        AppleMailConnector,
+        "_resolve_numeric_anchor_fast",
+        lambda self, mid: None,
+    )
     def test_get_thread_anchor_not_found_propagates(
         self,
         mock_anchor: MagicMock,
@@ -4317,9 +4362,13 @@ class TestAppleMailConnector:
         ]
         connector._get_thread_applescript("12345")
         anchor_script = mock_run.call_args_list[0][0][0]
-        # All record keys must be |quoted| per the v0.4.1 selector-collision rule.
-        assert "|rfc_message_id|:(message id of msg)" in anchor_script
-        assert "|subject|:(subject of msg)" in anchor_script
+        # All record keys must be |quoted| per the v0.4.1 selector-collision
+        # rule. Values go via locals so `missing value` can be coerced away
+        # before NSJSONSerialization sees them (#419).
+        assert "|rfc_message_id|:anchorRfc" in anchor_script
+        assert "|subject|:anchorSubject" in anchor_script
+        assert "set anchorRfc to (message id of msg)" in anchor_script
+        assert "set anchorSubject to (subject of msg)" in anchor_script
         # #415: a numeric input matches by the INDEXED integer `id` ONLY. The
         # unindexed `message id is` branches (which force Mail to load every
         # message) are dropped for all-digit ids — an RFC Message-ID always
@@ -8976,10 +9025,16 @@ class TestGetThreadNeverScansForRfcId:
             connector.get_thread("missing@x")
         assert scripts == []  # raised instead of scanning
 
-    def test_numeric_id_still_uses_applescript_anchor(
+    def test_numeric_id_falls_back_to_applescript_anchor_when_probe_misses(
         self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """#419: the unbounded accounts x mailboxes walk is retained as the
+        correctness backstop — it runs when the bounded probe can't place the
+        id (e.g. the message lives in neither the unified inbox nor Sent)."""
         seen: dict[str, str] = {}
+        monkeypatch.setattr(
+            connector, "_resolve_numeric_anchor_fast", lambda mid: None
+        )
         monkeypatch.setattr(
             connector, "_resolve_thread_anchor_applescript",
             lambda mid: seen.update(mid=mid) or {
@@ -8992,3 +9047,153 @@ class TestGetThreadNeverScansForRfcId:
         monkeypatch.setattr(connector, "_imap_get_thread", lambda anchor: [])
         connector.get_thread("12345")
         assert seen["mid"] == "12345"
+
+
+class TestNumericAnchorBoundedProbe:
+    """#419: a numeric id resolves its anchor from Mail.app's unified inbox /
+    sent mailbox instead of walking every mailbox of every account. The probe
+    returns the SAME anchor the walk does — the walk survives only as the
+    not-found backstop."""
+
+    FULL_ANCHOR_PAYLOAD = (
+        '{"found": true, "account": "Gmail", "rfc_message_id": "a@b",'
+        ' "subject": "S", "in_reply_to": "<parent@x>",'
+        ' "references_raw": "<root@x> <parent@x>"}'
+    )
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @staticmethod
+    def _capture_scripts(
+        connector: AppleMailConnector,
+        monkeypatch: pytest.MonkeyPatch,
+        payload: str,
+    ) -> list[str]:
+        scripts: list[str] = []
+
+        def _run(script: str) -> str:
+            scripts.append(script)
+            return payload
+
+        monkeypatch.setattr(connector, "_run_applescript", _run)
+        return scripts
+
+    def test_probe_script_is_bounded(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        scripts = self._capture_scripts(
+            connector, monkeypatch, self.FULL_ANCHOR_PAYLOAD
+        )
+        connector._resolve_numeric_anchor_fast("12345")
+
+        assert len(scripts) == 1
+        script = scripts[0]
+        # Bounded to Mail.app's locale-independent unified mailboxes (#407).
+        assert "of inbox" in script
+        assert "sent mailbox" in script
+        # The cost #419 removes: the accounts x mailboxes walk.
+        assert "repeat with acc in accounts" not in script
+        assert "mailboxes of acc" not in script
+        # Indexed integer match, never the unindexed `message id is` (#415).
+        assert "id is 12345" in script
+        assert "message id is" not in script
+
+    def test_probe_returns_the_same_anchor_shape_as_the_walk(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_thread picks between probe and walk purely on cost, so the two
+        must be interchangeable — same keys, same normalization."""
+        self._capture_scripts(
+            connector, monkeypatch, self.FULL_ANCHOR_PAYLOAD
+        )
+        probe_anchor = connector._resolve_numeric_anchor_fast("12345")
+
+        self._capture_scripts(
+            connector, monkeypatch, self.FULL_ANCHOR_PAYLOAD
+        )
+        walk_anchor = connector._resolve_thread_anchor_applescript("12345")
+
+        assert probe_anchor == walk_anchor
+        assert probe_anchor == {
+            "internal_id": "12345",
+            "account": "Gmail",
+            "rfc_message_id": "a@b",
+            "subject": "S",
+            "in_reply_to": "<parent@x>",
+            "references": ["root@x", "parent@x"],
+        }
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            '{"found": false}',
+            '{"found": true, "account": "", "rfc_message_id": "a@b"}',
+            '{"found": true, "account": "Gmail", "rfc_message_id": ""}',
+        ],
+        ids=["not-found", "no-account", "no-message-id"],
+    )
+    def test_probe_returns_none_without_raising(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch,
+        payload: str,
+    ) -> None:
+        """A miss is not an error — the caller falls back to the full walk,
+        which is what still raises MailMessageNotFoundError for a bad id."""
+        self._capture_scripts(connector, monkeypatch, payload)
+        assert connector._resolve_numeric_anchor_fast("12345") is None
+
+    def test_numeric_id_uses_probe_and_never_walks(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        anchor = {
+            "internal_id": "12345", "account": "Gmail",
+            "rfc_message_id": "a@b", "subject": "S",
+            "in_reply_to": None, "references": [],
+        }
+        monkeypatch.setattr(
+            connector, "_resolve_numeric_anchor_fast", lambda mid: dict(anchor)
+        )
+
+        def _never(mid: str) -> dict[str, Any]:
+            raise AssertionError("the accounts x mailboxes walk must not run")
+
+        monkeypatch.setattr(
+            connector, "_resolve_thread_anchor_applescript", _never
+        )
+        monkeypatch.setattr(connector, "_imap_breaker_open", lambda a: False)
+        monkeypatch.setattr(connector, "_imap_clear_breaker", lambda a: None)
+        anchors: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            connector, "_imap_get_thread",
+            lambda a: anchors.append(a) or [],
+        )
+
+        connector.get_thread("12345")
+        assert anchors == [anchor]
+
+    def test_probe_adds_no_imap_round_trip(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The anchor stays entirely in AppleScript. Routing it through
+        ImapConnector.resolve_anchor instead measured 17s on the 33k Gmail
+        account (SEARCH HEADER over All Mail) — slower than the walk it
+        replaced."""
+        monkeypatch.setattr(
+            connector, "_resolve_numeric_anchor_fast",
+            lambda mid: {
+                "internal_id": mid, "account": "Gmail",
+                "rfc_message_id": "a@b", "subject": "S",
+                "in_reply_to": None, "references": [],
+            },
+        )
+
+        def _never(mid: str) -> dict[str, Any]:
+            raise AssertionError("numeric anchor must not hit IMAP")
+
+        monkeypatch.setattr(connector, "_resolve_anchor_via_imap", _never)
+        monkeypatch.setattr(connector, "_imap_breaker_open", lambda a: False)
+        monkeypatch.setattr(connector, "_imap_clear_breaker", lambda a: None)
+        monkeypatch.setattr(connector, "_imap_get_thread", lambda a: [])
+
+        connector.get_thread("12345")


### PR DESCRIPTION
Closes #419.

## The issue's premise was wrong

#419 attributes the numeric/RFC gap (~17s vs ~7.5s on a 33k-message Gmail account) to **member collection**. It isn't. Both id forms converge on the same `_imap_get_thread` → `find_thread_members` ([mail_connector.py:2812-2821](../blob/fix/issue-419-numeric-anchor-bounded-probe/src/apple_mail_fast_mcp/mail_connector.py#L2812-L2821)) — there is no numeric-vs-RFC branch anywhere downstream of the anchor, so Tier 1 (X-GM-THRID via All Mail) already fired identically for both.

The entire difference is **anchor resolution**, where a numeric id paid a full `accounts x mailboxes` AppleScript walk plus a `headers of msg` read.

## Change

Resolve the numeric anchor against Mail.app's unified `inbox`, then `sent mailbox`. Those aggregate across every account and are locale-independent — the property that made `drafts mailbox` the right target in #407 — so the probe needs no per-account mailbox iteration and no name matching. It mirrors the bound `_anchor_probe_folders` already applies on the IMAP side.

The all-mailbox walk is retained as the not-found backstop. Both emit the same anchor record through a shared AppleScript fragment (`_anchor_record_applescript`) and a shared normalizer (`_anchor_from_applescript_record`), so the two cannot drift — which is what makes choosing between them purely a cost decision safe.

The shared fragment also coerces `missing value` on subject / Message-ID / account, which NSJSONSerialization would otherwise reject outright. That hardens the pre-existing walk too.

## Why not `ImapConnector.resolve_anchor`

That was the approved plan, and measurement killed it. Per-phase medians on the 33k Gmail account:

| anchor phase | time |
|---|---|
| bounded probe (this PR) | **1.33s** |
| old `accounts x mailboxes` walk | 2.98s |
| `ImapConnector.resolve_anchor` | **17.2s** |

End-to-end, that design measured 33.5s vs 21.2s for the old code — a 1.6x **slowdown**. `SEARCH HEADER Message-ID` over a 33k-message All Mail is nowhere near instant. Reading headers off the message the probe already holds costs +0.46s instead, and yields an identical anchor. Hence AppleScript on both sides of this branch.

## Verification

`make check-all` clean — 1587 unit tests, lint, mypy strict, complexity, client-server parity, version-sync, doc-drift.

Against real Mail (`MAIL_TEST_MODE=true MAIL_TEST_ACCOUNT=Gmail`), 5 `get_thread` integration tests pass, including:

- `test_numeric_anchor_fast_probe_resolves_real_message` — the probe places a real id **and returns an anchor equal to the walk's**. This is the invariant the change rests on, and it covers the new AppleScript (`whose id is N` against the unified `inbox`, `account of (mailbox of msg)`, JSON emission) that mocked unit tests structurally cannot catch.
- `test_numeric_anchor_probe_beats_unbounded_walk` — medians of 3, probe faster than the walk.
- `test_get_thread_numeric_and_rfc_anchors_agree` — same member set from both id forms.

The timing guard measures the **anchor phase**, not whole-of-`get_thread`, deliberately: the remainder is shared IMAP member collection, untouched here, which swings by tens of seconds under Gmail throttling and would swamp the signal.

## Scope

Per the issue triage, the numeric→anchor resolver stays private to `get_thread`. Promoting it to a shared helper for `get_message` / attachment callers is #418's job.

## Known-failing integration tests (pre-existing, not from this PR)

Verified failing identically on `main` (8759134) in a clean worktree, and filed:

- #420 — `test_get_thread_does_not_freeze_mail` blows the 10s #415 bound (26.8s on `main`). The cost is IMAP member collection, not the scan the guard names.
- #421 — `test_reply_save_preserves_threading_headers`: `create_draft(seed="reply")` returns an empty `draft_id`.

## Residual

Neither id form reaches single-digit seconds while member collection alone costs ~18s on this account. #419's acceptance ("numeric in roughly the RFC path's time") is now structurally guaranteed for the anchor; the remaining latency is #417/#420 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)