### PR TITLE
fix(#436): guard the AppleScript date-literal trap, and stop duplicating the fix

### DIFF
--- a/.claude/skills/applescript-mail/SKILL.md
+++ b/.claude/skills/applescript-mail/SKILL.md
@@ -75,6 +75,40 @@ def escape_applescript_string(s: str) -> str:
 
 **Rule:** Every string interpolated into AppleScript MUST go through `escape_applescript_string()`. No exceptions. Check via `check_applescript_safety.sh`.
 
+## Dates: never use a `date "..."` literal
+
+AppleScript parses date-string literals against the **user's locale**, and gets it wrong *silently*:
+
+```applescript
+date "2026-05-28"           --> year 12196
+date "2026-08-09 11:03:51"  --> Wednesday, October 8, 12177
+```
+
+Neither raises. Nothing warns. A filter built on one of these just quietly matches nothing — and because the surrounding code behaves correctly, the bug is invisible above the AppleScript boundary.
+
+**Bug story (#436):** a date literal bounded a message-search window. The window was ~10,000 years off, so it matched nothing, and the failure surfaced as a clean, plausible `MailAnchorLookupIncompleteError` for a message sitting at **index 1 of the INBOX**. Cost a full integration cycle. The trap had already been documented — in a helper docstring inside a 6,000-line module, which is not where anyone writing new AppleScript looks. Hence this section.
+
+**Always build dates from components** via `_construct_as_date_var()` in `mail_connector.py`:
+
+```python
+_construct_as_date_var("targetDate", 2026, 8, 9, 39831)  # 39831 = 11:03:51
+```
+
+which emits:
+
+```applescript
+set targetDate to current date
+set day of targetDate to 1        -- FIRST: see below
+set year of targetDate to 2026
+set month of targetDate to 8
+set day of targetDate to 9
+set time of targetDate to 39831   -- seconds since midnight
+```
+
+**Why `set day to 1` comes first:** if `current date` is the 31st and you set month to a 30-day month, AppleScript rolls into the next month. Resetting the day first makes the sequence safe for every date.
+
+**Rule:** every date in generated AppleScript goes through `_construct_as_date_var()`. `check_applescript_safety.sh` (Check 6) fails the build on a `date "..."` literal in `src/`. If you are *documenting* the trap rather than committing it, wrap the example in backticks — that is how the check distinguishes prose from code.
+
 ## Attachment Handling
 
 Attachments use POSIX file references:
@@ -120,7 +154,11 @@ messages whose sender contains "user" and subject contains "report"
 ## Known Mail.app Automation Limitations
 
 1. **No scheduled sending** — Mail.app has no AppleScript support for delayed/scheduled sends
-2. **Thread reconstruction is possible but not native** — Mail.app has no `thread` or `conversation` class. Reconstruct threads by reading `headers of msg` for `in-reply-to`, `references`, and matching against `message id of msg` (the RFC 822 header value) across candidate messages. **`whose message id is "X"` is NOT indexed** (~21s per lookup on a real mailbox); always subject-prefilter first. See `get_thread` in `mail_connector.py`.
+2. **Thread reconstruction is possible but not native** — Mail.app has no `thread` or `conversation` class. Reconstruct threads by reading `headers of msg` for `in-reply-to`, `references`, and matching against `message id of msg` (the RFC 822 header value) across candidate messages. See `get_thread` in `mail_connector.py`.
+
+   **`whose message id is "X"` is NOT indexed**, and AppleScript runs on Mail's UI thread — so it loads every message in the mailbox and *freezes the app*, not merely slowly (measured: 33,569 messages in one INBOX, 62,085 in Gmail's All Mail). The `_run_applescript` timeout does not rescue Mail; it kills our `osascript` client while Mail keeps grinding.
+
+   Resolve an RFC Message-ID by **IMAP first** — `SEARCH HEADER Message-ID` is server-indexed (measured 0.14s over 61,880 messages) and returns the arrival date — then binary-search the mailbox by that date. Messages enumerate strictly newest-first with cheap positional access, so that is ~log₂(n) property reads. See `find_message_by_message_id` (#432/#434). Mail's numeric `id` *is* indexed, so `whose id is N` stays instant and needs none of this.
 3. **Rule management is partial** — Rules are *readable* (`rules` collection, `name`, `enabled`, conditions/actions), but have no stable `id` and must be addressed positionally or by non-unique name. Mutation paths (creating, updating, deleting) are more complex and not yet implemented.
 4. **No smart mailbox access** — Smart mailboxes are not exposed to AppleScript
 5. **Rich text body** — `content of message` returns plain text; HTML body requires alternate approach
@@ -154,8 +192,9 @@ if result.startswith("ERROR:"):
 
 1. [ ] All user strings escaped with `escape_applescript_string()`
 2. [ ] All inputs sanitized with `sanitize_input()`
-3. [ ] Error handling with `try/on error` in AppleScript
-4. [ ] Timeout considered (complex operations may need > 60s)
-5. [ ] Integration test written against real Mail.app
-6. [ ] `check_applescript_safety.sh` passes
-7. [ ] Gmail compatibility considered (does this operation work with labels?)
+3. [ ] Any dates built via `_construct_as_date_var()`, never a `date "..."` literal
+4. [ ] Error handling with `try/on error` in AppleScript
+5. [ ] Timeout considered (complex operations may need > 60s)
+6. [ ] Integration test written against real Mail.app
+7. [ ] `check_applescript_safety.sh` passes
+8. [ ] Gmail compatibility considered (does this operation work with labels?)

--- a/scripts/check_applescript_safety.sh
+++ b/scripts/check_applescript_safety.sh
@@ -63,6 +63,38 @@ if [ -n "$HARDCODED" ]; then
     echo "$HARDCODED" | sed 's/^/    /'
 fi
 
+# Check 6: AppleScript `date "..."` string literals (#242 / #436)
+#
+# AppleScript parses date-string literals against the USER'S LOCALE and fails
+# silently: `date "2026-05-28"` evaluates to year 12196, and
+# `date "2026-08-09 11:03:51"` to October 8, 12177. Neither raises, so a filter
+# built on one just quietly matches nothing — #436 cost an integration cycle
+# to a bad window that reported a clean "not found" for a message at index 1.
+#
+# The only supported way to build a date is _construct_as_date_var().
+#
+# Prose vs code: every legitimate mention of the trap is inside backticks,
+# because it is documentation. So flag `date "` NOT preceded by a backtick.
+# Scans all of src/ (not just $CONNECTOR) so a literal landing in a future
+# module is caught too.
+echo ""
+echo "Check 6: AppleScript date string literals..."
+# --include='*.py' matters: without it this matches compiled bytecode in
+# __pycache__/*.pyc, which reports as a binary-file hit and is never actionable.
+DATE_LITERALS=$(grep -rnE --include='*.py' '[^`]date "' src/ 2>/dev/null || true)
+if [ -n "$DATE_LITERALS" ]; then
+    echo "  ERROR: AppleScript date string literal(s) found:"
+    echo "$DATE_LITERALS" | sed 's/^/    /'
+    echo ""
+    echo "  AppleScript parses these against the user's locale and fails"
+    echo "  SILENTLY (date \"2026-08-09\" -> year 12177). Build dates with"
+    echo "  _construct_as_date_var() instead."
+    echo "  If you are DOCUMENTING the trap, wrap it in backticks."
+    ERRORS=$((ERRORS + 1))
+else
+    echo "  OK: no unquoted date literals (dates go via _construct_as_date_var)."
+fi
+
 echo ""
 if [ $ERRORS -gt 0 ]; then
     echo "FAILED: $ERRORS safety issue(s) found."

--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -171,21 +171,34 @@ def _bare_message_id(message_id: str) -> str:
     return mid
 
 
-def _construct_as_date_var(var: str, year: int, month: int, day: int) -> str:
-    """Emit AppleScript that constructs an AS date object at midnight (local
-    time) on the given (year, month, day).
+def _construct_as_date_var(
+    var: str, year: int, month: int, day: int, seconds: int = 0
+) -> str:
+    """Emit AppleScript that constructs an AS date object on the given
+    (year, month, day), at ``seconds`` into that day (default: midnight).
 
     Why this exists: AppleScript's `date "YYYY-MM-DD"` literal does NOT
     parse ISO dates — `date "2026-05-28"` evaluates to year-12196, silently
-    breaking any filter that depends on it. The property-setter pattern
-    below is locale-independent and gives exactly midnight on the target
-    date.
+    breaking any filter that depends on it. Observed again in #436 with a
+    timestamp form: `date "2026-08-09 11:03:51"` yields "October 8, 12177".
+    Neither raises. The property-setter pattern below is locale-independent
+    and gives exactly the intended instant.
+
+    THIS IS THE ONLY SUPPORTED WAY to get a date into generated AppleScript.
+    `scripts/check_applescript_safety.sh` (Check 6) fails the build on a
+    `date "..."` literal so the trap cannot be re-introduced.
 
     The leading `set day of var to 1` is a defense against current-date
     quirks: if `current date` is e.g. 2026-01-31 and we immediately
     `set month of var to 2`, AppleScript would try to roll into Feb 31 and
     misbehave. Resetting day to 1 first, then year/month/day in that
     order, avoids all such edge cases. (#242)
+
+    Args:
+        seconds: Seconds into the day (0-86399). `set time of` takes
+            seconds-since-midnight, so an hour/minute/second timestamp is
+            passed as ``h * 3600 + m * 60 + s``. Defaults to 0 (midnight),
+            which is what date-only filters like ``date_from`` want. (#436)
     """
     indent = "\n            "
     return indent.join([
@@ -194,7 +207,7 @@ def _construct_as_date_var(var: str, year: int, month: int, day: int) -> str:
         f"set year of {var} to {year}",
         f"set month of {var} to {month}",
         f"set day of {var} to {day}",
-        f"set time of {var} to 0",
+        f"set time of {var} to {seconds}",
     ])
 
 
@@ -4929,21 +4942,18 @@ class AppleMailConnector:
         safe_bracketed = escape_applescript_string(
             sanitize_input(f"<{bare}>")
         )
-        # Build the date from COMPONENTS, never `date "..."`. AppleScript
-        # parses date-string literals against the user's locale: on this
-        # machine `date "2026-08-09 11:03:51"` yields "October 8, 12177",
-        # which silently makes any window comparison meaningless. Setting
-        # `day` to 1 first avoids overflow when the current day-of-month
-        # exceeds the target month's length.
-        secs_into_day = when.hour * 3600 + when.minute * 60 + when.second
+        # Dates go through _construct_as_date_var, never a `date "..."`
+        # literal — see its docstring for why (#242/#436).
+        target_date = _construct_as_date_var(
+            "targetDate",
+            when.year,
+            when.month,
+            when.day,
+            when.hour * 3600 + when.minute * 60 + when.second,
+        )
         script = _wrap_with_timeout(
             f"""tell application "Mail"
-            set targetDate to (current date)
-            set day of targetDate to 1
-            set year of targetDate to {when.year}
-            set month of targetDate to {when.month}
-            set day of targetDate to {when.day}
-            set time of targetDate to {secs_into_day}
+            {target_date}
             set loDate to targetDate - (1 * days)
             set hiDate to targetDate + (1 * days)
             set foundId to ""

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -28,6 +28,7 @@ from apple_mail_fast_mcp.exceptions import (
 )
 from apple_mail_fast_mcp.mail_connector import (
     AppleMailConnector,
+    _construct_as_date_var,
     _message_id_match_clause,
     _wrap_as_json_script,
     _wrap_with_timeout,
@@ -9097,6 +9098,55 @@ class TestSmtpSendPath:
         )
         assert connector._resolve_smtp_config("Gmail") == ("", 0, "")
         assert called == []
+
+
+class TestConstructAsDateVar:
+    """#242/#436: the ONLY supported way to get a date into generated
+    AppleScript.
+
+    `date "..."` string literals parse against the user's LOCALE and fail
+    silently — `date "2026-05-28"` gives year 12196, and
+    `date "2026-08-09 11:03:51"` gives October 8, 12177. Neither raises, so a
+    filter built on one just quietly matches nothing.
+    """
+
+    def test_emits_no_date_string_literal(self) -> None:
+        script = _construct_as_date_var("d", 2026, 8, 9)
+        assert 'date "' not in script
+
+    def test_defaults_to_midnight(self) -> None:
+        """Date-only callers (search_messages date_from/date_to) rely on this
+        default; changing it would silently shift their bounds."""
+        script = _construct_as_date_var("dateFromVar", 2026, 8, 9)
+        assert "set time of dateFromVar to 0" in script
+
+    def test_seconds_into_day_is_honoured(self) -> None:
+        """#436: `set time of` takes seconds-since-midnight, so a timestamp
+        arrives as h*3600 + m*60 + s. 11:03:51 -> 39831."""
+        script = _construct_as_date_var("targetDate", 2026, 8, 9, 39831)
+        assert "set time of targetDate to 39831" in script
+
+    def test_day_is_reset_to_one_before_the_month_is_set(self) -> None:
+        """Ordering guard: with `current date` on the 31st, setting month to a
+        30-day month before resetting day rolls into the next month."""
+        script = _construct_as_date_var("d", 2026, 2, 28)
+        assert script.index("set day of d to 1") < script.index(
+            "set month of d to 2"
+        )
+        # ...and the real day is applied after the month.
+        assert script.index("set month of d to 2") < script.index(
+            "set day of d to 28"
+        )
+
+    def test_year_month_day_all_present(self) -> None:
+        script = _construct_as_date_var("d", 2026, 8, 9)
+        for expected in (
+            "set d to current date",
+            "set year of d to 2026",
+            "set month of d to 8",
+            "set day of d to 9",
+        ):
+            assert expected in script
 
 
 class TestResolveAnchorViaImap:


### PR DESCRIPTION
Fixes #436.

## The trap

AppleScript parses `date "..."` literals against the **user's locale**, and fails silently:

```applescript
date "2026-05-28"           --> year 12196
date "2026-08-09 11:03:51"  --> Wednesday, October 8, 12177
```

Neither raises. In #432 this bounded a search window ~10,000 years off, so it matched nothing — and surfaced as a clean, plausible "not found" for a message sitting at **index 1 of the INBOX**.

## What this actually turned out to be

**The codebase already knew.** `_construct_as_date_var` exists precisely for this (#242), documents the year-12196 case, and handles the day-overflow quirk. `search_messages`' date filters use it.

So the issue wasn't "discover a trap". It was two things:

1. **The knowledge was in the wrong place** — a helper docstring inside a 6,000-line module, not anywhere someone writing new AppleScript looks. #432 walked into it *after* it was documented. That's the strongest argument for the skill change.
2. **#432's fix duplicated it** — hand-rolled the same component sequence inline, because the helper hardcoded midnight and it needed a time-of-day.

The audit was otherwise clean: no un-backticked `date "` literals anywhere in `src/`.

## Changes

**De-duplicated.** `_construct_as_date_var` gains an optional seconds-into-day argument (default `0`, so every existing caller is untouched); `_find_by_message_id_near_date` now calls it.

**Guarded.** Check 6 in `check_applescript_safety.sh`, which already runs in `make check-all` and `release-hygiene.yml`. Every legitimate mention is backticked because it's prose, so the rule is "flag `date \"` not preceded by a backtick", scanning all of `src/`.

**Documented.** New section in the `applescript-mail` skill — the failing example with its real output, the fix, why `set day to 1` comes first, and a checklist item.

**Also refreshed stale guidance in the same file:** it still said to "always subject-prefilter first" for `whose message id`. As of #434 the answer is resolve via indexed IMAP (0.14s over 61,880 messages) then binary-search by date — and the reason matters: that clause freezes Mail's UI thread outright rather than merely being slow.

## Verification

**The guard was proven to discriminate**, not just to pass:

| case | result |
|---|---|
| clean tree | passes ✓ |
| injected `f'set d to date "2026-08-09"'` | **fails** ✓ |
| backticked prose | passes ✓ |

(`--include='*.py'` matters — without it `__pycache__` bytecode reports as a useless binary-file hit. Caught on the first run.)

**The refactor is provably behaviour-preserving.** Diffing the emitted AppleScript between `main` and this branch for the same input, the only delta is `(current date)` → `current date` — redundant parentheses, semantically identical.

```
1632 unit passed (was 1627)
make check-all: All checks passed
```

`_construct_as_date_var` had **no direct test coverage at all**; it now has five pinning the midnight default, the new seconds argument, and the day-1-before-month ordering.

## Note on integration flakiness

`TestFindMessageByMessageIdIntegration` failed once per run on two runs (a *different* test each time), always with `OSError: cannot read from timed out object` from Gmail IMAP. `main` passed 4/4 once. I confirmed this isn't from this PR: the emitted-script diff above is cosmetic, and nothing here touches IMAP. The tests became IMAP-dependent in #434, and Gmail intermittently exceeds the 30s `OPERATION_TIMEOUT_S`. Worth its own issue if it keeps recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)