### PR TITLE
fix(#425): don't report a real message as missing when an account probe fails

### DIFF
--- a/src/apple_mail_fast_mcp/exceptions.py
+++ b/src/apple_mail_fast_mcp/exceptions.py
@@ -91,6 +91,31 @@ class MailMessageNotFoundError(MailError):
     pass
 
 
+class MailAnchorLookupIncompleteError(MailError):
+    """A thread anchor could not be located, but at least one account could
+    not actually be checked — so absence was never established. (#425)
+
+    ``get_thread`` resolves an RFC Message-ID by probing each IMAP-configured
+    account in turn. A probe that returns no match is a definitive "this
+    account does not have it"; a probe that *fails* (socket timeout, connect
+    error, rejected credentials) tells us nothing. Reporting the second case
+    as ``MailMessageNotFoundError`` is a false negative on a real message, and
+    sends the user to re-run ``setup-imap`` on an account that is configured
+    correctly.
+
+    Deliberately NOT a subclass of MailMessageNotFoundError: callers should be
+    able to tell "retry this" from "give up". Deliberately not in
+    ``_IMAP_FALLBACK_EXCS`` either — falling back to the unindexed AppleScript
+    scan is exactly what #415 forbids.
+
+    A missing Keychain entry does not count: that is the expected, stable
+    "user has not opted in to IMAP for this account" state, not a transient
+    failure.
+    """
+
+    pass
+
+
 class MailAppleScriptError(MailError):
     """AppleScript execution failed."""
 

--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -31,6 +31,7 @@ from .draft_builder import (
 from .drafts import _validate_draft_id
 from .exceptions import (
     MailAccountNotFoundError,
+    MailAnchorLookupIncompleteError,
     MailAppleScriptError,
     MailAttachmentIndexError,
     MailAttachmentTooLargeError,
@@ -2872,8 +2873,19 @@ class AppleMailConnector:
         INDEXED ``SEARCH HEADER Message-ID`` over a bounded folder set — never
         the unindexed all-mailbox AppleScript scan that freezes Mail. Returns
         the anchor dict with ``account`` filled in for the first account whose
-        server contains the Message-ID, or ``None`` if none resolve it.
+        server contains the Message-ID, or ``None`` if every account gave a
+        definitive "not here".
+
+        Raises:
+            MailAnchorLookupIncompleteError: No account resolved the anchor AND
+                at least one probe *failed* rather than answering — so absence
+                was never established. Returning None here would surface as
+                "no such message" for a message that exists (#425).
         """
+        # Accounts whose probe failed: we could not rule them out. Kept
+        # separate from a clean empty SEARCH result, which genuinely does
+        # rule an account out. (#425)
+        indeterminate: list[str] = []
         for acct in self.list_accounts():
             account = cast(str, acct.get("name") or "")
             if not account or self._imap_breaker_open(account):
@@ -2889,15 +2901,31 @@ class AppleMailConnector:
                     host, port, email, password, pool=self._imap_pool
                 )
                 anchor = imap.resolve_anchor(message_id)
-            except _IMAP_FALLBACK_EXCS as exc:
-                # No creds / breaker / connect failure for this account — try
-                # the next one. (MailKeychainEntryNotFoundError is included.)
+            except MailKeychainEntryNotFoundError as exc:
+                # Benign opt-out: the user has not configured IMAP for this
+                # account. Stable, not transient — not indeterminate.
                 self._log_imap_fallback(account, exc)
+                continue
+            except _IMAP_FALLBACK_EXCS as exc:
+                # Timeout / connect failure / rejected credentials. This
+                # account was NOT checked; remember that before moving on.
+                self._log_imap_fallback(account, exc)
+                indeterminate.append(account)
                 continue
             if anchor is not None:
                 self._imap_clear_breaker(account)
                 anchor["account"] = account
                 return anchor
+        if indeterminate:
+            raise MailAnchorLookupIncompleteError(
+                f"Could not determine whether Message-ID {message_id!r} "
+                f"exists: the IMAP probe failed for "
+                f"{', '.join(sorted(indeterminate))} "
+                f"({len(indeterminate)} of the configured accounts), so those "
+                "accounts were never checked. This is usually a transient "
+                "network timeout — retry the request. The message may well "
+                "exist."
+            )
         return None
 
     def _resolve_numeric_anchor(self, message_id: str) -> dict[str, Any]:

--- a/src/apple_mail_fast_mcp/server.py
+++ b/src/apple_mail_fast_mcp/server.py
@@ -18,6 +18,7 @@ from pydantic import BeforeValidator
 from .drafts import DraftStateStore, SeedRecord
 from .exceptions import (
     MailAccountNotFoundError,
+    MailAnchorLookupIncompleteError,
     MailAppleScriptError,
     MailAttachmentIndexError,
     MailAttachmentTooLargeError,
@@ -1556,6 +1557,16 @@ def get_thread(message_id: str) -> dict[str, Any]:
             "count": len(thread),
         }
 
+    except MailAnchorLookupIncompleteError as e:
+        # #425: distinct from message_not_found on purpose — the message may
+        # exist; we just could not check every account. Retryable.
+        logger.error(f"Thread anchor lookup incomplete: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "anchor_lookup_incomplete",
+            "retryable": True,
+        }
     except MailMessageNotFoundError as e:
         logger.error(f"Message not found: {e}")
         return {

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -2567,6 +2567,88 @@ class TestTemplateIntegration:
         assert today in rendered["body"]
 
 
+class TestAnchorLookupIncompleteIntegration:
+    """#425: a failed probe must never be reported as a missing message.
+
+    Unit tests mock the whole IMAP layer, so they can prove the branch is
+    wired but not that it holds against the real multi-account resolution
+    path. These drive the real connector with a real Message-ID and only
+    simulate the failure the network actually produces (socket timeout →
+    OSError, which is a member of ``_IMAP_FALLBACK_EXCS``).
+    """
+
+    def _real_rfc_id(
+        self, connector: AppleMailConnector, test_account: str
+    ) -> str:
+        rows = connector.search_messages(
+            account=test_account, mailbox="INBOX", limit=1
+        )
+        if not rows:
+            pytest.skip(f"{test_account} INBOX has no messages to test against")
+        rfc_id = rows[0].get("rfc_message_id") or rows[0].get("id")
+        if not rfc_id or "@" not in rfc_id:
+            pytest.skip(
+                "test_account is not on the IMAP path (no RFC Message-ID)"
+            )
+        return str(rfc_id)
+
+    def test_real_message_never_reported_missing_when_probes_fail(
+        self,
+        connector: AppleMailConnector,
+        test_account: str,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        """The exact #425 failure: the message EXISTS, every probe times out.
+
+        Before the fix this raised MailMessageNotFoundError and told the user
+        to run `setup-imap` on a correctly-configured account.
+        """
+        from apple_mail_fast_mcp.exceptions import (
+            MailAnchorLookupIncompleteError,
+            MailMessageNotFoundError,
+        )
+        from apple_mail_fast_mcp.imap_connector import ImapConnector
+
+        rfc_id = self._real_rfc_id(connector, test_account)
+
+        def _timeout(self: ImapConnector, message_id: str) -> None:
+            raise OSError("cannot read from timed out object")
+
+        monkeypatch.setattr(ImapConnector, "resolve_anchor", _timeout)
+
+        with pytest.raises(MailAnchorLookupIncompleteError) as exc:
+            connector.get_thread(rfc_id)
+        # Regression assertion: the old behavior is specifically excluded.
+        assert not isinstance(exc.value, MailMessageNotFoundError)
+        assert "setup-imap" not in str(exc.value)
+
+    def test_one_failing_account_does_not_break_a_resolvable_anchor(
+        self,
+        connector: AppleMailConnector,
+        test_account: str,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        """Availability is preserved: a probe failure on an account we did not
+        need must not prevent the anchor resolving where it really lives."""
+        from apple_mail_fast_mcp.imap_connector import ImapConnector
+
+        rfc_id = self._real_rfc_id(connector, test_account)
+        host, _port, _email = connector._resolve_imap_config(test_account)
+        original = ImapConnector.resolve_anchor
+
+        def _fail_other_hosts(
+            self: ImapConnector, message_id: str
+        ) -> dict[str, Any] | None:
+            if getattr(self, "_host", None) != host:
+                raise OSError("simulated timeout on an unrelated account")
+            return original(self, message_id)
+
+        monkeypatch.setattr(ImapConnector, "resolve_anchor", _fail_other_hosts)
+
+        thread = connector.get_thread(rfc_id)
+        assert isinstance(thread, list) and len(thread) >= 1
+
+
 class TestFindMessageByMessageIdIntegration:
     """Real-Mail.app round-trip for ``find_message_by_message_id``.
 

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -13,6 +13,7 @@ from imapclient.exceptions import LoginError
 
 from apple_mail_fast_mcp.exceptions import (
     MailAccountNotFoundError,
+    MailAnchorLookupIncompleteError,
     MailAppleScriptError,
     MailDraftInvalidIdError,
     MailDraftNotFoundError,
@@ -8979,6 +8980,142 @@ class TestResolveAnchorViaImap:
         assert connector._resolve_anchor_via_imap("nope@x") is None
 
 
+class TestResolveAnchorIndeterminate:
+    """#425: a probe that FAILS is not the same as a probe that says "absent".
+
+    `_IMAP_FALLBACK_EXCS` includes OSError, so a socket timeout on the account
+    that actually holds the Message-ID used to be swallowed by `continue`,
+    exhaust the remaining accounts, return None, and surface to the user as
+    `MailMessageNotFoundError` — a false negative on a real message, with
+    remediation advice (`setup-imap`) that cannot help.
+    """
+
+    @pytest.fixture
+    def connector(self) -> AppleMailConnector:
+        return AppleMailConnector(timeout=30)
+
+    @staticmethod
+    def _imap_by_account(behavior):
+        """Factory keyed on the host, which the tests build from the account
+        name. `behavior` returns an anchor dict, None, or raises."""
+        def _factory(host, port, email, password, pool=None):
+            m = MagicMock()
+            m.resolve_anchor.side_effect = lambda mid: behavior(host)
+            return m
+        return _factory
+
+    def _wire(self, connector, monkeypatch, accounts, behavior, pwd=None):
+        monkeypatch.setattr(
+            connector, "list_accounts", lambda: [{"name": a} for a in accounts]
+        )
+        monkeypatch.setattr(connector, "_imap_breaker_open", lambda a: False)
+        monkeypatch.setattr(connector, "_imap_clear_breaker", lambda a: None)
+        monkeypatch.setattr(connector, "_log_imap_fallback", lambda a, e: None)
+        monkeypatch.setattr(
+            connector, "_resolve_imap_config",
+            lambda a: (f"imap.{a}", 993, f"{a}@x"),
+        )
+        monkeypatch.setattr(
+            connector, "_get_imap_password_with_fallback",
+            pwd or (lambda a, e: "pw"),
+        )
+        monkeypatch.setattr(
+            "apple_mail_fast_mcp.mail_connector.ImapConnector",
+            self._imap_by_account(behavior),
+        )
+
+    def test_timeout_with_no_match_raises_incomplete_not_not_found(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The #425 bug: one account times out, another is a definitive miss.
+        We do NOT know the message is absent, so we must not say so."""
+        def _behavior(host: str):
+            if "Gmail" in host:
+                raise OSError("cannot read from timed out object")
+            return None
+
+        self._wire(connector, monkeypatch, ["iCloud", "Gmail"], _behavior)
+        with pytest.raises(MailAnchorLookupIncompleteError):
+            connector._resolve_anchor_via_imap("real@x")
+
+    def test_incomplete_error_names_the_unchecked_account(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The message must point at the real problem, not at `setup-imap`."""
+        def _behavior(host: str):
+            if "Gmail" in host:
+                raise OSError("cannot read from timed out object")
+            return None
+
+        self._wire(connector, monkeypatch, ["iCloud", "Gmail"], _behavior)
+        with pytest.raises(MailAnchorLookupIncompleteError) as exc:
+            connector._resolve_anchor_via_imap("real@x")
+        assert "Gmail" in str(exc.value)
+        assert "setup-imap" not in str(exc.value)
+
+    def test_hit_after_a_failed_probe_still_resolves(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failure on an account we did not need must not break a lookup
+        that succeeds elsewhere — availability is preserved."""
+        def _behavior(host: str):
+            if "iCloud" in host:
+                raise OSError("timed out")
+            return {"rfc_message_id": "abc@x", "references": [],
+                    "subject": "Hi", "in_reply_to": None}
+
+        self._wire(connector, monkeypatch, ["iCloud", "Gmail"], _behavior)
+        anchor = connector._resolve_anchor_via_imap("abc@x")
+        assert anchor is not None
+        assert anchor["account"] == "Gmail"
+
+    def test_all_definitive_misses_still_return_none(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every account answered "absent" — that IS a real not-found, and the
+        existing MailMessageNotFoundError behavior must be preserved."""
+        self._wire(connector, monkeypatch, ["iCloud", "Gmail"], lambda h: None)
+        assert connector._resolve_anchor_via_imap("nope@x") is None
+
+    def test_keychain_optout_is_definitive_not_indeterminate(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No Keychain entry is the expected, stable "user has not opted in to
+        IMAP" state — not a transient failure. Treating it as indeterminate
+        would fire this error for everyone with one non-IMAP account."""
+        def _pwd(a: str, e: str) -> str:
+            if a == "NoCreds":
+                raise MailKeychainEntryNotFoundError("no opt-in")
+            return "pw"
+
+        self._wire(
+            connector, monkeypatch, ["NoCreds", "Gmail"],
+            lambda h: None, pwd=_pwd,
+        )
+        assert connector._resolve_anchor_via_imap("nope@x") is None
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            OSError("timed out"),
+            LoginError("credentials rejected"),
+            MailKeychainAccessDeniedError("ACL denied"),
+        ],
+    )
+    def test_transient_and_auth_failures_are_indeterminate(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch,
+        exc: Exception,
+    ) -> None:
+        """Anything that isn't a clean "absent" answer or a benign opt-out
+        leaves us unable to rule the account out."""
+        def _behavior(host: str):
+            raise exc
+
+        self._wire(connector, monkeypatch, ["Gmail"], _behavior)
+        with pytest.raises(MailAnchorLookupIncompleteError):
+            connector._resolve_anchor_via_imap("real@x")
+
+
 class TestGetThreadNeverScansForRfcId:
     """#415: an RFC Message-ID anchor resolves via IMAP; get_thread must NEVER
     run the unindexed AppleScript scan for it."""
@@ -9024,6 +9161,30 @@ class TestGetThreadNeverScansForRfcId:
         with pytest.raises(MailMessageNotFoundError):
             connector.get_thread("missing@x")
         assert scripts == []  # raised instead of scanning
+
+    def test_incomplete_lookup_propagates_not_masked_as_not_found(
+        self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#425: get_thread must not collapse "we couldn't check" into "no such
+        message". MailAnchorLookupIncompleteError is not a subclass of
+        MailMessageNotFoundError, so callers can distinguish retry from give-up.
+        """
+        scripts: list[str] = []
+        monkeypatch.setattr(
+            connector, "_run_applescript",
+            lambda s: scripts.append(s) or "",
+        )
+
+        def _raise(mid: str) -> None:
+            raise MailAnchorLookupIncompleteError("Gmail could not be checked")
+
+        monkeypatch.setattr(connector, "_resolve_anchor_via_imap", _raise)
+        with pytest.raises(MailAnchorLookupIncompleteError):
+            connector.get_thread("real@x")
+        assert not issubclass(
+            MailAnchorLookupIncompleteError, MailMessageNotFoundError
+        )
+        assert scripts == []  # still no unindexed scan (#415 invariant holds)
 
     def test_numeric_id_falls_back_to_applescript_anchor_when_probe_misses(
         self, connector: AppleMailConnector, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1975,6 +1975,29 @@ class TestGetThread:
         assert result["error_type"] == "unknown"
         assert "boom" in result["error"]
 
+    def test_incomplete_lookup_is_its_own_retryable_error_type(
+        self, mock_mail: MagicMock, mock_logger: MagicMock
+    ) -> None:
+        """#425: an unchecked account must not read as "no such message".
+        MCP callers need to tell retry-worthy from definitive."""
+        from apple_mail_fast_mcp.exceptions import (
+            MailAnchorLookupIncompleteError,
+        )
+
+        mock_mail.get_thread.side_effect = MailAnchorLookupIncompleteError(
+            "the IMAP probe failed for Gmail"
+        )
+
+        result = get_thread("real@x")
+
+        assert result["success"] is False
+        assert result["error_type"] == "anchor_lookup_incomplete"
+        assert result["retryable"] is True
+        assert "Gmail" in result["error"]
+        # The misleading remediation must not survive into the tool response.
+        assert "setup-imap" not in result["error"]
+        mock_logger.log_operation.assert_not_called()
+
 
 class TestGetStatistics:
     """#378: consolidated inbox-stats aggregation over search_messages."""


### PR DESCRIPTION
Fixes #425. Found while measuring #420.

## The bug

`_resolve_anchor_via_imap` cannot tell these apart:

| outcome | meaning | old handling |
|---|---|---|
| `resolve_anchor()` returns `None` | server answered: this account **does not have** it | `continue` |
| `resolve_anchor()` raises | timeout / connect failure / auth — **we do not know** | `continue` |

`OSError` is in `_IMAP_FALLBACK_EXCS`, so a socket timeout on the account that actually holds the message was swallowed, the loop exhausted the remaining accounts, returned `None`, and `get_thread` raised `MailMessageNotFoundError` — telling the user to run `setup-imap` on a correctly-configured account.

Reproduced on `main` with a Message-ID that `search_messages` had returned seconds earlier, and which resolved fine in 1.35s on the next run.

## The fix

Track accounts whose probe failed. If nothing resolves **and** at least one was indeterminate, raise the new `MailAnchorLookupIncompleteError` naming them. Only an all-accounts-definitive miss keeps `MailMessageNotFoundError`.

Deliberate choices:
- **Keychain-entry-not-found is not indeterminate** — it's the expected, stable "hasn't opted in to IMAP" state. Treating it as failure would fire this for anyone with one non-IMAP account.
- **Not a subclass of `MailMessageNotFoundError`** — callers must distinguish retry from give-up.
- **Not added to `_IMAP_FALLBACK_EXCS`** — falling back to the unindexed AppleScript scan is what #415 forbids.

Surfaces as `error_type: "anchor_lookup_incomplete"` with `retryable: true`.

## Testing

10 new tests — 8 unit, 2 integration against real Mail.app.

Verified they're not vacuous: temporarily reverting the new branch makes 5 unit tests fail with `DID NOT RAISE`, while the three preserve-existing-behavior tests (all-definitive-miss still returns `None`, hit-after-failure still resolves, keychain opt-out unchanged) correctly stay green.

```
1597 passed (was 1587)
make check-all: All checks passed
integration -k AnchorLookupIncomplete: 2 passed
```

## Scope

Correctness only. The probe latency and the misattributed freeze guard are #420, fixed separately — see the [measured diagnosis](https://github.com/s-morgan-jeffries/apple-mail-fast-mcp/issues/420#issuecomment-5158294014) posted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)