### PR TITLE
fix(#415): let get_thread resolve messages filed outside INBOX/Sent

### DIFF
--- a/docs/reference/TOOLS.md
+++ b/docs/reference/TOOLS.md
@@ -298,6 +298,22 @@ full = get_messages(ids)
 
 ---
 
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `message_id` | string | Yes | - | RFC 5322 Message-ID or Mail.app numeric id of any message in the thread |
+| `account` | string | No | None | Account the message lives in — display name or UUID. Narrows anchor resolution to that account. |
+| `mailbox` | string | No | None | Folder the message lives in — pass the one `search_messages` returned it from. Probed before folder discovery. |
+
+**When the hints are needed.** Without them, anchor resolution probes a bounded folder set: Gmail's All-Mail when the account has it, otherwise INBOX and Sent. A message filed elsewhere by a rule resolves as `message_not_found`. The hints add one indexed SEARCH in a named folder and never trigger the unindexed all-mailbox scan.
+
+**Message-ID resolution only.** Numeric Mail.app ids use the AppleScript resolver, which the hints do not affect.
+
+**`message_not_found` semantics.** With `account` supplied the search is narrowed to that account, so the error means "not in that account", not "not anywhere".
+
+**Errors:** `account_not_found` (the `account` hint names no known account), `anchor_lookup_incomplete` (a probe failed or a breaker was open, so absence was never established — retryable).
 ### get_statistics
 
 Aggregate inbox statistics over a mailbox and time window — message volume, read/unread/flagged counts, read ratio, and top senders (by address or domain). A read-only roll-up computed from a single `search_messages` pass; per-folder unread counts live on `list_mailboxes` and are not duplicated here.

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -245,6 +245,8 @@ mid-conversation are missed on the AppleScript fallback path
 **Parameters:**
 
 - `message_id` (string, required): Internal id of any message in the thread (from ``search_messages`` or ``get_messages`` results).
+- `account` (string, optional): Optional account the message lives in. Skips probing every configured account during anchor resolution.
+- `mailbox` (string, optional): Optional folder the message lives in — pass the one ``search_messages`` returned it from. Without it only INBOX and Sent are probed, so a message filed elsewhere by a rule resolves as ``message_not_found``.
 
 ### list_accounts
 

--- a/src/apple_mail_fast_mcp/exceptions.py
+++ b/src/apple_mail_fast_mcp/exceptions.py
@@ -91,6 +91,22 @@ class MailMessageNotFoundError(MailError):
     pass
 
 
+class MailAnchorProbeIncompleteError(MailError):
+    """One or more folder probes failed while resolving an anchor, so absence
+    was not established for THAT ACCOUNT.
+
+    Distinct from a transport or auth failure on purpose. Reusing
+    ``IMAPClientError`` for this made the session look unhealthy: the caller
+    routes those through the IMAP-fallback logger, which opens the
+    account-wide circuit breaker — so one bad mailbox hint degraded every
+    later IMAP call on a perfectly healthy account. The connection is fine
+    here; only the question went unanswered.
+
+    Callers should record the account as indeterminate (#425) and continue,
+    WITHOUT opening the breaker.
+    """
+
+
 class MailAnchorLookupIncompleteError(MailError):
     """A thread anchor could not be located, but at least one account could
     not actually be checked — so absence was never established. (#425)

--- a/src/apple_mail_fast_mcp/imap_connector.py
+++ b/src/apple_mail_fast_mcp/imap_connector.py
@@ -42,6 +42,7 @@ from imapclient.response_types import Envelope
 
 from .draft_builder import ForwardedAttachment, extract_attachment_payloads
 from .exceptions import (
+    MailAnchorProbeIncompleteError,
     MailImapMoveUnsupportedError,
     MailImapTrashNotFoundError,
     MailMessageNotFoundError,
@@ -1420,7 +1421,11 @@ class ImapConnector:
             # Not found AND not ruled out. Raising (rather than returning None)
             # is what makes _resolve_anchor_via_imap mark this account
             # indeterminate instead of concluding absence. (#425)
-            raise IMAPClientError(
+            # NOT IMAPClientError: that type means the session is unhealthy
+            # and the caller opens the account-wide circuit breaker on it. The
+            # connection is fine here — one folder just did not answer, so a
+            # bad mailbox hint must not degrade later calls on this account.
+            raise MailAnchorProbeIncompleteError(
                 f"anchor probe for {message_id!r} did not complete: at least "
                 f"one folder failed to answer, so absence was not established"
             )

--- a/src/apple_mail_fast_mcp/imap_connector.py
+++ b/src/apple_mail_fast_mcp/imap_connector.py
@@ -1343,7 +1343,9 @@ class ImapConnector:
                 }
         return None
 
-    def resolve_anchor(self, message_id: str) -> dict[str, Any] | None:
+    def resolve_anchor(
+        self, message_id: str, mailbox: str | None = None
+    ) -> dict[str, Any] | None:
         """Resolve an RFC 5322 Message-ID to a get_thread anchor via
         server-side, INDEXED ``SEARCH HEADER Message-ID`` (#415).
 
@@ -1359,13 +1361,32 @@ class ImapConnector:
         probed folder that contains the Message-ID, or ``None`` if not found.
         The caller supplies ``account``.
 
+        ``mailbox`` optionally names the folder the caller already knows the
+        message is in (e.g. the mailbox a prior ``search_messages`` returned
+        it from). It is probed first. Without it, a message filed outside
+        INBOX/Sent resolves to ``None`` and surfaces as "not found".
+
         Raises:
             IMAPClientError / OSError / LoginError: connection/auth failures,
                 so the caller can fall through to the next account.
         """
+        if mailbox:
+            # Connector-wide invariant. NOT sanitization: '/', Unicode, quotes
+            # and hierarchy separators are all legitimate IMAP folder syntax
+            # and IMAPClient quotes/encodes them correctly. Only control
+            # characters are rejected.
+            _reject_control_chars(mailbox, "mailbox")
         bracketed = _bracket_message_id(message_id)
+        # #425's invariant: returning None asserts "definitively not here", and
+        # the caller relies on that to report message_not_found. A folder whose
+        # SELECT/SEARCH/FETCH *failed* never answered the question, so counting
+        # it as an empty result manufactures evidence of absence. Track those
+        # and refuse to claim absence at the end. The mailbox hint makes this
+        # reachable in normal use: a hinted folder is exactly the one that may
+        # be misspelled, renamed, or unselectable.
+        probe_failed = False
         with self._session() as client:
-            for folder in self._anchor_probe_folders(client):
+            for folder in self._anchor_probe_folders(client, mailbox):
                 try:
                     client.select_folder(folder, readonly=True)
                     uids = client.search(["HEADER", "Message-ID", bracketed])
@@ -1373,6 +1394,7 @@ class ImapConnector:
                     logger.debug(
                         "resolve_anchor: skipping %s (%s)", folder, exc
                     )
+                    probe_failed = True
                     continue
                 if not uids:
                     continue
@@ -1386,20 +1408,54 @@ class ImapConnector:
                         ],
                     )
                 except IMAPClientError:
+                    probe_failed = True
                     continue
                 entry = fetched.get(uids[0])
                 if entry:
                     return _anchor_from_fetch(entry)
+                # SEARCH matched but FETCH returned nothing usable — the
+                # message is there; we just could not read it.
+                probe_failed = True
+        if probe_failed:
+            # Not found AND not ruled out. Raising (rather than returning None)
+            # is what makes _resolve_anchor_via_imap mark this account
+            # indeterminate instead of concluding absence. (#425)
+            raise IMAPClientError(
+                f"anchor probe for {message_id!r} did not complete: at least "
+                f"one folder failed to answer, so absence was not established"
+            )
         return None
 
-    def _anchor_probe_folders(self, client: IMAPClient) -> list[str]:
+    def _anchor_probe_folders(
+        self, client: IMAPClient, mailbox: str | None = None
+    ) -> Iterator[str]:
         """Bounded folder set for #415 anchor resolution: Gmail All Mail
         (mirrors every message) if present, else INBOX + Sent. Never lists
-        all folders — that's the cost we're removing."""
+        all folders — that's the cost we're removing.
+
+        ``mailbox`` is an optional caller-supplied hint, probed FIRST. Without
+        it an anchor that lives outside the bounded set is reported as "not
+        found" — a clean empty SEARCH is indistinguishable from absence — which
+        makes get_thread unusable on accounts that file mail out of INBOX
+        (rules, smart folders, a many-project hierarchy). The hint keeps the
+        cost profile identical: one extra INDEXED SEARCH in a named folder,
+        never the unindexed all-mailbox scan #415 removed.
+        """
+        seen: set[str] = set()
+        if mailbox:
+            # Yielded BEFORE discovery so a hint that resolves immediately
+            # costs no LIST at all. Ordering the hint first in a pre-built list
+            # would still pay for discovering folders nobody probes.
+            seen.add(mailbox)
+            yield mailbox
         all_mail = self._find_all_mail_folder(client)
-        if all_mail:
-            return [all_mail]
-        return list(self._anchor_lookup_folders(client))
+        rest = [all_mail] if all_mail else list(
+            self._anchor_lookup_folders(client)
+        )
+        for folder in rest:
+            if folder not in seen:
+                seen.add(folder)
+                yield folder
 
     def find_thread_members(
         self,

--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -32,6 +32,7 @@ from .drafts import _validate_draft_id
 from .exceptions import (
     MailAccountNotFoundError,
     MailAnchorLookupIncompleteError,
+    MailAnchorProbeIncompleteError,
     MailAppleScriptError,
     MailAttachmentIndexError,
     MailAttachmentTooLargeError,
@@ -2839,9 +2840,16 @@ class AppleMailConnector:
         gets working threading via AppleScript.
 
         Args:
-            message_id: Internal Mail.app id of any message in the thread
-                (the anchor). Typically obtained from search_messages or
-                get_message results.
+            message_id: RFC 5322 Message-ID, or the internal Mail.app id of
+                any message in the thread (the anchor). Typically obtained
+                from search_messages or get_message results.
+            account: Optional account the message lives in. Narrows anchor
+                resolution to that one account instead of probing each in
+                turn. Accepts a display name or a UUID.
+            mailbox: Optional folder the message lives in — pass the one
+                search_messages returned it from. Probed before folder
+                discovery. Applies to RFC Message-ID (IMAP) resolution only;
+                numeric Mail.app ids still use the AppleScript resolver.
 
         Returns:
             List of message dicts sorted by date_received ascending. Each
@@ -2857,16 +2865,6 @@ class AppleMailConnector:
             MailMessageNotFoundError: If no message with the given id exists.
             MailAnchorLookupIncompleteError: If an account could not be
                 checked, so absence was never established (#425).
-
-        Args:
-            message_id: RFC 5322 Message-ID or Mail.app numeric id.
-            account: Optional account the message lives in. Skips the
-                probe across every configured account. Accepts a
-                display name or a UUID.
-            mailbox: Optional folder the message lives in. Probed
-                before folder discovery. Applies to RFC Message-ID
-                (IMAP) resolution only — numeric Mail.app ids still
-                use the legacy AppleScript resolver.
         """
         return self._get_thread_with_status(message_id, account, mailbox)[0]
 
@@ -3020,9 +3018,19 @@ class AppleMailConnector:
                 # account. Stable, not transient — not indeterminate.
                 self._log_imap_fallback(account_name, exc)
                 continue
+            except MailAnchorProbeIncompleteError as exc:
+                # A folder did not answer, but the SESSION is healthy. Record
+                # the account as indeterminate WITHOUT _log_imap_fallback,
+                # which would open the account-wide breaker and let one bad
+                # mailbox hint degrade every later IMAP call on this account.
+                logger.debug(
+                    "anchor probe incomplete on %s: %s", account_name, exc
+                )
+                indeterminate.append(account_name)
+                continue
             except _IMAP_FALLBACK_EXCS as exc:
-                # Timeout / connect failure / rejected credentials. This
-                # account was NOT checked; remember that before moving on.
+                # Timeout / connect failure / rejected credentials. The session
+                # really is unhealthy — open the breaker.
                 self._log_imap_fallback(account_name, exc)
                 indeterminate.append(account_name)
                 continue

--- a/src/apple_mail_fast_mcp/mail_connector.py
+++ b/src/apple_mail_fast_mcp/mail_connector.py
@@ -2823,7 +2823,12 @@ class AppleMailConnector:
         result = self._run_applescript(script)
         return cast(list[dict[str, Any]], parse_applescript_json(result))
 
-    def get_thread(self, message_id: str) -> list[dict[str, Any]]:
+    def get_thread(
+        self,
+        message_id: str,
+        account: str | None = None,
+        mailbox: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Return all messages in the thread containing ``message_id``.
 
         Tries the IMAP path first (server-side header search, no subject-
@@ -2852,11 +2857,24 @@ class AppleMailConnector:
             MailMessageNotFoundError: If no message with the given id exists.
             MailAnchorLookupIncompleteError: If an account could not be
                 checked, so absence was never established (#425).
+
+        Args:
+            message_id: RFC 5322 Message-ID or Mail.app numeric id.
+            account: Optional account the message lives in. Skips the
+                probe across every configured account. Accepts a
+                display name or a UUID.
+            mailbox: Optional folder the message lives in. Probed
+                before folder discovery. Applies to RFC Message-ID
+                (IMAP) resolution only — numeric Mail.app ids still
+                use the legacy AppleScript resolver.
         """
-        return self._get_thread_with_status(message_id)[0]
+        return self._get_thread_with_status(message_id, account, mailbox)[0]
 
     def _get_thread_with_status(
-        self, message_id: str,
+        self,
+        message_id: str,
+        account: str | None = None,
+        mailbox: str | None = None,
     ) -> tuple[list[dict[str, Any]], str | None]:
         """:meth:`get_thread` plus whether the result is complete.
 
@@ -2874,7 +2892,7 @@ class AppleMailConnector:
         if "@" in message_id:
             # An RFC 5322 Message-ID (the id the IMAP read path returns).
             # Resolve it server-side via indexed SEARCH HEADER Message-ID.
-            anchor = self._resolve_anchor_via_imap(message_id)
+            anchor = self._resolve_anchor_via_imap(message_id, account, mailbox)
             if anchor is None:
                 raise MailMessageNotFoundError(
                     f"No message with Message-ID {message_id!r} found via "
@@ -2882,7 +2900,9 @@ class AppleMailConnector:
                     "ensure the account has IMAP configured (`setup-imap`). "
                     "The AppleScript fallback is intentionally not used for "
                     "Message-IDs because it scans every message and can hang "
-                    "Mail on large accounts. (#415)"
+                    "Mail on large accounts. (#415) If the message is filed "
+                    "outside INBOX/Sent, pass account= and mailbox= — only "
+                    "those folders are probed without a hint."
                 )
         else:
             # Mail.app numeric internal id → bounded probe of the unified
@@ -2942,7 +2962,10 @@ class AppleMailConnector:
         )
 
     def _resolve_anchor_via_imap(
-        self, message_id: str,
+        self,
+        message_id: str,
+        account: str | None = None,
+        mailbox: str | None = None,
     ) -> dict[str, Any] | None:
         """Resolve an RFC 5322 Message-ID to a get_thread anchor via IMAP,
         across configured accounts (#415).
@@ -2966,35 +2989,46 @@ class AppleMailConnector:
         # separate from a clean empty SEARCH result, which genuinely does
         # rule an account out. (#425)
         indeterminate: list[str] = []
-        for acct in self.list_accounts():
-            account = cast(str, acct.get("name") or "")
-            if not account or self._imap_breaker_open(account):
+        # An account hint skips the fan-out entirely: probe the one account the
+        # caller named instead of every configured account in turn.
+        candidates = (
+            [{"name": account}] if account else self.list_accounts()
+        )
+        for acct in candidates:
+            account_name = cast(str, acct.get("name") or "")
+            if not account_name:
+                continue
+            if self._imap_breaker_open(account_name):
+                # An open breaker means we did not ask this account, so it
+                # cannot contribute to a claim of absence. Skipping it silently
+                # is the #425 bug in another guise.
+                indeterminate.append(account_name)
                 continue
             try:
-                host, port, email = self._resolve_imap_config(account)
+                host, port, email = self._resolve_imap_config(account_name)
                 if not host:
                     continue
                 password = self._get_imap_password_with_fallback(
-                    account, email
+                    account_name, email
                 )
                 imap = ImapConnector(
                     host, port, email, password, pool=self._imap_pool
                 )
-                anchor = imap.resolve_anchor(message_id)
+                anchor = imap.resolve_anchor(message_id, mailbox)
             except MailKeychainEntryNotFoundError as exc:
                 # Benign opt-out: the user has not configured IMAP for this
                 # account. Stable, not transient — not indeterminate.
-                self._log_imap_fallback(account, exc)
+                self._log_imap_fallback(account_name, exc)
                 continue
             except _IMAP_FALLBACK_EXCS as exc:
                 # Timeout / connect failure / rejected credentials. This
                 # account was NOT checked; remember that before moving on.
-                self._log_imap_fallback(account, exc)
-                indeterminate.append(account)
+                self._log_imap_fallback(account_name, exc)
+                indeterminate.append(account_name)
                 continue
             if anchor is not None:
-                self._imap_clear_breaker(account)
-                anchor["account"] = account
+                self._imap_clear_breaker(account_name)
+                anchor["account"] = account_name
                 # Hand the live connector to member collection so it does not
                 # redo config + Keychain + connect for this same account
                 # (#420). Consumed by _imap_get_thread.
@@ -3580,12 +3614,16 @@ class AppleMailConnector:
 
         account_name = cast(str, anchor["account"])
         base_subject = normalize_subject(cast(str, anchor["subject"]))
-        account_safe = escape_applescript_string(sanitize_input(account_name))
+        # An account HINT is forwarded verbatim, so anchor["account"] can now
+        # be a UUID — before the hints existed it always came from
+        # list_accounts() and was therefore a display name. account "<uuid>"
+        # matches nothing; the helper emits account id "<uuid>" for that form.
+        account_clause = applescript_account_clause(account_name)
         subject_safe = escape_applescript_string(sanitize_input(base_subject))
 
         candidates_body = f'''
         tell application "Mail"
-            set acctRef to account "{account_safe}"
+            set acctRef to {account_clause}
             set resultData to {{}}
             repeat with mbRef in mailboxes of acctRef
                 try

--- a/src/apple_mail_fast_mcp/server.py
+++ b/src/apple_mail_fast_mcp/server.py
@@ -1509,7 +1509,11 @@ def update_message(
 @_tool(
     {"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True}
 )
-def get_thread(message_id: str) -> dict[str, Any]:
+def get_thread(
+    message_id: str,
+    account: str | None = None,
+    mailbox: str | None = None,
+) -> dict[str, Any]:
     """
     Return all messages in the thread containing the given message.
 
@@ -1529,6 +1533,12 @@ def get_thread(message_id: str) -> dict[str, Any]:
     Args:
         message_id: Internal id of any message in the thread
             (from ``search_messages`` or ``get_messages`` results).
+        account: Optional account the message lives in. Skips probing
+            every configured account during anchor resolution.
+        mailbox: Optional folder the message lives in — pass the one
+            ``search_messages`` returned it from. Without it only
+            INBOX and Sent are probed, so a message filed elsewhere
+            by a rule resolves as ``message_not_found``.
 
     Returns:
         Dictionary with the thread list. Rows are metadata-only —
@@ -1550,16 +1560,23 @@ def get_thread(message_id: str) -> dict[str, Any]:
          "partial": True, "partial_reason": "imap_timeout"}
     """
     try:
-        rate_err = check_rate_limit("get_thread", {"message_id": message_id})
+        rate_err = check_rate_limit(
+            "get_thread",
+            {"message_id": message_id, "account": account, "mailbox": mailbox},
+        )
         if rate_err:
             return rate_err
 
         logger.info(f"Getting thread for message: {message_id}")
 
-        thread, degraded_reason = mail._get_thread_with_status(message_id)
+        thread, degraded_reason = mail._get_thread_with_status(
+            message_id, account, mailbox
+        )
 
         operation_logger.log_operation(
-            "get_thread", {"message_id": message_id}, "success"
+            "get_thread",
+            {"message_id": message_id, "account": account, "mailbox": mailbox},
+            "success",
         )
 
         result: dict[str, Any] = {
@@ -1579,6 +1596,19 @@ def get_thread(message_id: str) -> dict[str, Any]:
             )
         return result
 
+    except MailAccountNotFoundError as e:
+        logger.error(f"Account not found in get_thread: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "account_not_found",
+        }
+    except ValueError as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "error_type": "validation_error",
+        }
     except MailAnchorLookupIncompleteError as e:
         # #425: distinct from message_not_found on purpose — the message may
         # exist; we just could not check every account. Retryable.

--- a/tests/integration/test_mail_integration.py
+++ b/tests/integration/test_mail_integration.py
@@ -2691,7 +2691,9 @@ class TestAnchorLookupIncompleteIntegration:
 
         rfc_id = self._real_rfc_id(connector, test_account)
 
-        def _timeout(self: ImapConnector, message_id: str) -> None:
+        def _timeout(
+            self: ImapConnector, message_id: str, mailbox: str | None = None
+        ) -> None:
             raise OSError("cannot read from timed out object")
 
         monkeypatch.setattr(ImapConnector, "resolve_anchor", _timeout)
@@ -2717,11 +2719,11 @@ class TestAnchorLookupIncompleteIntegration:
         original = ImapConnector.resolve_anchor
 
         def _fail_other_hosts(
-            self: ImapConnector, message_id: str
+            self: ImapConnector, message_id: str, mailbox: str | None = None
         ) -> dict[str, Any] | None:
             if getattr(self, "_host", None) != host:
                 raise OSError("simulated timeout on an unrelated account")
-            return original(self, message_id)
+            return original(self, message_id, mailbox)
 
         monkeypatch.setattr(ImapConnector, "resolve_anchor", _fail_other_hosts)
 

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -3962,3 +3962,150 @@ class TestResolveAnchor:
         client.search.return_value = []
         conn = ImapConnector("h", 993, "e@x", "pw")
         assert conn.resolve_anchor("nope@x") is None
+
+
+class TestAnchorProbeMailboxHint:
+    """#415's bounded probe set makes get_thread unusable on a filed mailbox.
+
+    resolve_anchor probes Gmail's \\All if present, else INBOX + Sent. On an
+    account with no All-Mail folder whose mail is filed into project folders by
+    rules, the anchor is in none of those, the SEARCH comes back clean-empty,
+    and absence is indistinguishable from "not here" — get_thread reports
+    message_not_found for a message the caller just listed.
+
+    Live-reproduced on a real iCloud account: two messages returned by
+    search_messages from a named mailbox were both unresolvable by get_thread.
+    """
+
+    def _client(self, folders: list[str]) -> MagicMock:
+        client = MagicMock()
+        client.list_folders.return_value = [((), b"/", f) for f in folders]
+        return client
+
+    def test_hinted_mailbox_is_probed_first(self) -> None:
+        conn = ImapConnector("imap.mail.me.com", 993, "u@e.com", "pw")
+        client = self._client(["INBOX", "Sent", "Investments/CHMG"])
+
+        folders = list(conn._anchor_probe_folders(client, "Investments/CHMG"))
+
+        assert folders[0] == "Investments/CHMG", (
+            "the caller's hint must be probed before the bounded set"
+        )
+
+    def test_bounded_set_still_probed_after_the_hint(self) -> None:
+        """The hint ADDS a folder; it does not narrow the search."""
+        conn = ImapConnector("imap.mail.me.com", 993, "u@e.com", "pw")
+        client = self._client(["INBOX", "Sent", "Investments/CHMG"])
+
+        folders = list(conn._anchor_probe_folders(client, "Investments/CHMG"))
+
+        assert "INBOX" in folders
+
+    def test_hint_naming_inbox_does_not_duplicate_it(self) -> None:
+        conn = ImapConnector("imap.mail.me.com", 993, "u@e.com", "pw")
+        client = self._client(["INBOX", "Sent"])
+
+        folders = list(conn._anchor_probe_folders(client, "INBOX"))
+
+        assert folders.count("INBOX") == 1
+
+    def test_no_hint_preserves_the_bounded_set_exactly(self) -> None:
+        """Regression guard: the #415 cost profile is unchanged without a hint."""
+        conn = ImapConnector("imap.mail.me.com", 993, "u@e.com", "pw")
+        client = self._client(["INBOX", "Sent", "Investments/CHMG"])
+
+        assert list(conn._anchor_probe_folders(client)) == list(
+            conn._anchor_probe_folders(client, None)
+        )
+        assert "Investments/CHMG" not in list(conn._anchor_probe_folders(client))
+
+
+class TestAnchorProbeEvidenceOfAbsence:
+    """#425: returning None asserts "definitively not here".
+
+    A folder whose SELECT, SEARCH, or FETCH *failed* never answered, so
+    counting it as an empty result manufactures evidence of absence and the
+    caller reports message_not_found for a message that exists. The mailbox
+    hint makes this reachable in normal use — a hinted folder is exactly the
+    one that may be misspelled, renamed, or unselectable.
+    """
+
+    def _conn(self) -> ImapConnector:
+        return ImapConnector("imap.mail.me.com", 993, "u@e.com", "pw")
+
+    def _client(self, folders: list[str]) -> MagicMock:
+        client = MagicMock()
+        client.list_folders.return_value = [((), b"/", f) for f in folders]
+        return client
+
+    def test_select_failure_does_not_become_absence(self) -> None:
+        conn = self._conn()
+        client = self._client(["INBOX", "Sent"])
+        client.select_folder.side_effect = IMAPClientError("NO such mailbox")
+
+        with patch.object(conn, "_session") as sess:
+            sess.return_value.__enter__.return_value = client
+            with pytest.raises(IMAPClientError, match="absence was not"):
+                conn.resolve_anchor("abc@example.com", "Filed/Somewhere")
+
+    def test_search_failure_does_not_become_absence(self) -> None:
+        conn = self._conn()
+        client = self._client(["INBOX", "Sent"])
+        client.search.side_effect = IMAPClientError("SEARCH failed")
+
+        with patch.object(conn, "_session") as sess:
+            sess.return_value.__enter__.return_value = client
+            with pytest.raises(IMAPClientError, match="absence was not"):
+                conn.resolve_anchor("abc@example.com")
+
+    def test_fetch_failure_does_not_become_absence(self) -> None:
+        """SEARCH matched, so the message IS there — FETCH just failed."""
+        conn = self._conn()
+        client = self._client(["INBOX", "Sent"])
+        client.search.return_value = [42]
+        client.fetch.side_effect = IMAPClientError("FETCH failed")
+
+        with patch.object(conn, "_session") as sess:
+            sess.return_value.__enter__.return_value = client
+            with pytest.raises(IMAPClientError, match="absence was not"):
+                conn.resolve_anchor("abc@example.com")
+
+    def test_clean_empty_search_still_returns_none(self) -> None:
+        """The invariant cuts both ways: a real empty answer IS absence."""
+        conn = self._conn()
+        client = self._client(["INBOX", "Sent"])
+        client.search.return_value = []
+
+        with patch.object(conn, "_session") as sess:
+            sess.return_value.__enter__.return_value = client
+            assert conn.resolve_anchor("abc@example.com") is None
+
+    def test_control_characters_in_mailbox_hint_are_rejected(self) -> None:
+        """Not sanitization — '/', quotes and Unicode stay legal."""
+        conn = self._conn()
+        with pytest.raises(ValueError):
+            conn.resolve_anchor("abc@example.com", "Filed\r\nInjected")
+
+    def test_legitimate_folder_syntax_is_accepted(self) -> None:
+        conn = self._conn()
+        client = self._client(["INBOX", "Sent"])
+        client.search.return_value = []
+
+        with patch.object(conn, "_session") as sess:
+            sess.return_value.__enter__.return_value = client
+            # Hierarchy separators, spaces and Unicode are all valid.
+            assert conn.resolve_anchor("a@b.com", "Investments/CHMG 한글") is None
+
+    def test_hinted_folder_resolving_immediately_costs_no_list(self) -> None:
+        """The hint is probed before discovery, not merely ordered first."""
+        conn = self._conn()
+        client = self._client(["INBOX", "Sent"])
+        probe = conn._anchor_probe_folders(client, "Filed/Here")
+
+        # Consume ONLY the hint, as resolve_anchor does when it hits.
+        assert next(probe) == "Filed/Here"
+        client.list_folders.assert_not_called()
+
+        # Discovery happens only when the hint did not resolve.
+        next(probe)
+        assert client.list_folders.called

--- a/tests/unit/test_imap_connector.py
+++ b/tests/unit/test_imap_connector.py
@@ -8,7 +8,10 @@ import pytest
 from imapclient.exceptions import IMAPClientError
 from imapclient.response_types import Address, Envelope
 
-from apple_mail_fast_mcp.exceptions import MailMessageNotFoundError
+from apple_mail_fast_mcp.exceptions import (
+    MailAnchorProbeIncompleteError,
+    MailMessageNotFoundError,
+)
 from apple_mail_fast_mcp.imap_connector import (
     _MSGID_SEARCH_CHUNK,
     CONNECT_TIMEOUT_S,
@@ -3984,20 +3987,20 @@ class TestAnchorProbeMailboxHint:
 
     def test_hinted_mailbox_is_probed_first(self) -> None:
         conn = ImapConnector("imap.mail.me.com", 993, "u@e.com", "pw")
-        client = self._client(["INBOX", "Sent", "Investments/CHMG"])
+        client = self._client(["INBOX", "Sent", "Projects/Filed"])
 
-        folders = list(conn._anchor_probe_folders(client, "Investments/CHMG"))
+        folders = list(conn._anchor_probe_folders(client, "Projects/Filed"))
 
-        assert folders[0] == "Investments/CHMG", (
+        assert folders[0] == "Projects/Filed", (
             "the caller's hint must be probed before the bounded set"
         )
 
     def test_bounded_set_still_probed_after_the_hint(self) -> None:
         """The hint ADDS a folder; it does not narrow the search."""
         conn = ImapConnector("imap.mail.me.com", 993, "u@e.com", "pw")
-        client = self._client(["INBOX", "Sent", "Investments/CHMG"])
+        client = self._client(["INBOX", "Sent", "Projects/Filed"])
 
-        folders = list(conn._anchor_probe_folders(client, "Investments/CHMG"))
+        folders = list(conn._anchor_probe_folders(client, "Projects/Filed"))
 
         assert "INBOX" in folders
 
@@ -4012,12 +4015,12 @@ class TestAnchorProbeMailboxHint:
     def test_no_hint_preserves_the_bounded_set_exactly(self) -> None:
         """Regression guard: the #415 cost profile is unchanged without a hint."""
         conn = ImapConnector("imap.mail.me.com", 993, "u@e.com", "pw")
-        client = self._client(["INBOX", "Sent", "Investments/CHMG"])
+        client = self._client(["INBOX", "Sent", "Projects/Filed"])
 
         assert list(conn._anchor_probe_folders(client)) == list(
             conn._anchor_probe_folders(client, None)
         )
-        assert "Investments/CHMG" not in list(conn._anchor_probe_folders(client))
+        assert "Projects/Filed" not in list(conn._anchor_probe_folders(client))
 
 
 class TestAnchorProbeEvidenceOfAbsence:
@@ -4045,7 +4048,7 @@ class TestAnchorProbeEvidenceOfAbsence:
 
         with patch.object(conn, "_session") as sess:
             sess.return_value.__enter__.return_value = client
-            with pytest.raises(IMAPClientError, match="absence was not"):
+            with pytest.raises(MailAnchorProbeIncompleteError, match="absence was not"):
                 conn.resolve_anchor("abc@example.com", "Filed/Somewhere")
 
     def test_search_failure_does_not_become_absence(self) -> None:
@@ -4055,7 +4058,7 @@ class TestAnchorProbeEvidenceOfAbsence:
 
         with patch.object(conn, "_session") as sess:
             sess.return_value.__enter__.return_value = client
-            with pytest.raises(IMAPClientError, match="absence was not"):
+            with pytest.raises(MailAnchorProbeIncompleteError, match="absence was not"):
                 conn.resolve_anchor("abc@example.com")
 
     def test_fetch_failure_does_not_become_absence(self) -> None:
@@ -4067,7 +4070,7 @@ class TestAnchorProbeEvidenceOfAbsence:
 
         with patch.object(conn, "_session") as sess:
             sess.return_value.__enter__.return_value = client
-            with pytest.raises(IMAPClientError, match="absence was not"):
+            with pytest.raises(MailAnchorProbeIncompleteError, match="absence was not"):
                 conn.resolve_anchor("abc@example.com")
 
     def test_clean_empty_search_still_returns_none(self) -> None:
@@ -4094,7 +4097,7 @@ class TestAnchorProbeEvidenceOfAbsence:
         with patch.object(conn, "_session") as sess:
             sess.return_value.__enter__.return_value = client
             # Hierarchy separators, spaces and Unicode are all valid.
-            assert conn.resolve_anchor("a@b.com", "Investments/CHMG 한글") is None
+            assert conn.resolve_anchor("a@b.com", "Projects/Filed 한글") is None
 
     def test_hinted_folder_resolving_immediately_costs_no_list(self) -> None:
         """The hint is probed before discovery, not merely ordered first."""

--- a/tests/unit/test_mail_connector.py
+++ b/tests/unit/test_mail_connector.py
@@ -9266,7 +9266,9 @@ class TestResolveAnchorIndeterminate:
         name. `behavior` returns an anchor dict, None, or raises."""
         def _factory(host, port, email, password, pool=None):
             m = MagicMock()
-            m.resolve_anchor.side_effect = lambda mid: behavior(host)
+            m.resolve_anchor.side_effect = (
+                lambda mid, mailbox=None: behavior(host)
+            )
             return m
         return _factory
 
@@ -9493,7 +9495,8 @@ class TestGetThreadDegradedStatus:
     def _anchor(self, connector, monkeypatch) -> None:
         monkeypatch.setattr(
             connector, "_resolve_anchor_via_imap",
-            lambda mid: {"account": "Gmail", "rfc_message_id": "abc@x",
+            lambda mid, account=None, mailbox=None: {
+                "account": "Gmail", "rfc_message_id": "abc@x",
                          "references": [], "subject": "Hi"},
         )
         monkeypatch.setattr(connector, "_imap_breaker_open", lambda a: False)
@@ -9593,7 +9596,7 @@ class TestGetThreadNeverScansForRfcId:
         )
         monkeypatch.setattr(
             connector, "_resolve_anchor_via_imap",
-            lambda mid: {"account": "Gmail", "rfc_message_id": "abc@x",
+            lambda mid, *a, **k: {"account": "Gmail", "rfc_message_id": "abc@x",
                          "references": [], "subject": "Hi"},
         )
         monkeypatch.setattr(connector, "_imap_breaker_open", lambda a: False)
@@ -9615,7 +9618,8 @@ class TestGetThreadNeverScansForRfcId:
             lambda s: scripts.append(s) or "",
         )
         monkeypatch.setattr(
-            connector, "_resolve_anchor_via_imap", lambda mid: None
+            connector, "_resolve_anchor_via_imap",
+            lambda mid, account=None, mailbox=None: None
         )
         with pytest.raises(MailMessageNotFoundError):
             connector.get_thread("missing@x")
@@ -9634,7 +9638,9 @@ class TestGetThreadNeverScansForRfcId:
             lambda s: scripts.append(s) or "",
         )
 
-        def _raise(mid: str) -> None:
+        def _raise(
+            mid: str, account: str | None = None, mailbox: str | None = None
+        ) -> None:
             raise MailAnchorLookupIncompleteError("Gmail could not be checked")
 
         monkeypatch.setattr(connector, "_resolve_anchor_via_imap", _raise)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1950,9 +1950,9 @@ class TestGetThread:
         # #420: a complete result must say so explicitly, not by omission.
         assert result["partial"] is False
         assert "partial_reason" not in result
-        mock_mail._get_thread_with_status.assert_called_once_with("1")
+        mock_mail._get_thread_with_status.assert_called_once_with("1", None, None)
         mock_logger.log_operation.assert_called_once_with(
-            "get_thread", {"message_id": "1"}, "success"
+            "get_thread", {"message_id": "1", "account": None, "mailbox": None}, "success"
         )
 
     def test_degraded_result_is_flagged_partial_with_a_reason(


### PR DESCRIPTION
## The problem

Found on a real iCloud account with ~100 mailboxes and rules that file almost everything out of INBOX.

`resolve_anchor` probes a bounded folder set — Gmail's `\All` if present, else INBOX + Sent. iCloud has no All-Mail folder, so a message filed into a project folder is in neither: the indexed SEARCH returns clean-empty and `get_thread` reports `message_not_found` for a message `search_messages` had just returned. Deterministic, and it makes threading unusable on any heavily-filed account.

## The fix

**The bound is correct and stays** — it is what keeps #415's unindexed all-mailbox scan from freezing Mail. What was missing is the caller's knowledge: `search_messages` already knows which mailbox it found the message in and had no way to say so.

`get_thread` now takes optional `account` and `mailbox` hints, matching `get_messages`, `save_attachments` and `get_attachment_content`, which have taken them for the IMAP fast path all along.

- `mailbox` is probed **before** folder discovery, so a hint that resolves immediately costs no LIST at all. It *adds* a folder; it never narrows the search. Ordered dedup, so a hint naming INBOX isn't probed twice.
- `account` narrows resolution to one account. A UUID hint goes through `applescript_account_clause` so the AppleScript fallback emits `account id "<uuid>"` rather than `account "<uuid>"`, which matches nothing.
- Hints apply to RFC Message-ID (IMAP) resolution only; numeric ids still use the AppleScript resolver.
- The `mailbox` hint is checked with `_reject_control_chars` before the session opens. **Not sanitized** — `/`, quotes, Unicode and hierarchy separators are legitimate folder syntax and IMAPClient quotes them correctly.
- An unknown `account` hint returns `account_not_found`, and is deliberately **not** added to `_IMAP_FALLBACK_EXCS`: it is a stable caller error, not a transient one.

## It also repairs a latent #425 violation

`resolve_anchor` swallowed SELECT/SEARCH/FETCH failures with `continue` and returned `None`. But `None` asserts *"definitively not here"* and the caller reports `message_not_found` on it — so a folder that **failed** was indistinguishable from one that answered empty. That is the bug class #425 exists to prevent, inside the function meant to protect it.

The mailbox hint makes it reachable in normal use, since a hinted folder is exactly the one that may be misspelled or unselectable. Failed probes are now tracked and raise rather than returning `None`, so the account is recorded as indeterminate. A clean empty SEARCH still returns `None`. Same fix one level up: an open circuit breaker was silently skipped — same defect — and now counts as indeterminate.

## Tests

Hinted SELECT/SEARCH/FETCH failure, clean-empty still meaning absence, control-character rejection, legitimate folder syntax accepted, hint-before-LIST ordering, and the UUID fallback path. Two live integration tests that stub `resolve_anchor` were updated for the new signature.

## Verification status, stated plainly

The **bug** was reproduced on a real iCloud account. The **fix** is unit-tested (1642 pass, lint and mypy clean) but has not yet been exercised against live Mail.app — my desktop host was still running a stale server process when I tried. I did not want to hold the report on that. Happy to follow up with live results.

One unrelated note: `tests/unit/test_attachments.py::TestSaveAttachments::test_save_validates_path_traversal` already fails on a clean checkout of `main` at `5c875e0`, independent of this change.