### PR TITLE
fix(#421): wait for the saved draft before diffing for its id

### DIFF
--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -98,6 +98,17 @@ _IMAP_FALLBACK_EXCS: tuple[type[Exception], ...] = (
 )
 
 
+_DRAFT_POLL_INTERVAL_S: float = 0.5
+"""Seconds between drafts-mailbox rescans while waiting for a just-saved
+draft to surface (#421). Same cadence as the old fixed `delay 0.5` — the bug
+was scanning once, not scanning too coarsely."""
+
+_DRAFT_POLL_MAX_S: float = 30.0
+"""Ceiling on the #421 poll. Measured visibility lag on a real Gmail account
+was 12.6-19.6s, so 30s covers the cold case with headroom. Capped rather than
+open-ended so a long connector timeout can't leave osascript spinning."""
+
+
 def _degraded_reason_for(exc: Exception) -> str:
     """Map a fallback-triggering exception to a stable, machine-readable
     reason string for the ``partial_reason`` field of get_thread (#420).
@@ -6084,20 +6095,30 @@ class AppleMailConnector:
                 return "SENT"
             """
         else:
-            terminal_block = """
+            # #421: poll rather than scan once behind a fixed delay. A saved
+            # draft takes 12.6-19.6s to surface in Mail's unified `drafts
+            # mailbox` (measured, real Gmail); the old `delay 0.5` scanned
+            # before it existed and returned "" — silently, since newDraftId
+            # starts empty inside a bare `try`. #413 exposed this: replacing
+            # the nested accounts x mailboxes scan with one fast pass removed
+            # the accidental slack that had been covering the sync lag.
+            terminal_block = f"""
                 save theMessage
-                delay 0.5
 
                 set newDraftId to ""
-                try
-                    repeat with d in messages of drafts mailbox
-                        set candId to (id of d as text)
-                        if candId is not in beforeIds then
-                            set newDraftId to candId
-                            exit repeat
-                        end if
-                    end repeat
-                end try
+                repeat {self._draft_poll_iterations()} times
+                    try
+                        repeat with d in messages of drafts mailbox
+                            set candId to (id of d as text)
+                            if candId is not in beforeIds then
+                                set newDraftId to candId
+                                exit repeat
+                            end if
+                        end repeat
+                    end try
+                    if newDraftId is not "" then exit repeat
+                    delay {_DRAFT_POLL_INTERVAL_S}
+                end repeat
                 return newDraftId
             """
 
@@ -6193,6 +6214,22 @@ class AppleMailConnector:
             f"unreachable, or a non-RFC reply seed). {tail} Configure or "
             "repair IMAP for the account with `apple-mail-fast-mcp setup-imap`."
         )
+
+    def _draft_poll_iterations(self) -> int:
+        """How many times the AppleScript id-diff rescans the unified drafts
+        mailbox while waiting for a just-saved draft to appear (#421).
+
+        Budgeted from ``self.timeout`` rather than hardcoded: the generated
+        script is wrapped by ``_wrap_with_timeout(..., timeout=self.timeout)``,
+        so a fixed 30s poll would blow a caller-supplied
+        ``AppleMailConnector(timeout=20)``. Half the budget goes to the poll,
+        leaving the rest for the save itself (~5s measured) — and never more
+        than ``_DRAFT_POLL_MAX_S``. Always at least one scan, so a very short
+        timeout degrades to the pre-#421 single-shot behavior rather than
+        skipping the lookup entirely.
+        """
+        budget = min(_DRAFT_POLL_MAX_S, self.timeout * 0.5)
+        return max(1, int(budget / _DRAFT_POLL_INTERVAL_S))
 
     def _effective_from_account(
         self, from_account: str | None, send_now: bool

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -1074,11 +1074,64 @@ class TestDraftsLifecycleIntegration:
             self._wait_for_draft(connector, draft_id)
             assert connector.delete_draft(draft_id) is True
 
+    def test_applescript_save_returns_a_usable_draft_id(
+        self,
+        connector: AppleMailConnector,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        """#421 regression, seed="new" variant.
+
+        The empty-draft_id bug lives in the shared terminal block, so it hit
+        every AppleScript save-as-draft — not just replies. The reply test
+        below covers the reported case; this covers compose, which had none.
+
+        The clean IMAP path is forced off rather than relying on this machine
+        having several enabled accounts (which is what made `effective_account`
+        None here and pushed the reported failure onto AppleScript). Without
+        that, a single-account machine would take the IMAP-APPEND path and
+        silently not exercise the fix at all.
+        """
+        monkeypatch.setattr(
+            AppleMailConnector, "_try_clean_create_or_send",
+            lambda self, **kwargs: None,
+        )
+        marker = "ZZZ-AMM-421-APPLESCRIPT-NEW"
+        result = connector.create_draft(
+            seed="new",
+            to=["test1@example.com"],
+            subject=marker,
+            body="body for the #421 id-bridging poll",
+        )
+        draft_id = result["draft_id"]
+        assert draft_id, (
+            "AppleScript save returned an empty draft_id — the id-bridging "
+            "diff ran before Mail materialised the draft (#421)"
+        )
+        assert "@" not in draft_id, (
+            f"expected Mail's internal numeric id from the AppleScript path; "
+            f"got {draft_id!r}"
+        )
+        try:
+            # The id must be immediately usable — that is the whole point of
+            # waiting for it inside the script.
+            state = connector.get_draft_state(draft_id)
+            assert state["subject"] == marker
+        finally:
+            assert connector.delete_draft(draft_id) is True
+
     def test_reply_save_preserves_threading_headers(
         self,
         connector: AppleMailConnector,
         anchor_message_id: str,
     ) -> None:
+        """#421 regression, the reported case.
+
+        `anchor_message_id` is Mail's numeric internal id, and
+        `_try_imap_reply_forward_draft` requires an RFC Message-ID (`"@" in
+        seed_id`) — so this always exercises the AppleScript save path, on any
+        machine. Before the fix `draft_id` came back `''` every time and the
+        threading assertions below never ran.
+        """
         result = connector.create_draft(
             seed="reply",
             seed_id=anchor_message_id,

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -6108,6 +6108,76 @@ class TestCreateDraft:
         # No diff snapshot when sending.
         assert "set beforeIds to" not in script
 
+    # --- #421: the id-bridging diff must wait for the draft to appear ----
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_id_diff_polls_instead_of_a_single_fixed_delay(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """#421: a saved draft takes 12.6-19.6s to surface in Mail's unified
+        `drafts mailbox` (measured on real Gmail). The old fixed `delay 0.5`
+        scanned once, found nothing, and returned "" — silently, because
+        newDraftId is initialised empty inside a bare `try`.
+
+        #413 caused this: it replaced the nested accounts x mailboxes scan
+        with a single fast pass, and that scan's slowness had been the only
+        thing giving Mail time to materialise the draft.
+        """
+        mock_run.return_value = "1"
+        connector.create_draft(seed="new", to=["a@example.com"],
+                               subject="hi", body="x")
+        script = mock_run.call_args[0][0]
+
+        assert "save theMessage" in script
+        # A bounded retry around the drafts scan, not one scan behind a delay.
+        assert "repeat" in script and "times" in script
+        assert 'if newDraftId is not "" then exit repeat' in script
+        # The scan itself is unchanged (#407 unified, locale-independent).
+        assert "messages of drafts mailbox" in script
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_poll_budget_scales_with_connector_timeout(
+        self, mock_run: MagicMock
+    ) -> None:
+        """The script is wrapped by _wrap_with_timeout(timeout=self.timeout),
+        so a hardcoded poll would blow a caller-supplied shorter timeout.
+        A 20s connector must poll for less wall-clock than a 60s one."""
+        mock_run.return_value = "1"
+        counts = {}
+        for timeout in (20, 60):
+            c = AppleMailConnector(timeout=timeout)
+            with patch.object(c, "_run_applescript", return_value="1") as m:
+                c.create_draft(seed="new", to=["a@example.com"],
+                               subject="hi", body="x")
+            counts[timeout] = c._draft_poll_iterations()
+            assert f"repeat {counts[timeout]} times" in m.call_args[0][0]
+
+        assert counts[20] < counts[60], (
+            "poll budget must shrink with the connector timeout"
+        )
+
+    @pytest.mark.parametrize("timeout", [2, 10, 20, 60, 300])
+    def test_poll_never_exceeds_its_own_timeout(self, timeout: int) -> None:
+        """The poll must leave room for the rest of the script (~5s measured)
+        rather than consuming the whole osascript budget."""
+        c = AppleMailConnector(timeout=timeout)
+        iterations = c._draft_poll_iterations()
+        assert iterations >= 1, "must always scan at least once"
+        assert iterations * 0.5 <= timeout * 0.5 + 0.01, (
+            f"poll of {iterations * 0.5}s exceeds half of a {timeout}s budget"
+        )
+
+    @patch.object(AppleMailConnector, "_run_applescript")
+    def test_send_path_has_no_poll(
+        self, mock_run: MagicMock, connector: AppleMailConnector
+    ) -> None:
+        """send_now returns "SENT" and never diffs drafts — no poll to add."""
+        mock_run.return_value = "SENT"
+        connector.create_draft(seed="new", to=["a@example.com"],
+                               subject="hi", body="x", send_now=True)
+        script = mock_run.call_args[0][0]
+        assert "newDraftId" not in script
+
     @patch.object(AppleMailConnector, "_run_applescript")
     def test_new_with_from_account_sets_display_name_sender(
         self, mock_run: MagicMock, connector: AppleMailConnector


### PR DESCRIPTION
Fixes #421.

## Diagnosis

The draft **is** created — the lookup runs too early.

`create_draft`'s AppleScript save path snapshots the ids in Mail's unified `drafts mailbox`, saves, waits, then returns the first id that wasn't there before. `newDraftId` is initialised to `""` and the whole scan sits inside a bare `try`, so when the draft hasn't materialised yet the script silently returns the empty string.

The wait was a fixed `delay 0.5`. Measured against the real Gmail test account:

| run | `create_draft` returned | `draft_id` | draft actually visible |
|---|---|---|---|
| cold | 10.9s | `''` | **19.6s** |
| 1 | 4.8s | `''` | 13.1s |
| 2 | 4.4s | `''` | 12.6s |
| 3 | 4.3s | `''` | 13.8s |

The draft appears ~8–10s *after the script has already returned*. `delay 0.5` is ~40× too short. Reproduces 100% of the time.

## Why it regressed

#413 replaced the nested `accounts × mailboxes` scan (gated on `name of mb contains "Drafts"`) with a single fast pass over the unified drafts mailbox. That was right for locale-independence and for dodging Gmail's All Mail mirror — but the old scan's **slowness was the only thing giving Mail time to materialise the draft**. `delay 0.5` predates #413 and was never re-calibrated.

The mechanism was already diagnosed for the *other* draft path. `_wait_for_draft`'s docstring says it outright:

> "The pre-#407 broad-mailbox scan incidentally masked this by being slow; the #407 drafts-scoped lookup is fast, so tests that look up a just-created draft must wait for the sync explicitly."

That compensation could only live in the tests. On the AppleScript path the id is produced *inside* the script, so the wait has to live there too.

## The fix

Bounded poll instead of a single scan behind a fixed delay. The budget derives from `self.timeout` rather than a constant — the script is wrapped by `_wrap_with_timeout(timeout=self.timeout)`, so a hardcoded 30s poll would blow a caller-supplied `AppleMailConnector(timeout=20)`. Half the budget goes to the poll, capped at 30s, always at least one scan (so a very short timeout degrades to the old single-shot behavior rather than skipping the lookup).

## Scope is wider than the issue title

The terminal block is shared by every `not send_now` call, so **`seed="new"` and `seed="forward"` had the same defect** whenever they fell through to AppleScript. #421 only noticed it via the reply test. Added integration coverage for compose, which had none.

## Cost

The AppleScript save path goes from ~4.5s returning junk to ~14–20s returning a usable id. A real latency regression, traded for correctness, affecting only calls that were already broken.

## Testing

```
1618 unit passed (was 1610)
make check-all: All checks passed
create_draft held at CC 19 (ceiling 20) — the helper stays out of it
integration -k "applescript_save_returns or reply_save_preserves": 2 passed
```

Verified non-vacuous: reverting `_draft_poll_iterations` to `return 1` (the pre-fix single scan) makes both integration tests fail with `assert ''` — the exact reported symptom.

The new integration test forces the clean IMAP path off rather than relying on this machine happening to have several enabled accounts (which is what pushed the reported failure onto AppleScript here). Without that, a single-account machine would take the IMAP-APPEND path and never exercise the fix.

## Note on the integration suite

The broader `-k "draft"` run surfaced two **pre-existing** failures on `main` — `test_flag_two_ids_resolves_via_single_or_search` and `test_create_draft_reply_round_trip_with_bare_rfc_id` — both timing out in `find_message_by_message_id`'s unindexed all-mailbox scan, which froze Mail.app outright. Confirmed unrelated to this change by reproducing on `main`. Filed as #432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)